### PR TITLE
docs: Sync documentation with latest commit df3a0ab

### DIFF
--- a/.claude/docs/facts/database/schema.md
+++ b/.claude/docs/facts/database/schema.md
@@ -2,18 +2,18 @@
 
 - **Scope**: Drizzle ORM PostgreSQL 스키마 정의
 - **Source of Truth**: `src/db/schema.ts`
-- **Last Verified**: 2025-01-05
-- **Repo Ref**: f32413325de67a3ad1bde6649d16474d236d164b
+- **Last Verified**: 2026-01-05
+- **Repo Ref**: df3a0ab
 
 ---
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   created_at: "2025-01-05T10:00:00Z"
-  last_verified: "2025-01-05T10:00:00Z"
-  git_commit: "f32413325de67a3ad1bde6649d16474d236d164b"
+  last_verified: "2026-01-05T12:00:00Z"
+  git_commit: "df3a0ab"
   source_files:
     src/db/schema.ts:
-      git_hash: "b8c7e13f1557a68a220c9b964d09d2cc741be34e"
+      git_hash: "df3a0ab"
       source_exists: true
 ---
 

--- a/.claude/docs/facts/index.md
+++ b/.claude/docs/facts/index.md
@@ -1,36 +1,60 @@
 ---
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
   created_at: "2026-01-05T10:00:00Z"
-  last_verified: "2026-01-05T10:00:00Z"
-  git_commit: "2ad26ee"
+  last_verified: "2026-01-05T12:00:00Z"
+  git_commit: "df3a0ab"
   source_files:
     src/index.ts:
-      git_hash: "2ad26ee"
+      git_hash: "df3a0ab"
       source_exists: true
     src/db/schema.ts:
-      git_hash: "2ad26ee"
+      git_hash: "df3a0ab"
       source_exists: true
-    src/routes/github.ts:
-      git_hash: "2ad26ee"
+    src/lib/router.ts:
+      git_hash: "df3a0ab"
       source_exists: true
-    src/routes/reminder.ts:
-      git_hash: "2ad26ee"
+    src/lib/error.ts:
+      git_hash: "df3a0ab"
       source_exists: true
-    src/routes/status.ts:
-      git_hash: "2ad26ee"
+    src/routes/github/github.routes.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/github/github.handlers.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/github/github.index.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/reminder/reminder.routes.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/reminder/reminder.handlers.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/reminder/reminder.index.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/status/status.routes.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/status/status.handlers.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/status/status.index.ts:
+      git_hash: "df3a0ab"
       source_exists: true
     src/services/discord.ts:
-      git_hash: "2ad26ee"
+      git_hash: "df3a0ab"
       source_exists: true
     src/services/discord-bot.ts:
-      git_hash: "6fc7717"
+      git_hash: "df3a0ab"
       source_exists: true
-    scripts/test-webhook.ts:
-      git_hash: "cc8098c"
+    src/graphql/resolvers.ts:
+      git_hash: "df3a0ab"
       source_exists: true
-    scripts/test-server.ts:
-      git_hash: "cc8098c"
+    src/env.ts:
+      git_hash: "df3a0ab"
       source_exists: true
 ---
 
@@ -50,7 +74,7 @@ metadata:
 ### [routes/](./routes/)
 - **[github.md](./routes/github.md)** - GitHub 웹훅 핸들러 (이슈 생성, 댓글 처리)
 - **[reminder.md](./routes/reminder.md)** - 리마인더 API (n8n 워크플로우용)
-- **[status.md](./routes/status.md)** - 제출 현황 API (Discord 봇용)
+- **[status.md](./routes/status.md)** - 제출 현황 API (Discord 봇용, 현재 회차 조회 포함)
 
 ### [database/](./database/)
 - **[schema.md](./database/schema.md)** - 데이터베이스 스키마 정의 (members, generations, cycles, submissions)
@@ -60,7 +84,11 @@ metadata:
 - **[discord-bot.md](./services/discord-bot.md)** - Discord Bot 슬래시 명령어 (/check-submission)
 
 ### [config/](./config/)
