### PR TITLE
feat: Add Docker health check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,7 @@ USER hono
 
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) })"
+
 CMD ["node", "dist/index.js"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { ApolloServer } from '@apollo/server';
+import { sql } from 'drizzle-orm';
 import githubRouter from './routes/github/github.index';
 import reminderRouter from './routes/reminder/reminder.index';
 import statusRouter from './routes/status/status.index';
@@ -22,7 +23,7 @@ app.get('/health', async (c) => {
   try {
     // DB 연결 확인
     const { db } = await import('./lib/db');
-    await db.execute({ sql: 'SELECT 1' });
+    await db.execute(sql`SELECT 1`);
 
     return c.json({
       status: 'healthy',

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,32 @@ const app = new Hono();
 // CORS 허용
 app.use('/*', cors());
 
-// Health check
+// Health check for Docker
+app.get('/health', async (c) => {
+  try {
+    // DB 연결 확인
+    const { db } = await import('./lib/db');
+    await db.execute({ sql: 'SELECT 1' });
+
+    return c.json({
+      status: 'healthy',
+      database: 'connected',
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    return c.json(
+      {
+        status: 'unhealthy',
+        database: 'disconnected',
+        error: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+      },
+      503
+    );
+  }
+});
+
+// Root endpoint
 app.get('/', (c) => c.json({ status: 'ok', message: '똥글똥글 API' }));
 
 // GitHub webhook


### PR DESCRIPTION
## Summary
- Add `/health` endpoint for Docker container health checks
- The endpoint checks database connection and returns appropriate status
- Update Dockerfile with HEALTHCHECK instruction for container monitoring

## Changes
- **src/index.ts**: Added `/health` endpoint with database connection check
- **Dockerfile**: Added HEALTHCHECK instruction with 30s interval and retry logic

## Test plan
- Start the application and verify `/health` endpoint returns 200 status
- Test database disconnection to verify 503 status
- Test Docker container health status using `docker inspect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)