### PR TITLE
fix: Add Discord guild ID support for instant slash commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
 # Create bot at: https://discord.com/developers/applications
 DISCORD_BOT_TOKEN="your_bot_token_here"
 DISCORD_CLIENT_ID="your_application_id_here"
+DISCORD_GUILD_ID="your_server_id_here"
 
 # GitHub (for fetching projects/members)
 # Create token at: https://github.com/settings/tokens

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 1. **GitHub Issue 댓글 감지** - 글 제출 시 Discord 알림
 2. **리마인더 API** - n8n에서 주기적으로 호출하여 미제출자 알림
-3. **제출 현황 조회** - Discord 명령어용 제출 현황 API
+3. **제출 현황 조회** - Discord 슬래시 명령어 `/check-submission` 지원
 
 ## 시작하기
 
@@ -30,7 +30,16 @@ pnpm install
 ```env
 # Neon PostgreSQL (브랜치별로 다른 URL 사용)
 DATABASE_URL=postgresql://user:password@ep-xxx.aws.neon.tech/neondb?sslmode=require
+
+# Discord Webhook (제출/리마인더 알림)
 DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+
+# Discord Bot (슬래시 명령어용)
+DISCORD_BOT_TOKEN=your_bot_token_here
+DISCORD_CLIENT_ID=your_application_id_here
+DISCORD_GUILD_ID=your_server_id_here
+
+# Server
 PORT=3000
 ```
 
@@ -192,3 +201,30 @@ Discord 메시지 포맷으로 제출 현황을 반환합니다.
 3. Content type: `application/json`
 4. Events: Issue comments > `Comment created`
 5. Secret 설정 (선택)
+
+## Discord Bot 설정
+
+`/check-submission` 슬래시 명령어를 사용하려면 Discord Bot이 필요합니다.
+
+### 1. Discord 앱 생성
+
+1. [Discord Developer Portal](https://discord.com/developers/applications) 접속
+2. **New Application** 클릭 → 이름 입력
+3. **Bot** 탭 → **Add Bot** 클릭
+4. **Reset Token**으로 토큰 복사 → `DISCORD_BOT_TOKEN`
+
+### 2. 봇을 서버에 초대
+
+1. **OAuth2** → **URL Generator** 탭
+2. Scopes: `bot`, `applications.commands` 체크
+3. Bot Permissions: `Send Messages`, `Embed Links` 체크
+4. 생성된 URL로 접속하여 봇을 서버에 초대
+
+### 3. 서버 ID 확인
+
+1. Discord 설정 → **고급** → **개발자 모드** 켜기
+2. 서버 우클릭 → **ID 복사** → `DISCORD_GUILD_ID`
+
+### 4. Application ID 확인
+
+**General Information** 탭에서 **Application ID** 복사 → `DISCORD_CLIENT_ID`

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,6 +22,10 @@ export const env = createEnv({
       .string()
       .min(1, { message: 'DISCORD_CLIENT_ID is required' })
       .optional(),
+    DISCORD_GUILD_ID: z
+      .string()
+      .min(1, { message: 'DISCORD_GUILD_ID is required' })
+      .optional(),
   },
 
   /**
@@ -46,6 +50,7 @@ export const env = createEnv({
     DISCORD_WEBHOOK_URL: process.env.DISCORD_WEBHOOK_URL,
     DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN,
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
+    DISCORD_GUILD_ID: process.env.DISCORD_GUILD_ID,
   },
 
   /**

--- a/src/services/discord-bot.ts
+++ b/src/services/discord-bot.ts
@@ -66,12 +66,18 @@ export const registerSlashCommands = async (): Promise<void> => {
 
     if (guildId) {
       // 길드 명령어로 등록 (즉시 반영)
-      await rest.put(Routes.applicationGuildCommands(clientId, guildId), { body: commands });
-      console.log(`✅ Successfully registered guild commands for server: ${guildId}`);
+      await rest.put(Routes.applicationGuildCommands(clientId, guildId), {
+        body: commands,
+      });
+      console.log(
+        `✅ Successfully registered guild commands for server: ${guildId}`
+      );
     } else {
       // 글로벌 명령어로 등록 (최대 1시간 소요)
       await rest.put(Routes.applicationCommands(clientId), { body: commands });
-      console.log('✅ Successfully registered global commands (may take up to 1 hour to propagate)');
+      console.log(
+        '✅ Successfully registered global commands (may take up to 1 hour to propagate)'
+      );
     }
 
     console.log('✅ Successfully reloaded application (/) commands.');

--- a/src/services/discord-bot.ts
+++ b/src/services/discord-bot.ts
@@ -62,7 +62,17 @@ export const registerSlashCommands = async (): Promise<void> => {
       throw new Error('DISCORD_CLIENT_ID is not set');
     }
 
-    await rest.put(Routes.applicationCommands(clientId), { body: commands });
+    const guildId = env.DISCORD_GUILD_ID;
+
+    if (guildId) {
+      // 길드 명령어로 등록 (즉시 반영)
+      await rest.put(Routes.applicationGuildCommands(clientId, guildId), { body: commands });
+      console.log(`✅ Successfully registered guild commands for server: ${guildId}`);
+    } else {
+      // 글로벌 명령어로 등록 (최대 1시간 소요)
+      await rest.put(Routes.applicationCommands(clientId), { body: commands });
+      console.log('✅ Successfully registered global commands (may take up to 1 hour to propagate)');
+    }
 
     console.log('✅ Successfully reloaded application (/) commands.');
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add Discord guild ID support to slash commands for instant propagation
- Fix long wait time (up to 1 hour) for global command registration
- Commands now register immediately when guild ID is provided

## Test plan
- Configure DISCORD_GUILD_ID in environment variables
- Restart Discord bot service
- Verify /check-submission command works instantly in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)