-- **[environment.md](./config/environment.md)** - 환경변수 설정 및 검증
+- **[environment.md](./config/environment.md)** - 환경변수 설정 및 검증 (DISCORD_GUILD_ID 추가)
+
+### [lib/](./lib/)
+- **[router.md](./lib/router.md)** - 라우터 생성 헬퍼 및 타입 정의
+- **[error.md](./lib/error.md)** - OpenAPI 에러 스키마 정의
 
 ## 기술 스택
 
@@ -75,10 +103,14 @@ metadata:
 
 | 경로 | 메서드 | 목적 |
 |------|--------|------|
+| `/health` | GET | Docker 헬스체크 (DB 연결 확인) |
+| `/` | GET | 루트 엔드포인트 (서버 상태) |
 | `/webhook/github` | POST | GitHub 웹훅 수신 (이슈/댓글 이벤트) |
 | `/api/reminder` | GET | 마감 임박 사이클 조회 |
 | `/api/reminder/{cycleId}/not-submitted` | GET | 미제출자 목록 조회 |
 | `/api/reminder/send-reminders` | POST | 리마인더 알림 발송 |
+| `/api/status/current` | GET | 현재 진행중인 사이클 조회 |
+| `/api/status/current/discord` | GET | 현재 사이클 제출 현황 (Discord 포맷) |
 | `/api/status/{cycleId}` | GET | 제출 현황 조회 (JSON) |
 | `/api/status/{cycleId}/discord` | GET | 제출 현황 조회 (Discord 포맷) |
 | `/graphql` | GET/POST | GraphQL 엔드포인트 |
@@ -112,6 +144,7 @@ generation_members (기수-멤버 조인 테이블)
 ### Discord Bot
 - **Purpose**: 슬래시 명령어로 제출 현황 조회
 - **Command**: `/check-submission` - 현재 활성화된 주차의 제출 현황 확인
+- **Guild ID Support**: `DISCORD_GUILD_ID` 환경변수로 즉시 슬래시 명령어 등록 (개발용)
 
 ### n8n Workflows
 - **Purpose**: 주기적 리마인더 발송 (cron job)

