### PR TITLE
docs: Add Discord Bot features to documentation

### DIFF
--- a/.claude/docs/facts/index.md
+++ b/.claude/docs/facts/index.md
@@ -1,9 +1,45 @@
+---
+metadata:
+  version: "1.1.0"
+  created_at: "2026-01-05T10:00:00Z"
+  last_verified: "2026-01-05T10:00:00Z"
+  git_commit: "2ad26ee"
+  source_files:
+    src/index.ts:
+      git_hash: "2ad26ee"
+      source_exists: true
+    src/db/schema.ts:
+      git_hash: "2ad26ee"
+      source_exists: true
+    src/routes/github.ts:
+      git_hash: "2ad26ee"
+      source_exists: true
+    src/routes/reminder.ts:
+      git_hash: "2ad26ee"
+      source_exists: true
+    src/routes/status.ts:
+      git_hash: "2ad26ee"
+      source_exists: true
+    src/services/discord.ts:
+      git_hash: "2ad26ee"
+      source_exists: true
+    src/services/discord-bot.ts:
+      git_hash: "6fc7717"
+      source_exists: true
+    scripts/test-webhook.ts:
+      git_hash: "cc8098c"
+      source_exists: true
+    scripts/test-server.ts:
+      git_hash: "cc8098c"
+      source_exists: true
+---
+
 # 똥글똥글 API 문서화 FACTS
 
 - **Scope**: Hono 기반 API 서버 전체 구조
 - **Source of Truth**: 소스 코드 및 Drizzle 스키마
-- **Last Verified**: 2025-01-05
-- **Repo Ref**: f32413325de67a3ad1bde6649d16474d236d164b
+- **Last Verified**: 2026-01-05
+- **Repo Ref**: 2ad26ee
 
 ## 개요
 
@@ -21,6 +57,7 @@
 
 ### [services/](./services/)
 - **[discord.md](./services/discord.md)** - Discord 웹훅 메시지 생성 및 전송 서비스
+- **[discord-bot.md](./services/discord-bot.md)** - Discord Bot 슬래시 명령어 (/check-submission)
 
 ### [config/](./config/)
 - **[environment.md](./config/environment.md)** - 환경변수 설정 및 검증
@@ -29,9 +66,10 @@
 
 - **Framework**: Hono (TypeScript web framework)
 - **ORM**: Drizzle ORM
-- **Database**: PostgreSQL
+- **Database**: PostgreSQL (Neon)
+- **Discord Bot**: discord.js
 - **API Documentation**: OpenAPI 3.0 (@hono/zod-openapi)
-- **External Integrations**: GitHub Webhooks, Discord Webhooks, n8n workflows
+- **External Integrations**: GitHub Webhooks, Discord Webhooks, Discord Bot, n8n workflows
 
 ## 핵심 엔드포인트
 
@@ -71,12 +109,14 @@ generation_members (기수-멤버 조인 테이블)
 - **Purpose**: 제출 알림, 마감 리마인더, 현황 공유
 - **Formats**: Embed 메시지 (컬러, 필드, 타임스탬프)
 
+### Discord Bot
+- **Purpose**: 슬래시 명령어로 제출 현황 조회
+- **Command**: `/check-submission` - 현재 활성화된 주차의 제출 현황 확인
+
 ### n8n Workflows
 - **Purpose**: 주기적 리마인더 발송 (cron job)
 - **Endpoints**: `/api/reminder?hoursBefore=N`, `/api/reminder/send-reminders`
 
 ---
 
-**Metadata Version**: 1.0.0
-**Created**: 2025-01-05T10:00:00Z
-**Git Commit**: f32413325de67a3ad1bde6649d16474d236d164b
+*See YAML frontmatter for detailed metadata.*

--- a/.claude/docs/insights/index.md
+++ b/.claude/docs/insights/index.md
@@ -1,3 +1,12 @@
+---
+metadata:
+  version: "1.1.0"
+  created_at: "2026-01-05T10:00:00Z"
+  last_verified: "2026-01-05T10:00:00Z"
+  git_commit: "2ad26ee"
+  based_on_facts: "../facts/index.md"
+---
+
 # 똥글똥글 비즈니스 인사이트
 
 - **Scope**: 전체 비즈니스 컨텍스트 분석
@@ -16,6 +25,7 @@
 
 - [GitHub 웹훅 자동화](operations/github-webhook.md) - 제출 수집 및 회차 생성 자동화 흐름 분석
 - [Discord 알림 시스템](operations/discord-notifications.md) - 알림 전송 효율성과 신뢰성 분석
+- [Discord Bot](operations/discord-bot.md) - 슬래시 명령어 (/check-submission) 운영 분석
 - [리마인더 시스템](operations/reminder-system.md) - 마감 임박 알림 워크플로우 분석
 - [상태 추적 시스템](operations/status-tracking.md) - 제출 현황 조회 및 모니터링 분석
 
@@ -69,16 +79,21 @@
 
 ### 기회 (Opportunities)
 
