### PR TITLE
feat: Add Direnv support for automatic environment variable loading

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,8 @@
+# .envrc Example
+# This file is automatically loaded by direnv when entering the project directory.
+# Copy this file to .envrc and run: direnv allow
+
+# Load environment variables from .env file
+if [ -f .env ]; then
+  export $(cat .env | grep -v '^#' | grep -v '^$' | xargs)
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 .env
+.envrc
 .DS_Store
 *.log
 drizzle

--- a/README.md
+++ b/README.md
@@ -17,6 +17,38 @@
 
 ## 시작하기
 
+### 0. Direnv 설정 (권장, 워크트리 사용 시 필수)
+
+여러 git worktree에서 개발할 때 환경변수를 자동으로 로드하기 위해 **direnv**를 사용합니다.
+
+#### 설치
+
+```bash
+# macOS
+brew install direnv
+
+# 셸 설정 추가 (zsh)
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+source ~/.zshrc
+
+# 셸 설정 추가 (bash)
+echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+#### 프로젝트 설정
+
+```bash
+# 프로젝트 루트에서 .envrc 활성화
+direnv allow
+
+# 워크트리를 사용하는 경우, 메인 워크트리의 .envrc를 심링크로 연결
+ln -s /path/to/main/worktree/.envrc .envrc
+direnv allow
+```
+
+이제 프로젝트 디렉토리에 진입하면 `.env` 파일의 환경변수가 자동으로 로드되고, 나가면 자동으로 언로드됩니다.
+
 ### 1. 의존성 설치
 
 ```bash
@@ -51,9 +83,17 @@ pnpm run db:push
 
 ### 4. 실행
 
+direnv가 설정된 경우 환경변수가 자동으로 로드됩니다:
+
 ```bash
+# direnv로 자동 로드되는지 확인
+echo $DATABASE_URL
+
+# 개발 서버 시작
 pnpm run dev
 ```
+
+**참고**: direnv를 사용하지 않는 경우 `dotenv` 클라이언트가 `.env`를 로드합니다.
 
 ## API 명세
 


### PR DESCRIPTION
## Summary

- Add `.envrc` to automatically load `.env` variables with direnv
- Update README.md with comprehensive Direnv setup guide
- Add `.envrc.example` for reference
- Add `.envrc` to `.gitignore` to prevent accidental commits

## Changes

### .gitignore
- Added `.envrc` to prevent accidental commits

### README.md
- Added section 0 "Direnv 설정 (권장, 워크트리 사용 시 필수)" with:
  - Installation instructions for macOS (brew)
  - Shell configuration for zsh/bash
  - Project setup commands
  - Workflow explanation
- Updated execution section to mention direnv auto-loading

### .envrc.example
- Created reference file showing how `.envrc` loads environment variables

## Benefits

This implementation allows developers to work across multiple git worktrees without manually managing environment variables in each workspace. When entering a project directory, direnv automatically loads the `.env` file, and when leaving, it unloads them.

## Test plan

- [ ] Verify direnv installation on macOS
- [ ] Test environment variable auto-loading
- [ ] Test across multiple git worktrees
- [ ] Test fallback to dotenv when direnv is not used

🤖 Generated with [Claude Code](https://claude.com/claude-code)