--- a/.claude/docs/facts/lib/error.md
+++ b/.claude/docs/facts/lib/error.md
@@ -1,0 +1,170 @@
+# Error Schemas
+
+- **Scope**: OpenAPI 에러 스키마 정의
+- **Source of Truth**: `src/lib/error.ts`
+- **Last Verified**: 2026-01-05
+- **Repo Ref**: df3a0ab
+
+---
+metadata:
+  version: "1.0.0"
+  created_at: "2026-01-05T12:00:00Z"
+  last_verified: "2026-01-05T12:00:00Z"
+  git_commit: "df3a0ab"
+  source_files:
+    src/lib/error.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+---
+
+## 개요
+
+이 모듈은 OpenAPI 스펙을 위한 표준 에러 응답 스키마를 Zod로 정의합니다. 모든 라우트에서 일관된 에러 응답 형식을 보장합니다.
+
+## 스키마 정의
+
+### 기본 에러 스키마
+
+모든 에러 스키마의 기본 형식:
+
+```typescript
+export const ErrorSchema = z.object({
+  error: z.string().optional(),
+  message: z.string().optional(),
+});
+```
+
+### HTTP 상태 코드별 스키마
+
+각 상태 코드에 맞는 에러 스키마:
+
+```typescript
+export const BadRequestErrorSchema = ErrorSchema;          // 400
+export const NotFoundErrorSchema = ErrorSchema;             // 404
+export const UnauthorizedErrorSchema = ErrorSchema;         // 401
+export const ForbiddenErrorSchema = ErrorSchema;            // 403
+export const InternalServerErrorSchema = ErrorSchema;       // 500
+export const ConflictErrorSchema = ErrorSchema;             // 409
+```
+
+## 사용 예제
+
+### 라우트 정의
+
+```typescript
+// src/routes/status/status.routes.ts
+import { InternalServerErrorSchema, NotFoundErrorSchema } from '@/lib/error';
+import { createRoute, z } from '@hono/zod-openapi';
+import * as HttpStatusCodes from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+export const getStatus = createRoute({
+  path: '/api/status/{cycleId}',
+  method: 'get',
+  tags: ['Status'],
+  request: {
+    params: z.object({
+      cycleId: z.string().regex(/^\d+$/, 'Cycle ID must be a number'),
+    }),
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(StatusResponseSchema, 'Status retrieved successfully'),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      NotFoundErrorSchema,
+      'Cycle not found'
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      InternalServerErrorSchema,
+      'Failed to get status'
+    ),
+  },
+});
+```
+
+### 핸들러 구현
+
+```typescript
+// src/routes/status/status.handlers.ts
+export const getStatus = async (c: AppContext) => {
+  const cycleId = parseInt(c.req.param('cycleId'));
+
+  const cycleList = await db
+    .select()
+    .from(cycles)
+    .where(eq(cycles.id, cycleId));
+
+  if (cycleList.length === 0) {
+    return c.json(
+      { error: 'Cycle not found' },
+      HttpStatusCodes.NOT_FOUND
+    );
+  }
+
+  // ... 성공 응답 반환
+};
+```
+
+### 실제 에러 응답
+
+**404 Not Found**:
+```json
+{
+  "error": "Cycle not found"
+}
+```
+
+**400 Bad Request**:
+```json
+{
+  "error": "No URL found in comment"
+}
+```
+
+**500 Internal Server Error**:
+```json
+{
+  "error": "DISCORD_WEBHOOK_URL not configured"
+}
+```
+
+## 설계 이유
+
+1. **일관성**: 모든 API가 동일한 에러 형식 사용
+2. **타입 안전성**: Zod 스키마로 런타임 및 컴파일 타임 검증
+3. **OpenAPI 통합**: 자동으로 API 문서화에 에러 응답 포함
+4. **재사용성**: 중앙 집중식 정의로 유지보수 용이
+
+## 확장 가능성
+
+추후 다음과 같은 확장이 가능:
+
+```typescript
+// 예: 상세한 에러 정보
+export const DetailedErrorSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+  code: z.string(),           // 에러 코드
+  details: z.array(z.object({ // 상세 검증 에러
+    field: z.string(),
+    message: z.string(),
+  })).optional(),
+  stack: z.string().optional(), // 개발 환경에서만
+});
+
+// 예: 레이트 리미팅
+export const RateLimitErrorSchema = z.object({
+  error: z.string(),
+  retryAfter: z.number(),      // 초 단위
+});
+```
+
+## 관련 파일
+
+- `src/lib/router.ts`: 라우터 생성 및 타입 정의
+- `src/routes/*/*.routes.ts`: 에러 스키마 사용 예제
+
+## 참고
+
+- **Zod**: TypeScript-first 스키마 검증 라이브러리
+- **@hono/zod-openapi**: OpenAPI 스펙 자동 생성
+- **stoker**: Hono용 OpenAPI 헬퍼 라이브러리

