### PR TITLE
fix: Configure tsup to use tsconfig for DTS generation

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
-  dts: true,
+  dts: { tsconfig: 'tsconfig.json' },
   target: 'node24',
   clean: true,
   sourcemap: true,


### PR DESCRIPTION
## Summary
- Fix Docker build error by configuring tsup to use tsconfig.json for DTS generation
- Replace `dts: true` with `dts: { tsconfig: 'tsconfig.json' }` in tsup.config.ts

## Test plan
- Verified local build works with `pnpm build`
- Docker build should now successfully generate TypeScript declaration files

🤖 Generated with [Claude Code](https://claude.com/claude-code)