-1. **기수-멤버 연결 테이블 활용** (`generation_members`)
+1. **Discord Bot 확장**
+   - 현재 `/check-submission` 하나만 제공
+   - 추가 명령어 가능: 미제출자 리마인드, 통계 조회 등
+   - 대화형 인터페이스로 멤버 경험 개선
+
+2. **기수-멤버 연결 테이블 활용** (`generation_members`)
    - 현재 TODO 상태로 미사용
    - 도입 시 기수별 멤버 관리 정교화 가능
    - 미제출자 계산 로직 개선 (현재 전체 멤버 대상)
 
-2. **다중 기수 동시 운영**
+3. **다중 기수 동시 운영**
    - 스키마는 이미 지원 (generations.isActive 플래그)
    - 운영 프로세스 정립 시 여러 기수 병행 운영 가능
 
-3. **제출 데이터 분석**
+4. **제출 데이터 분석**
    - 제출 패턴, 제출 시간 분석
    - 멤버 참여도 추적
 
@@ -145,9 +160,4 @@
 
 ---
 
-## 문서 버전
-
-- **Version**: 1.0.0
-- **Created**: 2026-01-05
-- **Last Updated**: 2026-01-05
-- **Git Commit**: f324133
+*See YAML frontmatter for detailed metadata.*

--- a/.claude/docs/specs/index.md
+++ b/.claude/docs/specs/index.md
@@ -1,3 +1,13 @@
+---
+metadata:
+  version: "1.1.0"
+  created_at: "2026-01-05T10:00:00Z"
+  last_verified: "2026-01-05T10:00:00Z"
+  git_commit: "2ad26ee"
+  based_on_facts: "../facts/index.md"
+  based_on_insights: "../insights/index.md"
+---
+
 # 똥글똥글 기능 명세서 (Feature Specifications)
 
 - **Scope**: 전체 시스템 기능 명세
@@ -17,6 +27,10 @@
   - Issue 생성으로 자동 회차 생성
   - Issue 댓글로 제출 처리
   - Week 패턴 파싱 및 마감일 추출
+
+- **[Discord Bot](./discord-bot.md)** - Discord 슬래시 명령어
+  - `/check-submission` - 현재 활성화된 주차의 제출 현황 조회
+  - 자동으로 활성화된 기수와 최신 주차 탐색
 
 - **[Reminder System](./reminder-system.md)** - 마감 리마인더 자동화
   - 마감 임박 회차 조회
@@ -60,6 +74,10 @@ PostgreSQL Database (Drizzle ORM)
     ↓
 Discord Webhook (Notifications)
 
+Discord Bot
+    ↓ (Slash Commands)
+API Server
+
 n8n Workflows
     ↓ (Scheduled Polling)
 API Server (Reminder/Status APIs)
@@ -71,6 +89,7 @@ API Server (Reminder/Status APIs)
 |------|------|----------|------|
 | GitHub Webhook - Issue Comment | As-Is | P0 | 운영 중 |
 | GitHub Webhook - Issues (Auto Cycle Creation) | As-Is | P0 | 운영 중 |
+| Discord Bot - /check-submission | As-Is | P0 | 운영 중 |
 | Reminder - Query Cycles | As-Is | P0 | 운영 중 |
 | Reminder - Not Submitted Members | As-Is | P1 | 운영 중 (TODO: generation_members 활용) |
 | Reminder - Send Reminders | As-Is | P0 | 운영 중 |
@@ -122,6 +141,11 @@ API Server (Reminder/Status APIs)
    - 개선: 쿼리 파라미터로 커스텀
    - 참조: [reminder-system.md](./reminder-system.md)
 
+7. **Discord Bot 추가 명령어**
+   - 현재: `/check-submission` 하나만 제공
+   - 개선: `/remind`, `/stats`, `/history` 등
+   - 참조: [discord-bot.md](./discord-bot.md) (TODO)
+
 ## 비즈니스 가치 요약
 
 ### 운영 효율성
@@ -133,8 +157,9 @@ API Server (Reminder/Status APIs)
 ### 멤버 경험
 
 - **즉시 피드백**: 제출 후 1초 이내 Discord 알림
-- **투명성**: 제출 현황 실시간 확인 가능
+- **투명성**: 제출 현황 실시간 확인 가능 (API + Discord Bot)
 - **마감 준수**: 리마인더로 마감 놓침 방지
+- **대화형 인터페이스**: `/check-submission` 슬래시 명령어로 간편 조회
 
 ### 기술적 안정성
 
@@ -158,7 +183,4 @@ API Server (Reminder/Status APIs)
 
 ---
 
-**문서 버전**: 1.0.0
-**생성일**: 2026-01-05
-**마지막 업데이트**: 2026-01-05
-**Git Commit**: f324133
+*See YAML frontmatter for detailed metadata.*


### PR DESCRIPTION
Update documentation to include new Discord Bot features:

- Add Discord Bot service documentation with /check-submission command
- Update metadata to v1.1.0 with Git commit tracking
- Add Discord Bot to external integrations and system architecture
- Include business insights for Discord Bot expansion opportunities
- Update feature status table and business value summary

This PR ensures documentation stays current with the latest code changes, including the Discord Bot implementation for checking submission status via slash commands.