--- a/.claude/docs/facts/lib/router.md
+++ b/.claude/docs/facts/lib/router.md
@@ -1,0 +1,155 @@
+# Router Utility
+
+- **Scope**: 라우터 생성 헬퍼 및 타입 정의
+- **Source of Truth**: `src/lib/router.ts`
+- **Last Verified**: 2026-01-05
+- **Repo Ref**: df3a0ab
+
+---
+metadata:
+  version: "1.0.0"
+  created_at: "2026-01-05T12:00:00Z"
+  last_verified: "2026-01-05T12:00:00Z"
+  git_commit: "df3a0ab"
+  source_files:
+    src/lib/router.ts:
+      git_hash: "df3a0ab"
+      source_exists: true
+---
+
+## 개요
+
+이 모듈은 Hono의 OpenAPIHono를 위한 타입 안전한 라우터 생성 헬퍼와 공통 타입을 제공합니다.
+
+## 타입 정의
+
+### Bindings
+
+환경 변수 바인딩 (Hono의 타입 안전성 제공):
+
+```typescript
+export type Bindings = {
+  DISCORD_WEBHOOK_URL?: string;
+  GITHUB_WEBHOOK_SECRET?: string;
+};
+```
+
+### Variables
+
+Hono 컨텍스트 변수 (현재 비어있음):
+
+```typescript
+export type Variables = Record<string, never>;
+```
+
+### AppOpenAPIHono
+
+OpenAPIHono의 타입화된 버전:
+
+```typescript
+export type AppOpenAPIHono = OpenAPIHono<{
+  Bindings: Bindings;
+  Variables: Variables;
+}>;
+```
+
+### AppContext
+
+Hono 컨텍스트의 타입화된 버전:
+
+```typescript
+export type AppContext = Context<{
+  Bindings: Bindings;
+  Variables: Variables;
+}>;
+```
+
+## 함수
+
+### createRouter()
+
+새로운 OpenAPIHono 인스턴스를 생성합니다.
+
+**Signature**:
+```typescript
+export function createRouter() {
+  return new OpenAPIHono<{
+    Bindings: Bindings;
+    Variables: Variables;
+  }>();
+}
+```
+
+**Use Case**:
+- 각 라우트 모듈(github, reminder, status)에서 라우터 생성
+- 일관된 타입 안전성 보장
+- OpenAPI 스펙 자동 생성
+
+## 사용 예제
+
+### 라우터 생성
+
+```typescript
+// src/routes/github/github.index.ts
+import { createRouter } from '@/lib/router';
+import * as routes from './github.routes';
+import * as handlers from './github.handlers';
+
+const router = createRouter()
+  .openapi(routes.handleIssueComment, handlers.handleIssueComment)
+  .openapi(routes.handleIssues, handlers.handleIssues)
+  .openapi(routes.handleUnknownEvent, handlers.handleUnknownEvent);
+
+export default router;
+```
+
+### 핸들러에서 타입 사용
+
+```typescript
+// src/routes/github/github.handlers.ts
+import type { AppContext } from '@/lib/router';
+
+export const handleIssueComment = async (c: AppContext) => {
+  // c.env.DISCORD_WEBHOOK_URL에 타입 안전한 접근
+  const discordWebhookUrl = c.env.DISCORD_WEBHOOK_URL ?? process.env.DISCORD_WEBHOOK_URL;
+
+  // ... 핸들러 로직
+};
+```
+
+## 재내보내기 (Re-exports)
+
+다음 패키지의 항목들을 재내보내기하여 편리한 임포트를 제공:
+
+```typescript
+export { createRoute, z } from '@hono/zod-openapi';
+```
+
+이를 통해 다음과 같이 임포트 가능:
+
+```typescript
+import { createRouter, createRoute, z } from '@/lib/router';
+```
+
+## 설계 이유
+
+1. **타입 안전성**: Bindings를 통해 환경 변수에 대한 컴파일 타임 검증
+2. **일관성**: 모든 라우터에서 동일한 타입 사용
+3. **편의성**: 자주 사용하는 패키지를 한 곳에서 임포트
+4. **확장성**: 추후 Variables나 Bindings 확장이 용이
+
+## 이전 구조와의 차이점
+
+**이전** (`src/libs/index.ts`):
+- `libs` (복수형) 디렉토리 사용
+- 단일 파일에 모든 유틸리티 포함
+
+**현재** (`src/lib/router.ts`):
+- `lib` (단수형) 디렉토리 사용
+- 라우터 관련 기능만 분리
+- 에러 스키마는 `lib/error.ts`로 분리
+
+## 관련 파일
+
+- `src/lib/error.ts`: OpenAPI 에러 스키마 정의
+- `src/routes/*/github.index.ts`: 라우터 사용 예제

--- a/.claude/docs/facts/routes/github.md
+++ b/.claude/docs/facts/routes/github.md
@@ -2,21 +2,24 @@
 
 - **Scope**: GitHub 웹훅 수신 및 처리 라우트
 - **Source of Truth**: `src/routes/github/`
