### PR TITLE
fix: Separate /current-cycle command from /check-submission functionality

### DIFF
--- a/src/services/discord-bot.ts
+++ b/src/services/discord-bot.ts
@@ -121,33 +121,20 @@ const handleCurrentCycle = async (
 
     const { cycle, generation } = currentCycle[0];
 
-    const submissionList = await db
-      .select({
-        memberId: submissions.memberId,
-      })
-      .from(submissions)
-      .where(eq(submissions.cycleId, cycle.id));
-
-    const allMembers = await db.select().from(members);
-
-    const submittedIds = new Set(submissionList.map((s) => s.memberId));
-
-    const submittedNames = allMembers
-      .filter((m) => submittedIds.has(m.id))
-      .map((m) => m.name);
-
-    const notSubmittedNames = allMembers
-      .filter((m) => !submittedIds.has(m.id))
-      .map((m) => m.name);
-
-    const discordMessage = createStatusMessage(
-      `${generation.name} - ${cycle.week}주차`,
-      submittedNames,
-      notSubmittedNames,
-      cycle.endDate
+    const daysUntilDeadline = Math.ceil(
+      (new Date(cycle.endDate).getTime() - now.getTime()) /
+        (1000 * 60 * 60 * 24)
     );
 
-    await interaction.editReply(discordMessage);
+    await interaction.editReply({
+      content: `📅 **현재 주차 정보**\n\n**기수**: ${
+        generation.name
+      }\n**주차**: ${cycle.week}주차\n**마감일**: ${new Date(
+        cycle.endDate
+      ).toLocaleDateString('ko-KR')} (${
+        daysUntilDeadline > 0 ? `D-${daysUntilDeadline}` : '오늘 마감'
+      })\n\n이슈 링크: ${cycle.githubIssueUrl}`,
+    });
   } catch (error) {
     console.error('Error handling current-cycle command:', error);
     await interaction.editReply({


### PR DESCRIPTION
## Summary
- Fixed `/current-cycle` command to show only current cycle information instead of submission status
- Added deadline countdown (D-N days) display
- `/check-submission` command remains unchanged for full submission status view

## Test plan
- Test `/current-cycle` command shows generation name, week number, deadline, and issue link
- Verify `/check-submission` still shows full submission status
- Test edge case when no active cycle exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)