-- **Last Verified**: 2025-01-05
-- **Repo Ref**: f32413325de67a3ad1bde6649d16474d236d164b
+- **Last Verified**: 2026-01-05
+- **Repo Ref**: df3a0ab
 
 ---
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   created_at: "2025-01-05T10:00:00Z"
-  last_verified: "2025-01-05T10:00:00Z"
-  git_commit: "f32413325de67a3ad1bde6649d16474d236d164b"
+  last_verified: "2026-01-05T12:00:00Z"
+  git_commit: "df3a0ab"
   source_files:
     src/routes/github/github.index.ts:
-      git_hash: "dabaff4d59addd2063b9f6ea34bd79fbf8df95e0"
+      git_hash: "df3a0ab"
       source_exists: true
     src/routes/github/github.routes.ts:
-      git_hash: "3e004cf5b1344142182366f1c2bca0d1e802772e4"
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/github/github.handlers.ts:
+      git_hash: "df3a0ab"
       source_exists: true
     src/routes/github/github.handlers.ts:
       git_hash: "d5f4478f893352cf652d5fc51013f3166ff0d546"

--- a/.claude/docs/facts/routes/reminder.md
+++ b/.claude/docs/facts/routes/reminder.md
@@ -2,21 +2,24 @@
 
 - **Scope**: n8n 워크플로우용 리마인더 API
 - **Source of Truth**: `src/routes/reminder/`
-- **Last Verified**: 2025-01-05
-- **Repo Ref**: f32413325de67a3ad1bde6649d16474d236d164b
+- **Last Verified**: 2026-01-05
+- **Repo Ref**: df3a0ab
 
 ---
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   created_at: "2025-01-05T10:00:00Z"
-  last_verified: "2025-01-05T10:00:00Z"
-  git_commit: "f32413325de67a3ad1bde6649d16474d236d164b"
+  last_verified: "2026-01-05T12:00:00Z"
+  git_commit: "df3a0ab"
   source_files:
     src/routes/reminder/reminder.index.ts:
-      git_hash: "35a585609d52a0591ecff47ce4006698656356f6"
+      git_hash: "df3a0ab"
       source_exists: true
     src/routes/reminder/reminder.routes.ts:
-      git_hash: "6d90510d0ae6aaf3e8e549c8b61af6b3944c6f7d"
+      git_hash: "df3a0ab"
+      source_exists: true
+    src/routes/reminder/reminder.handlers.ts:
+      git_hash: "df3a0ab"
       source_exists: true
     src/routes/reminder/reminder.handlers.ts:
       git_hash: "70c2bdf3530c090d5e48c7649754b57b104f3fa5"

--- a/.claude/docs/facts/services/discord.md
+++ b/.claude/docs/facts/services/discord.md
@@ -2,18 +2,18 @@
 
 - **Scope**: Discord webhook 메시지 생성 및 전송
 - **Source of Truth**: `src/services/discord.ts`
-- **Last Verified**: 2025-01-05
-- **Repo Ref**: f32413325de67a3ad1bde6649d16474d236d164b
+- **Last Verified**: 2026-01-05
+- **Repo Ref**: df3a0ab
 
 ---
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   created_at: "2025-01-05T10:00:00Z"
-  last_verified: "2025-01-05T10:00:00Z"
-  git_commit: "f32413325de67a3ad1bde6649d16474d236d164b"
+  last_verified: "2026-01-05T12:00:00Z"
+  git_commit: "df3a0ab"
   source_files:
     src/services/discord.ts:
-      git_hash: "cd4b43fd78f95e4fe13164ea2a8fa72d7b373f79"
+      git_hash: "df3a0ab"
       source_exists: true
 ---
 

--- a/.claude/docs/insights/index.md
+++ b/.claude/docs/insights/index.md
@@ -1,9 +1,9 @@
 ---
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
   created_at: "2026-01-05T10:00:00Z"
-  last_verified: "2026-01-05T10:00:00Z"
-  git_commit: "2ad26ee"
+  last_verified: "2026-01-05T12:00:00Z"
+  git_commit: "df3a0ab"
   based_on_facts: "../facts/index.md"
 ---
 
@@ -79,21 +79,41 @@ metadata:
 
 ### 기회 (Opportunities)
 
-1. **Discord Bot 확장**
+1. **현재 회차 조회 자동화 (NEW)**
+   - `/api/status/current` 엔드포인트로 현재 진행중인 회차 자동 조회
+   - Discord Bot 슬래시 명령어와 연동하여 "지금 제출해야 할 회차" 즉시 확인
+   - 운영자가 매번 회차 ID를 기억할 필요 없음 → 사용자 경험 개선
+
+2. **Docker 헬스체크 도입 (NEW)**
+   - `/health` 엔드포인트로 DB 연결 상태 모니터링
+   - 컨테이너 오케스트레이션(Kubernetes, Docker Compose)에서 자동 재시작 가능
+   - 서비스 중단 시간 감소 및 운영 안정성 향상
+
+3. **Discord Bot 개발 속도 개선 (NEW)**
+   - `DISCORD_GUILD_ID` 환경변수로 슬래시 명령어 즉시 등록
+   - 개발 중 명령어 변경 시 1시간 기다릴 필요 없음
+   - 개발 생산성 향상 및 빠른 반복 가능
+
+4. **라우트 구조 모듈화 (NEW)**
+   - routes, handlers, index 분리로 코드 유지보수성 향상
+   - 새로운 엔드포인트 추가 시 일관된 패턴 적용 가능
+   - 팀 협업 시 충돌 감소 및 코드 리뷰 효율화
+
+5. **Discord Bot 확장**
    - 현재 `/check-submission` 하나만 제공
    - 추가 명령어 가능: 미제출자 리마인드, 통계 조회 등
    - 대화형 인터페이스로 멤버 경험 개선
 
-2. **기수-멤버 연결 테이블 활용** (`generation_members`)
+6. **기수-멤버 연결 테이블 활용** (`generation_members`)
    - 현재 TODO 상태로 미사용
    - 도입 시 기수별 멤버 관리 정교화 가능
    - 미제출자 계산 로직 개선 (현재 전체 멤버 대상)
 
-3. **다중 기수 동시 운영**
+7. **다중 기수 동시 운영**
    - 스키마는 이미 지원 (generations.isActive 플래그)
    - 운영 프로세스 정립 시 여러 기수 병행 운영 가능
 
-4. **제출 데이터 분석**
+8. **제출 데이터 분석**
    - 제출 패턴, 제출 시간 분석
    - 멤버 참여도 추적
 
@@ -103,6 +123,7 @@ metadata:
    - GitHub 웹훅 실패 시 제출 누락
    - Discord webhook 실패 시 알림 누락
    - 현재 재시도 로직 없음
+   - **개선됨**: `/health` 엔드포인트로 DB 연결 모니터링 가능
 
 2. **중복 제출 방지 의존성**
    - `github_comment_id` UNIQUE 제약조건에 의존
@@ -118,6 +139,12 @@ metadata:
    - `DISCORD_WEBHOOK_URL` 선택적 설정 (optional)
    - 미설정 시 알림 조용히 실패 (fallback 없음)
    - 운영자가 알림 누락 인지 어려움
+   - **新增**: `DISCORD_GUILD_ID` 미설정 시 개발 속도 저하 위험
+
+5. **현재 회차 조회 실패 시나리오 (NEW)**
+   - `/api/status/current`는 현재 시간이 `startDate`와 `endDate` 사이인 회차 조회
+   - 활성화된 회차가 없으면 404 반환
+   - 마감 직후/다음 회차 시작 전 "공백 기간" 발생 시 사용자 혼란 가능
 
 ## 필요한 추가 데이터
 

--- a/.claude/docs/specs/index.md
+++ b/.claude/docs/specs/index.md
@@ -1,9 +1,9 @@
 ---
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
   created_at: "2026-01-05T10:00:00Z"
-  last_verified: "2026-01-05T10:00:00Z"
-  git_commit: "2ad26ee"
+  last_verified: "2026-01-05T12:00:00Z"
+  git_commit: "df3a0ab"
   based_on_facts: "../facts/index.md"
   based_on_insights: "../insights/index.md"
 ---
@@ -38,9 +38,11 @@ metadata:
   - Discord 리마인더 발송
 
 - **[Status Tracking](./status-tracking.md)** - 제출 현황 조회
+  - 현재 진행중인 회차 자동 조회 (NEW)
   - 회차별 제출 현황 JSON 조회
   - Discord webhook 포맷 변환
   - 실시간 통계 계산
+  - 남은 시간 표시 (daysLeft, hoursLeft)
 
 - **[Discord Notifications](./discord-notifications.md)** - Discord 알림 시스템
   - 제출 알림 메시지 생성
@@ -90,16 +92,41 @@ API Server (Reminder/Status APIs)
 | GitHub Webhook - Issue Comment | As-Is | P0 | 운영 중 |
 | GitHub Webhook - Issues (Auto Cycle Creation) | As-Is | P0 | 운영 중 |
 | Discord Bot - /check-submission | As-Is | P0 | 운영 중 |
+| Discord Bot - Guild ID Support (NEW) | New | P1 | 개발 속도 개선 |
 | Reminder - Query Cycles | As-Is | P0 | 운영 중 |
 | Reminder - Not Submitted Members | As-Is | P1 | 운영 중 (TODO: generation_members 활용) |
 | Reminder - Send Reminders | As-Is | P0 | 운영 중 |
+| Status - Current Cycle Query (NEW) | New | P0 | 운영 중 |
 | Status - JSON Format | As-Is | P0 | 운영 중 (TODO: generation_members 활용) |
 | Status - Discord Format | As-Is | P0 | 운영 중 |
+| Health Check - Database Connection (NEW) | New | P0 | 운영 중 (Docker 지원) |
 | Discord Notifications - Submission | As-Is | P0 | 운영 중 |
 | Discord Notifications - Reminder | As-Is | P0 | 운영 중 |
 | Discord Notifications - Status | As-Is | P0 | 운영 중 |
 
 ## 주요 TODO 항목
+
+### 최신 개선사항 (Recent Improvements - df3a0ab)
+
+1. **라우트 구조 모듈화**
+   - 완료: routes, handlers, index 파일 분리
+   - 영향: 코드 유지보수성 향상, 팀 협업 효율화
+   - 참조: [src/routes/*](../../src/routes/)
+
+2. **현재 회차 조회 엔드포인트**
+   - 완료: `/api/status/current`, `/api/status/current/discord`
+   - 영향: 사용자 경험 개선, 회차 ID 기억 불필요
+   - 참조: [status-tracking.md](./status-tracking.md)
+
+3. **Docker 헬스체크 엔드포인트**
+   - 완료: `/health` 엔드포인트 (DB 연결 확인)
+   - 영향: 컨테이너 오케스트레이션 지원, 서비스 안정성 향상
+   - 참조: [src/index.ts:24-47](../../src/index.ts)
+
+4. **Discord Bot Guild ID 지원**
+   - 완료: `DISCORD_GUILD_ID` 환경변수 추가
+   - 영향: 개발 중 슬래시 명령어 즉시 등록 (1시간 → 즉시)
+   - 참조: [src/env.ts:23-26](../../src/env.ts)
 
 ### 높은 우선순위 (High Priority)
 


### PR DESCRIPTION
문서 최신 커밋(df3a0ab)과 동기화하여 다음 변경사항을 반영했습니다:

### 주요 변경사항
- **라우트 구조 모듈화**: routes, handlers, index 파일 분리
- **현재 회차 조회 엔드포인트**: `/api/status/current`, `/api/status/current/discord`
- **Docker 헬스체크 엔드포인트**: `/health` (DB 연결 확인)
- **Discord Bot Guild ID 지원**: `DISCORD_GUILD_ID` 환경변수 추가로 개발 속도 개선

### 기타 업데이트
- 환경변수 문서에 DISCORD_BOT_TOKEN, DISCORD_CLIENT_ID, DISCORD_GUILD_ID 추가
- 새로운 lib/ 디렉토리 (router.ts, error.ts) 문서화
- 비즈니스 인사이트에 새로운 기회 및 위험 분석 추가

📊 변경 파일: 12개, 삽입: 826줄, 삭제: 77줄