### PR TITLE
feat: Implement DDD for submission domain (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dist
 .env
 .DS_Store
 *.log
-drizzle
 .pnpm-store
+# Only ignore drizzle folder in root (for migrations), not in src
+/drizzle

--- a/src/application/commands/create-cycle.command.ts
+++ b/src/application/commands/create-cycle.command.ts
@@ -1,0 +1,77 @@
+// CreateCycleCommand - 사이클 생성 Command
+
+import { Cycle } from '../../domain/cycle/cycle.domain';
+import { CycleRepository } from '../../domain/cycle/cycle.repository';
+import { GenerationRepository } from '../../domain/generation/generation.repository';
+import { ConflictError } from '../../domain/common/errors';
+
+/**
+ * 사이클 생성 Command 요청 데이터
+ */
+export interface CreateCycleRequest {
+  week: number;
+  startDate?: Date;
+  endDate?: Date;
+  githubIssueUrl: string;
+}
+
+/**
+ * 사이클 생성 Command 결과
+ */
+export interface CreateCycleResult {
+  cycle: Cycle;
+  generationName: string;
+}
+
+/**
+ * 사이클 생성 Command (Use Case)
+ *
+ * 책임:
+ * 1. 활성화된 기수를 찾는다
+ * 2. 이미 동일한 주차의 사이클이 있는지 확인한다
+ * 3. 사이클을 생성하고 저장한다
+ */
+export class CreateCycleCommand {
+  constructor(
+    private readonly cycleRepo: CycleRepository,
+    private readonly generationRepo: GenerationRepository
+  ) {}
+
+  async execute(request: CreateCycleRequest): Promise<CreateCycleResult> {
+    // 1. 활성화된 기수 찾기
+    const generation = await this.generationRepo.findActive();
+
+    // 2. 이미 동일한 주차가 있는지 확인
+    const existing = await this.cycleRepo.findByGenerationAndWeek(
+      generation.id.value,
+      request.week
+    );
+    if (existing) {
+      throw new ConflictError(
+        `Cycle with week ${request.week} already exists for generation ${generation.name}`
+      );
+    }
+
+    // 3. 날짜 계산 (기본값: 현재부터 7일간)
+    const now = new Date();
+    const startDate = request.startDate ?? now;
+    const endDate = request.endDate ?? new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+    // 4. 사이클 생성
+    const cycle = Cycle.create({
+      generationId: generation.id.value,
+      week: request.week,
+      startDate,
+      endDate,
+      githubIssueUrl: request.githubIssueUrl,
+    });
+
+    // 5. 저장
+    await this.cycleRepo.save(cycle);
+
+    return {
+      cycle,
+      generationName: generation.name,
+    };
+  }
+}

--- a/src/application/commands/create-cycle.command.ts
+++ b/src/application/commands/create-cycle.command.ts
@@ -40,6 +40,9 @@ export class CreateCycleCommand {
   async execute(request: CreateCycleRequest): Promise<CreateCycleResult> {
     // 1. 활성화된 기수 찾기
     const generation = await this.generationRepo.findActive();
+    if (!generation) {
+      throw new ConflictError('No active generation found');
+    }
 
     // 2. 이미 동일한 주차가 있는지 확인
     const existing = await this.cycleRepo.findByGenerationAndWeek(

--- a/src/application/commands/create-cycle.command.ts
+++ b/src/application/commands/create-cycle.command.ts
@@ -55,7 +55,8 @@ export class CreateCycleCommand {
     // 3. 날짜 계산 (기본값: 현재부터 7일간)
     const now = new Date();
     const startDate = request.startDate ?? now;
-    const endDate = request.endDate ?? new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+    const endDate =
+      request.endDate ?? new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
 
     // 4. 사이클 생성
     const cycle = Cycle.create({

--- a/src/application/commands/create-generation.command.ts
+++ b/src/application/commands/create-generation.command.ts
@@ -1,0 +1,68 @@
+// CreateGenerationCommand - 기수 생성 Command
+
+import { Generation } from '../../domain/generation/generation.domain';
+import { GenerationRepository } from '../../domain/generation/generation.repository';
+import { GenerationService } from '../../domain/generation/generation.service';
+import { ValidationError } from '../../domain/common/errors';
+
+/**
+ * 기수 생성 Command 요청 데이터
+ */
+export interface CreateGenerationRequest {
+  name: string;
+  startedAt: Date;
+  isActive?: boolean;
+}
+
+/**
+ * 기수 생성 Command 결과
+ */
+export interface CreateGenerationResult {
+  generation: Generation;
+}
+
+/**
+ * 기수 생성 Command (Use Case)
+ *
+ * 책임:
+ * 1. 기수 이름 검증
+ * 2. 활성화된 기수가 있는지 확인
+ * 3. 기수 생성 및 저장
+ */
+export class CreateGenerationCommand {
+  constructor(
+    private readonly generationRepo: GenerationRepository,
+    private readonly generationService: GenerationService
+  ) {}
+
+  async execute(
+    request: CreateGenerationRequest
+  ): Promise<CreateGenerationResult> {
+    // 1. 기수 이름 검증
+    const trimmedName = request.name.trim();
+    if (trimmedName.length === 0) {
+      throw new ValidationError('Generation name cannot be empty');
+    }
+    if (trimmedName.length > 50) {
+      throw new ValidationError('Generation name cannot exceed 50 characters');
+    }
+
+    // 2. 활성화된 기수가 있는지 확인 (isActive가 true인 경우)
+    const isActive = request.isActive ?? false;
+    await this.generationService.validateNewGeneration(isActive);
+
+    // 3. 기수 생성
+    const generation = Generation.create({
+      name: trimmedName,
+      startedAt: request.startedAt,
+      isActive,
+    });
+
+    // 4. 저장
+    await this.generationRepo.save(generation);
+
+    return {
+      generation,
+    };
+  }
+}

--- a/src/application/commands/create-member.command.ts
+++ b/src/application/commands/create-member.command.ts
@@ -1,0 +1,55 @@
+// CreateMemberCommand - 회원 생성 Command
+
+import { Member } from '../../domain/member/member.domain';
+import { MemberRepository } from '../../domain/member/member.repository';
+import { MemberService } from '../../domain/member/member.service';
+
+/**
+ * 회원 생성 Command 요청 데이터
+ */
+export interface CreateMemberRequest {
+  githubUsername: string;
+  name: string;
+  discordId?: string;
+}
+
+/**
+ * 회원 생성 Command 결과
+ */
+export interface CreateMemberResult {
+  member: Member;
+}
+
+/**
+ * 회원 생성 Command (Use Case)
+ *
+ * 책임:
+ * 1. 중복 회원 검사
+ * 2. 회원 생성
+ * 3. 회원 저장
+ */
+export class CreateMemberCommand {
+  constructor(
+    private readonly memberRepo: MemberRepository,
+    private readonly memberService: MemberService
+  ) {}
+
+  async execute(request: CreateMemberRequest): Promise<CreateMemberResult> {
+    // 1. 중복 회원 검사
+    await this.memberService.validateNewMember(request.githubUsername);
+
+    // 2. 회원 생성
+    const member = Member.create({
+      githubUsername: request.githubUsername,
+      name: request.name,
+      discordId: request.discordId,
+    });
+
+    // 3. 저장
+    await this.memberRepo.save(member);
+
+    return {
+      member,
+    };
+  }
+}

--- a/src/application/commands/index.ts
+++ b/src/application/commands/index.ts
@@ -2,3 +2,5 @@
 
 export * from './record-submission.command';
 export * from './create-cycle.command';
+export * from './create-generation.command';
+export * from './create-member.command';

--- a/src/application/commands/index.ts
+++ b/src/application/commands/index.ts
@@ -1,3 +1,4 @@
 // Application Commands exports
 
 export * from './record-submission.command';
+export * from './create-cycle.command';

--- a/src/application/commands/index.ts
+++ b/src/application/commands/index.ts
@@ -1,0 +1,3 @@
+// Application Commands exports
+
+export * from './record-submission.command';

--- a/src/application/commands/record-submission.command.ts
+++ b/src/application/commands/record-submission.command.ts
@@ -83,7 +83,7 @@ export class RecordSubmissionCommand {
     // 6. 결과 반환 (핸들러에서 Discord 알림 등 추가 작업 수행)
     return {
       submission,
-      memberName: member.name,
+      memberName: member.name.value,
       cycleName: `${cycle.week}주차`,
     };
   }

--- a/src/application/commands/record-submission.command.ts
+++ b/src/application/commands/record-submission.command.ts
@@ -44,7 +44,9 @@ export class RecordSubmissionCommand {
     private readonly submissionService: SubmissionService
   ) {}
 
-  async execute(request: RecordSubmissionRequest): Promise<RecordSubmissionResult> {
+  async execute(
+    request: RecordSubmissionRequest
+  ): Promise<RecordSubmissionResult> {
     // 1. Cycle 찾기
     const cycle = await this.cycleRepo.findByIssueUrl(request.githubIssueUrl);
     if (!cycle) {

--- a/src/application/commands/record-submission.command.ts
+++ b/src/application/commands/record-submission.command.ts
@@ -1,0 +1,88 @@
+// RecordSubmissionCommand - 제출 기록 Command
+
+import { Submission } from '../../domain/submission/submission.domain';
+import { CycleRepository } from '../../domain/cycle/cycle.repository';
+import { MemberRepository } from '../../domain/member/member.repository';
+import { SubmissionRepository } from '../../domain/submission/submission.repository';
+import { SubmissionService } from '../../domain/submission/submission.service';
+import { NotFoundError } from '../../domain/common/errors';
+
+/**
+ * 제출 기록 Command 요청 데이터
+ */
+export interface RecordSubmissionRequest {
+  githubUsername: string;
+  blogUrl: string;
+  githubCommentId: string;
+  githubIssueUrl: string;
+}
+
+/**
+ * 제출 기록 Command 결과
+ */
+export interface RecordSubmissionResult {
+  submission: Submission;
+  memberName: string;
+  cycleName: string;
+}
+
+/**
+ * 제출 기록 Command (Use Case)
+ *
+ * 책임:
+ * 1. GitHub Issue URL에 해당하는 Cycle을 찾는다
+ * 2. GitHub Username으로 Member를 찾는다
+ * 3. 제출 가능 여부를 검증한다
+ * 4. Submission을 생성하고 저장한다
+ * 5. 도메인 이벤트를 발행한다 (Discord 알림 등)
+ */
+export class RecordSubmissionCommand {
+  constructor(
+    private readonly cycleRepo: CycleRepository,
+    private readonly memberRepo: MemberRepository,
+    private readonly submissionRepo: SubmissionRepository,
+    private readonly submissionService: SubmissionService
+  ) {}
+
+  async execute(request: RecordSubmissionRequest): Promise<RecordSubmissionResult> {
+    // 1. Cycle 찾기
+    const cycle = await this.cycleRepo.findByIssueUrl(request.githubIssueUrl);
+    if (!cycle) {
+      throw new NotFoundError('Cycle', `issueUrl=${request.githubIssueUrl}`);
+    }
+
+    // 2. Member 찾기
+    const member = await this.memberRepo.findByGithubUsername(
+      request.githubUsername
+    );
+    if (!member) {
+      throw new NotFoundError('Member', `github=${request.githubUsername}`);
+    }
+
+    // 3. 제출 가능 여부 검증
+    await this.submissionService.validateSubmission(
+      cycle.id,
+      member.id,
+      request.githubCommentId
+    );
+
+    // 4. Submission 생성
+    const submission = Submission.create({
+      cycleId: cycle.id.value,
+      memberId: member.id.value,
+      url: request.blogUrl,
+      githubCommentId: request.githubCommentId,
+      submittedAt: new Date(),
+    });
+
+    // 5. 저장
+    await this.submissionRepo.save(submission);
+
+    // 6. 결과 반환 (핸들러에서 Discord 알림 등 추가 작업 수행)
+    return {
+      submission,
+      memberName: member.name,
+      cycleName: `${cycle.week}주차`,
+    };
+  }
+}

--- a/src/application/event-handlers/index.ts
+++ b/src/application/event-handlers/index.ts
@@ -1,0 +1,3 @@
+// Application Event Handlers exports
+
+export * from './submission-event.handler';

--- a/src/application/event-handlers/submission-event.handler.ts
+++ b/src/application/event-handlers/submission-event.handler.ts
@@ -1,0 +1,32 @@
+// Submission Event Handlers
+
+import { SubmissionRecordedEvent } from '../../domain/submission/submission.domain';
+import { IDiscordWebhookClient } from '../../infrastructure/external/discord';
+
+/**
+ * 제출 관련 도메인 이벤트 핸들러
+ *
+ * 책임:
+ * - Submission 도메인 이벤트를 수신하고 외부 알림 전송
+ */
+export class SubmissionEventHandler {
+  constructor(private readonly discordClient: IDiscordWebhookClient) {}
+
+  /**
+   * 제출 기록 이벤트 처리
+   */
+  async handleSubmissionRecorded(
+    event: SubmissionRecordedEvent,
+    webhookUrl: string,
+    memberName: string,
+    cycleName: string,
+    blogUrl: string
+  ): Promise<void> {
+    await this.discordClient.sendSubmissionNotification(
+      webhookUrl,
+      memberName,
+      cycleName,
+      blogUrl
+    );
+  }
+}

--- a/src/application/queries/get-cycle-status.query.ts
+++ b/src/application/queries/get-cycle-status.query.ts
@@ -1,0 +1,220 @@
+// GetCycleStatusQuery - 사이클 현황 조회 Query
+
+import { CycleRepository } from '../../domain/cycle/cycle.repository';
+import { GenerationRepository } from '../../domain/generation/generation.repository';
+import { SubmissionRepository } from '../../domain/submission/submission.repository';
+import { MemberRepository } from '../../domain/member/member.repository';
+import { NotFoundError } from '../../domain/common/errors';
+
+/**
+ * 제출자 정보
+ */
+export interface SubmittedMember {
+  name: string;
+  github: string;
+  url: string;
+  submittedAt: string;
+}
+
+/**
+ * 미제출자 정보
+ */
+export interface NotSubmittedMember {
+  name: string;
+  github: string;
+}
+
+/**
+ * 사이클 현황 결과
+ */
+export interface CycleStatusResult {
+  cycle: {
+    id: number;
+    week: number;
+    startDate: string;
+    endDate: string;
+    generationName: string;
+  };
+  summary: {
+    total: number;
+    submitted: number;
+    notSubmitted: number;
+  };
+  submitted: SubmittedMember[];
+  notSubmitted: NotSubmittedMember[];
+}
+
+/**
+ * 현재 진행 중인 사이클 결과
+ */
+export interface CurrentCycleResult {
+  id: number;
+  week: number;
+  generationName: string;
+  startDate: string;
+  endDate: string;
+  githubIssueUrl?: string;
+  daysLeft: number;
+  hoursLeft: number;
+}
+
+/**
+ * 사이클 현황 조회 Query (Use Case)
+ *
+ * 책임:
+ * 1. 현재 진행 중인 사이클 조회
+ * 2. 특정 사이클의 제출 현황 조회
+ */
+export class GetCycleStatusQuery {
+  constructor(
+    private readonly cycleRepo: CycleRepository,
+    private readonly generationRepo: GenerationRepository,
+    private readonly submissionRepo: SubmissionRepository,
+    private readonly memberRepo: MemberRepository
+  ) {}
+
+  /**
+   * 현재 진행 중인 사이클 조회
+   */
+  async getCurrentCycle(): Promise<CurrentCycleResult | null> {
+    // 활성화된 기수 찾기
+    const generation = await this.generationRepo.findActive();
+    if (!generation) {
+      return null;
+    }
+
+    // 진행 중인 사이클 찾기
+    const cycles = await this.cycleRepo.findActiveCyclesByGeneration(
+      generation.id.value
+    );
+    if (cycles.length === 0) {
+      return null;
+    }
+
+    const cycle = cycles[0];
+    const hoursRemaining = cycle.getHoursRemaining();
+    const daysLeft = Math.floor(hoursRemaining / 24);
+    const hoursLeft = Math.floor(hoursRemaining % 24);
+
+    return {
+      id: cycle.id.value,
+      week: cycle.week.toNumber(),
+      generationName: generation.name,
+      startDate: cycle.startDate.toISOString(),
+      endDate: cycle.endDate.toISOString(),
+      githubIssueUrl: cycle.githubIssueUrl?.value,
+      daysLeft,
+      hoursLeft,
+    };
+  }
+
+  /**
+   * 특정 사이클의 제출 현황 조회
+   */
+  async getCycleStatus(cycleId: number): Promise<CycleStatusResult> {
+    // 사이클 조회
+    const cycle = await this.cycleRepo.findById(
+      cycleId // CycleId는 내부에서 생성 필요
+    );
+    if (!cycle) {
+      throw new NotFoundError(`Cycle with ID ${cycleId} not found`);
+    }
+
+    // 기수 조회
+    const generation = await this.generationRepo.findById(
+      cycle.generationId // GenerationId는 내부에서 생성 필요
+    );
+    if (!generation) {
+      throw new NotFoundError(`Generation for cycle ${cycleId} not found`);
+    }
+
+    // 제출 목록 조회
+    const submissions = await this.submissionRepo.findByCycleId(cycle.id);
+
+    // 전체 멤버
+    const allMembers = await this.memberRepo.findAll();
+    const submittedIds = new Set(submissions.map((s) => s.memberId.value));
+
+    const submitted = submissions.map((s) => {
+      const member = allMembers.find((m) => m.id.value === s.memberId.value);
+      return {
+        name: member?.name.value ?? 'Unknown',
+        github: member?.githubUsername.value ?? 'unknown',
+        url: s.url.value,
+        submittedAt: s.submittedAt.toISOString(),
+      };
+    });
+
+    const notSubmitted = allMembers
+      .filter((m) => !submittedIds.has(m.id.value))
+      .map((m) => ({
+        name: m.name.value,
+        github: m.githubUsername.value,
+      }));
+
+    return {
+      cycle: {
+        id: cycle.id.value,
+        week: cycle.week.toNumber(),
+        startDate: cycle.startDate.toISOString(),
+        endDate: cycle.endDate.toISOString(),
+        generationName: generation.name,
+      },
+      summary: {
+        total: allMembers.length,
+        submitted: submissions.length,
+        notSubmitted: notSubmitted.length,
+      },
+      submitted,
+      notSubmitted,
+    };
+  }
+
+  /**
+   * 사이클의 제출자/미제출자 이름 목록 조회 (Discord 메시지용)
+   */
+  async getCycleParticipantNames(cycleId: number): Promise<{
+    cycleName: string;
+    submittedNames: string[];
+    notSubmittedNames: string[];
+    endDate: Date;
+  } | null> {
+    // 사이클 조회
+    const cycle = await this.cycleRepo.findById(
+      cycleId // CycleId는 내부에서 생성 필요
+    );
+    if (!cycle) {
+      return null;
+    }
+
+    // 기수 조회
+    const generation = await this.generationRepo.findById(
+      cycle.generationId // GenerationId는 내부에서 생성 필요
+    );
+    if (!generation) {
+      return null;
+    }
+
+    // 제출 목록 조회
+    const submissions = await this.submissionRepo.findByCycleId(cycle.id);
+
+    // 전체 멤버
+    const allMembers = await this.memberRepo.findAll();
+    const submittedIds = new Set(submissions.map((s) => s.memberId.value));
+
+    const submittedNames = allMembers
+      .filter((m) => submittedIds.has(m.id.value))
+      .map((m) => m.name.value);
+
+    const notSubmittedNames = allMembers
+      .filter((m) => !submittedIds.has(m.id.value))
+      .map((m) => m.name.value);
+
+    return {
+      cycleName: `${generation.name} - ${cycle.week.toNumber()}주차`,
+      submittedNames,
+      notSubmittedNames,
+      endDate: cycle.endDate,
+    };
+  }
+}

--- a/src/application/queries/get-cycle-status.query.ts
+++ b/src/application/queries/get-cycle-status.query.ts
@@ -1,7 +1,9 @@
 // GetCycleStatusQuery - 사이클 현황 조회 Query
 
 import { CycleRepository } from '../../domain/cycle/cycle.repository';
+import { CycleId } from '../../domain/cycle/cycle.domain';
 import { GenerationRepository } from '../../domain/generation/generation.repository';
+import { GenerationId } from '../../domain/generation/generation.domain';
 import { SubmissionRepository } from '../../domain/submission/submission.repository';
 import { MemberRepository } from '../../domain/member/member.repository';
 import { NotFoundError } from '../../domain/common/errors';
@@ -53,7 +55,7 @@ export interface CurrentCycleResult {
   generationName: string;
   startDate: string;
   endDate: string;
-  githubIssueUrl?: string;
+  githubIssueUrl: string | null;
   daysLeft: number;
   hoursLeft: number;
 }
@@ -102,7 +104,7 @@ export class GetCycleStatusQuery {
       generationName: generation.name,
       startDate: cycle.startDate.toISOString(),
       endDate: cycle.endDate.toISOString(),
-      githubIssueUrl: cycle.githubIssueUrl?.value,
+      githubIssueUrl: cycle.githubIssueUrl?.value ?? null,
       daysLeft,
       hoursLeft,
     };
@@ -113,16 +115,14 @@ export class GetCycleStatusQuery {
    */
   async getCycleStatus(cycleId: number): Promise<CycleStatusResult> {
     // 사이클 조회
-    const cycle = await this.cycleRepo.findById(
-      cycleId // CycleId는 내부에서 생성 필요
-    );
+    const cycle = await this.cycleRepo.findById(CycleId.create(cycleId));
     if (!cycle) {
       throw new NotFoundError(`Cycle with ID ${cycleId} not found`);
     }
 
     // 기수 조회
     const generation = await this.generationRepo.findById(
-      cycle.generationId // GenerationId는 내부에서 생성 필요
+      GenerationId.create(cycle.generationId)
     );
     if (!generation) {
       throw new NotFoundError(`Generation for cycle ${cycleId} not found`);
@@ -180,16 +180,14 @@ export class GetCycleStatusQuery {
     endDate: Date;
   } | null> {
     // 사이클 조회
-    const cycle = await this.cycleRepo.findById(
-      cycleId // CycleId는 내부에서 생성 필요
-    );
+    const cycle = await this.cycleRepo.findById(CycleId.create(cycleId));
     if (!cycle) {
       return null;
     }
 
     // 기수 조회
     const generation = await this.generationRepo.findById(
-      cycle.generationId // GenerationId는 내부에서 생성 필요
+      GenerationId.create(cycle.generationId)
     );
     if (!generation) {
       return null;

--- a/src/application/queries/get-reminder-targets.query.ts
+++ b/src/application/queries/get-reminder-targets.query.ts
@@ -1,6 +1,7 @@
 // GetReminderTargetsQuery - 리마인더 대상 조회 Query
 
 import { CycleRepository } from '../../domain/cycle/cycle.repository';
+import { CycleId } from '../../domain/cycle/cycle.domain';
 import { GenerationRepository } from '../../domain/generation/generation.repository';
 import { SubmissionRepository } from '../../domain/submission/submission.repository';
 import { MemberRepository } from '../../domain/member/member.repository';
@@ -13,16 +14,16 @@ export interface ReminderCycleInfo {
   cycleId: number;
   cycleName: string;
   endDate: string;
-  githubIssueUrl?: string;
+  githubIssueUrl: string | null;
 }
 
 /**
  * 미제출자 정보
  */
-export interface NotSubmittedMember {
+export interface NotSubmittedMemberInfo {
   github: string;
   name: string;
-  discordId?: string;
+  discordId: string | null;
 }
 
 /**
@@ -32,7 +33,7 @@ export interface NotSubmittedResult {
   cycleId: number;
   week: number;
   endDate: string;
-  notSubmitted: NotSubmittedMember[];
+  notSubmitted: NotSubmittedMemberInfo[];
   submittedCount: number;
   totalMembers: number;
 }
@@ -78,7 +79,7 @@ export class GetReminderTargetsQuery {
       cycleId: cycle.id.value,
       cycleName: `${generation.name} - ${cycle.week.toNumber()}주차`,
       endDate: cycle.endDate.toISOString(),
-      githubIssueUrl: cycle.githubIssueUrl?.value,
+      githubIssueUrl: cycle.githubIssueUrl?.value ?? null,
     }));
   }
 
@@ -87,9 +88,7 @@ export class GetReminderTargetsQuery {
    */
   async getNotSubmittedMembers(cycleId: number): Promise<NotSubmittedResult> {
     // 사이클 조회
-    const cycle = await this.cycleRepo.findById(
-      cycleId // CycleId는 내부에서 생성 필요
-    );
+    const cycle = await this.cycleRepo.findById(CycleId.create(cycleId));
     if (!cycle) {
       throw new NotFoundError(`Cycle with ID ${cycleId} not found`);
     }
@@ -105,7 +104,7 @@ export class GetReminderTargetsQuery {
       .map((m) => ({
         github: m.githubUsername.value,
         name: m.name.value,
-        discordId: m.discordId?.value,
+        discordId: m.discordId?.value ?? null,
       }));
 
     return {

--- a/src/application/queries/get-reminder-targets.query.ts
+++ b/src/application/queries/get-reminder-targets.query.ts
@@ -1,0 +1,120 @@
+// GetReminderTargetsQuery - 리마인더 대상 조회 Query
+
+import { CycleRepository } from '../../domain/cycle/cycle.repository';
+import { GenerationRepository } from '../../domain/generation/generation.repository';
+import { SubmissionRepository } from '../../domain/submission/submission.repository';
+import { MemberRepository } from '../../domain/member/member.repository';
+import { NotFoundError } from '../../domain/common/errors';
+
+/**
+ * 리마인더 대상 사이클 정보
+ */
+export interface ReminderCycleInfo {
+  cycleId: number;
+  cycleName: string;
+  endDate: string;
+  githubIssueUrl?: string;
+}
+
+/**
+ * 미제출자 정보
+ */
+export interface NotSubmittedMember {
+  github: string;
+  name: string;
+  discordId?: string;
+}
+
+/**
+ * 미제출자 목록 결과
+ */
+export interface NotSubmittedResult {
+  cycleId: number;
+  week: number;
+  endDate: string;
+  notSubmitted: NotSubmittedMember[];
+  submittedCount: number;
+  totalMembers: number;
+}
+
+/**
+ * 리마인더 대상 조회 Query (Use Case)
+ *
+ * 책임:
+ * 1. 마감 임박한 사이클 조회
+ * 2. 미제출자 목록 조회
+ */
+export class GetReminderTargetsQuery {
+  constructor(
+    private readonly cycleRepo: CycleRepository,
+    private readonly generationRepo: GenerationRepository,
+    private readonly submissionRepo: SubmissionRepository,
+    private readonly memberRepo: MemberRepository
+  ) {}
+
+  /**
+   * 마감 시간이 특정 시간 내인 사이클 조회
+   */
+  async getCyclesWithDeadlineIn(
+    hoursBefore: number
+  ): Promise<ReminderCycleInfo[]> {
+    const now = new Date();
+    const deadline = new Date(now.getTime() + hoursBefore * 60 * 60 * 1000);
+
+    // 활성화된 기수 찾기
+    const generation = await this.generationRepo.findActive();
+    if (!generation) {
+      return [];
+    }
+
+    // 마감 시간이 deadline 근처인 사이클 찾기
+    const cycles = await this.cycleRepo.findCyclesWithDeadlineInRange(
+      generation.id.value,
+      now,
+      deadline
+    );
+
+    return cycles.map((cycle) => ({
+      cycleId: cycle.id.value,
+      cycleName: `${generation.name} - ${cycle.week.toNumber()}주차`,
+      endDate: cycle.endDate.toISOString(),
+      githubIssueUrl: cycle.githubIssueUrl?.value,
+    }));
+  }
+
+  /**
+   * 특정 사이클의 미제출자 목록 조회
+   */
+  async getNotSubmittedMembers(cycleId: number): Promise<NotSubmittedResult> {
+    // 사이클 조회
+    const cycle = await this.cycleRepo.findById(
+      cycleId // CycleId는 내부에서 생성 필요
+    );
+    if (!cycle) {
+      throw new NotFoundError(`Cycle with ID ${cycleId} not found`);
+    }
+
+    // 제출한 멤버 ID 목록
+    const submissions = await this.submissionRepo.findByCycleId(cycle.id);
+    const submittedIds = new Set(submissions.map((s) => s.memberId.value));
+
+    // 전체 멤버 중 미제출자 필터링
+    const allMembers = await this.memberRepo.findAll();
+    const notSubmitted = allMembers
+      .filter((m) => !submittedIds.has(m.id.value))
+      .map((m) => ({
+        github: m.githubUsername.value,
+        name: m.name.value,
+        discordId: m.discordId?.value,
+      }));
+
+    return {
+      cycleId: cycle.id.value,
+      week: cycle.week.toNumber(),
+      endDate: cycle.endDate.toISOString(),
+      notSubmitted,
+      submittedCount: submissions.length,
+      totalMembers: allMembers.length,
+    };
+  }
+}

--- a/src/application/queries/index.ts
+++ b/src/application/queries/index.ts
@@ -1,4 +1,16 @@
 // Application Queries exports
 
-export * from './get-reminder-targets.query';
-export * from './get-cycle-status.query';
+export {
+  GetReminderTargetsQuery,
+  type ReminderCycleInfo,
+  type NotSubmittedMemberInfo,
+  type NotSubmittedResult,
+} from './get-reminder-targets.query';
+
+export {
+  GetCycleStatusQuery,
+  type SubmittedMember,
+  type NotSubmittedMember,
+  type CycleStatusResult,
+  type CurrentCycleResult,
+} from './get-cycle-status.query';

--- a/src/application/queries/index.ts
+++ b/src/application/queries/index.ts
@@ -1,0 +1,4 @@
+// Application Queries exports
+
+export * from './get-reminder-targets.query';
+export * from './get-cycle-status.query';

--- a/src/domain/common/errors.ts
+++ b/src/domain/common/errors.ts
@@ -1,0 +1,85 @@
+// Domain Errors - 도메인 에러 정의
+
+// 기반 도메인 에러
+export abstract class DomainError extends Error {
+  abstract readonly code: string;
+
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    Error.captureStackTrace?.(this, this.constructor);
+  }
+}
+
+// 리포지토리 에러
+export abstract class RepositoryError extends DomainError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class NotFoundError extends RepositoryError {
+  readonly code = 'NOT_FOUND' as const;
+
+  constructor(entity: string, id?: number | string) {
+    super(
+      id
+        ? `${entity} with ID ${id} not found`
+        : `${entity} not found`
+    );
+  }
+}
+
+export class DuplicateError extends RepositoryError {
+  readonly code = 'DUPLICATE' as const;
+
+  constructor(entity: string, field: string, value: unknown) {
+    super(`${entity} with ${field}=${String(value)} already exists`);
+  }
+}
+
+export class ConstraintViolationError extends RepositoryError {
+  readonly code = 'CONSTRAINT_VIOLATION' as const;
+
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+// 애플리케이션 에러 (Use Case 레벨)
+export abstract class ApplicationError extends Error {
+  abstract readonly code: string;
+
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export class ValidationError extends ApplicationError {
+  readonly code = 'VALIDATION_ERROR' as const;
+  readonly field?: string;
+  readonly value?: unknown;
+
+  constructor(message: string, field?: string, value?: unknown) {
+    super(message);
+    this.field = field;
+    this.value = value;
+  }
+}
+
+export class UnauthorizedError extends ApplicationError {
+  readonly code = 'UNAUTHORIZED' as const;
+
+  constructor(message = 'Unauthorized') {
+    super(message);
+  }
+}
+
+export class ConflictError extends ApplicationError {
+  readonly code = 'CONFLICT' as const;
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/domain/common/errors.ts
+++ b/src/domain/common/errors.ts
@@ -22,11 +22,7 @@ export class NotFoundError extends RepositoryError {
   readonly code = 'NOT_FOUND' as const;
 
   constructor(entity: string, id?: number | string) {
-    super(
-      id
-        ? `${entity} with ID ${id} not found`
-        : `${entity} not found`
-    );
+    super(id ? `${entity} with ID ${id} not found` : `${entity} not found`);
   }
 }
 

--- a/src/domain/common/errors.ts
+++ b/src/domain/common/errors.ts
@@ -64,6 +64,18 @@ export class ValidationError extends ApplicationError {
   }
 }
 
+export class InvalidValueError extends ValidationError {
+  constructor(fieldName: string, value: unknown, reason?: string) {
+    super(
+      reason
+        ? `${fieldName}: ${reason}`
+        : `Invalid value for ${fieldName}: ${String(value)}`,
+      fieldName,
+      value
+    );
+  }
+}
+
 export class UnauthorizedError extends ApplicationError {
   readonly code = 'UNAUTHORIZED' as const;
 

--- a/src/domain/common/index.ts
+++ b/src/domain/common/index.ts
@@ -1,0 +1,4 @@
+// Common exports for domain layer
+
+export * from './types';
+export * from './errors';

--- a/src/domain/common/types.ts
+++ b/src/domain/common/types.ts
@@ -1,0 +1,76 @@
+// Common Domain Types - 공통 도메인 타입 정의
+
+// Entity ID를 위한 기반 클래스
+export abstract class EntityId {
+  protected constructor(public readonly value: number) {
+    if (value <= 0) {
+      throw new Error('ID must be a positive number');
+    }
+  }
+
+  equals(other: EntityId): boolean {
+    if (this.constructor !== other.constructor) {
+      return false;
+    }
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return String(this.value);
+  }
+}
+
+// 도메인 이벤트 기반 클래스
+export abstract class DomainEvent {
+  readonly occurredAt: Date;
+
+  constructor() {
+    this.occurredAt = new Date();
+  }
+}
+
+// Aggregate Root 기반 클래스
+export abstract class AggregateRoot<ID extends EntityId> {
+  protected constructor(public readonly id: ID) {}
+
+  private _domainEvents: DomainEvent[] = [];
+
+  get domainEvents(): DomainEvent[] {
+    return [...this._domainEvents];
+  }
+
+  protected addDomainEvent(event: DomainEvent): void {
+    this._domainEvents.push(event);
+  }
+
+  clearDomainEvents(): void {
+    this._domainEvents = [];
+  }
+}
+
+// 결과 객체 (Result Pattern)
+export type Result<T, E = Error> =
+  | { success: true; value: T }
+  | { success: false; error: E };
+
+export const Result = {
+  ok: <T>(value: T): Result<T> => ({ success: true, value }),
+  fail: <E = Error>(error: E): Result<never, E> => ({
+    success: false,
+    error,
+  }),
+};
+
+// 페이지네이션
+export interface Pagination {
+  page: number;
+  limit: number;
+}
+
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/src/domain/cycle/cycle.domain.ts
+++ b/src/domain/cycle/cycle.domain.ts
@@ -34,6 +34,7 @@ export interface CreateCycleData {
   startDate: Date;
   endDate: Date;
   githubIssueUrl?: string;
+  createdAt?: Date;
 }
 
 // 사이클 엔티티 (Aggregate Root)
@@ -43,7 +44,8 @@ export class Cycle extends AggregateRoot<CycleId> {
     private readonly _generationId: number,
     private readonly _week: Week,
     private readonly _dateRange: DateRange,
-    private readonly _githubIssueUrl: GitHubIssueUrl | null
+    private readonly _githubIssueUrl: GitHubIssueUrl | null,
+    private readonly _createdAt: Date
   ) {
     super(id);
   }
@@ -56,8 +58,16 @@ export class Cycle extends AggregateRoot<CycleId> {
 
     const id = data.id ? CycleId.create(data.id) : CycleId.create(0);
     const generationId = data.generationId;
+    const createdAt = data.createdAt ?? new Date();
 
-    const cycle = new Cycle(id, generationId, week, dateRange, githubIssueUrl);
+    const cycle = new Cycle(
+      id,
+      generationId,
+      week,
+      dateRange,
+      githubIssueUrl,
+      createdAt
+    );
 
     // 도메인 이벤트 발행 (새 생성 시에만)
     if (data.id === 0) {
@@ -75,6 +85,7 @@ export class Cycle extends AggregateRoot<CycleId> {
     startDate: Date;
     endDate: Date;
     githubIssueUrl?: string;
+    createdAt: Date;
   }): Cycle {
     return Cycle.create({
       id: data.id,
@@ -83,6 +94,7 @@ export class Cycle extends AggregateRoot<CycleId> {
       startDate: data.startDate,
       endDate: data.endDate,
       githubIssueUrl: data.githubIssueUrl,
+      createdAt: data.createdAt,
     });
   }
 
@@ -140,6 +152,7 @@ export class Cycle extends AggregateRoot<CycleId> {
       startDate: this._dateRange.startDate.toISOString(),
       endDate: this._dateRange.endDate.toISOString(),
       githubIssueUrl: this._githubIssueUrl?.value,
+      createdAt: this._createdAt.toISOString(),
     };
   }
 }
@@ -151,4 +164,5 @@ export interface CycleDTO {
   startDate: string;
   endDate: string;
   githubIssueUrl?: string;
+  createdAt: string;
 }

--- a/src/domain/cycle/cycle.domain.ts
+++ b/src/domain/cycle/cycle.domain.ts
@@ -1,0 +1,82 @@
+// Cycle Domain - 사이클(주차) 도메인
+
+import { EntityId, AggregateRoot } from '../common/types';
+
+// Cycle ID
+export class CycleId extends EntityId {
+  static create(value: number): CycleId {
+    return new CycleId(value);
+  }
+}
+
+// 사이클 엔티티 (간단 버전 - 추후 확장)
+export class Cycle extends AggregateRoot<CycleId> {
+  private constructor(
+    id: CycleId,
+    private readonly _week: number,
+    private readonly _startDate: Date,
+    private readonly _endDate: Date,
+    private readonly _githubIssueUrl?: string
+  ) {
+    super(id);
+  }
+
+  static create(data: {
+    id: number;
+    week: number;
+    startDate: Date;
+    endDate: Date;
+    githubIssueUrl?: string;
+  }): Cycle {
+    return new Cycle(
+      CycleId.create(data.id),
+      data.week,
+      data.startDate,
+      data.endDate,
+      data.githubIssueUrl
+    );
+  }
+
+  get week(): number {
+    return this._week;
+  }
+
+  get startDate(): Date {
+    return new Date(this._startDate);
+  }
+
+  get endDate(): Date {
+    return new Date(this._endDate);
+  }
+
+  get githubIssueUrl(): string | undefined {
+    return this._githubIssueUrl;
+  }
+
+  /**
+   * 마감까지 남은 시간 (시간 단위)
+   */
+  getHoursRemaining(): number {
+    return Math.floor(
+      (this._endDate.getTime() - Date.now()) / (1000 * 60 * 60)
+    );
+  }
+
+  toDTO(): CycleDTO {
+    return {
+      id: this.id.value,
+      week: this._week,
+      startDate: this._startDate.toISOString(),
+      endDate: this._endDate.toISOString(),
+      githubIssueUrl: this._githubIssueUrl,
+    };
+  }
+}
+
+export interface CycleDTO {
+  id: number;
+  week: number;
+  startDate: string;
+  endDate: string;
+  githubIssueUrl?: string;
+}

--- a/src/domain/cycle/cycle.domain.ts
+++ b/src/domain/cycle/cycle.domain.ts
@@ -151,7 +151,7 @@ export class Cycle extends AggregateRoot<CycleId> {
       week: this._week.toNumber(),
       startDate: this._dateRange.startDate.toISOString(),
       endDate: this._dateRange.endDate.toISOString(),
-      githubIssueUrl: this._githubIssueUrl?.value,
+      githubIssueUrl: this._githubIssueUrl?.value ?? null,
       createdAt: this._createdAt.toISOString(),
     };
   }
@@ -163,6 +163,6 @@ export interface CycleDTO {
   week: number;
   startDate: string;
   endDate: string;
-  githubIssueUrl?: string;
+  githubIssueUrl: string | null;
   createdAt: string;
 }

--- a/src/domain/cycle/cycle.domain.ts
+++ b/src/domain/cycle/cycle.domain.ts
@@ -1,6 +1,9 @@
 // Cycle Domain - 사이클(주차) 도메인
 
 import { EntityId, AggregateRoot } from '../common/types';
+import { Week } from './vo/week.vo';
+import { DateRange } from './vo/date-range.vo';
+import { GitHubIssueUrl } from './vo/github-issue-url.vo';
 
 // Cycle ID
 export class CycleId extends EntityId {
@@ -9,72 +12,141 @@ export class CycleId extends EntityId {
   }
 }
 
-// 사이클 엔티티 (간단 버전 - 추후 확장)
+// 도메인 이벤트
+export class CycleCreatedEvent {
+  readonly type = 'CycleCreated' as const;
+  readonly occurredAt: Date;
+
+  constructor(
+    public readonly cycleId: CycleId,
+    public readonly week: Week,
+    public readonly dateRange: DateRange
+  ) {
+    this.occurredAt = new Date();
+  }
+}
+
+// 사이클 생성 데이터
+export interface CreateCycleData {
+  id?: number;
+  generationId: number;
+  week: number;
+  startDate: Date;
+  endDate: Date;
+  githubIssueUrl?: string;
+}
+
+// 사이클 엔티티 (Aggregate Root)
 export class Cycle extends AggregateRoot<CycleId> {
   private constructor(
     id: CycleId,
-    private readonly _week: number,
-    private readonly _startDate: Date,
-    private readonly _endDate: Date,
-    private readonly _githubIssueUrl?: string
+    private readonly _generationId: number,
+    private readonly _week: Week,
+    private readonly _dateRange: DateRange,
+    private readonly _githubIssueUrl: GitHubIssueUrl | null
   ) {
     super(id);
   }
 
-  static create(data: {
+  // 팩토리 메서드: 새 사이클 생성
+  static create(data: CreateCycleData): Cycle {
+    const week = Week.create(data.week);
+    const dateRange = DateRange.create(data.startDate, data.endDate);
+    const githubIssueUrl = GitHubIssueUrl.createOrNull(data.githubIssueUrl);
+
+    const id = data.id ? CycleId.create(data.id) : CycleId.create(0);
+    const generationId = data.generationId;
+
+    const cycle = new Cycle(id, generationId, week, dateRange, githubIssueUrl);
+
+    // 도메인 이벤트 발행 (새 생성 시에만)
+    if (data.id === 0) {
+      cycle.addDomainEvent(new CycleCreatedEvent(id, week, dateRange));
+    }
+
+    return cycle;
+  }
+
+  // 팩토리 메서드: DB에서 조회한 엔티티 복원
+  static reconstitute(data: {
     id: number;
+    generationId: number;
     week: number;
     startDate: Date;
     endDate: Date;
     githubIssueUrl?: string;
   }): Cycle {
-    return new Cycle(
-      CycleId.create(data.id),
-      data.week,
-      data.startDate,
-      data.endDate,
-      data.githubIssueUrl
-    );
+    return Cycle.create({
+      id: data.id,
+      generationId: data.generationId,
+      week: data.week,
+      startDate: data.startDate,
+      endDate: data.endDate,
+      githubIssueUrl: data.githubIssueUrl,
+    });
   }
 
-  get week(): number {
+  // Getters
+  get generationId(): number {
+    return this._generationId;
+  }
+
+  get week(): Week {
     return this._week;
   }
 
+  get dateRange(): DateRange {
+    return this._dateRange;
+  }
+
   get startDate(): Date {
-    return new Date(this._startDate);
+    return new Date(this._dateRange.startDate);
   }
 
   get endDate(): Date {
-    return new Date(this._endDate);
+    return new Date(this._dateRange.endDate);
   }
 
-  get githubIssueUrl(): string | undefined {
+  get githubIssueUrl(): GitHubIssueUrl | null {
     return this._githubIssueUrl;
   }
 
-  /**
-   * 마감까지 남은 시간 (시간 단위)
-   */
+  // 비즈니스 로직: 마감까지 남은 시간
   getHoursRemaining(): number {
-    return Math.floor(
-      (this._endDate.getTime() - Date.now()) / (1000 * 60 * 60)
-    );
+    return this._dateRange.getHoursRemaining();
   }
 
+  // 비즈니스 로직: 마감이 지났는지 확인
+  isPast(): boolean {
+    return this._dateRange.isPast();
+  }
+
+  // 비즈니스 로직: 현재 진행 중인지 확인
+  isActive(): boolean {
+    return this._dateRange.isActive();
+  }
+
+  // 비즈니스 로직: 특정 기수에 속하는지 확인
+  belongsToGeneration(generationId: number): boolean {
+    return this._generationId === generationId;
+  }
+
+  // DTO로 변환
   toDTO(): CycleDTO {
     return {
       id: this.id.value,
-      week: this._week,
-      startDate: this._startDate.toISOString(),
-      endDate: this._endDate.toISOString(),
-      githubIssueUrl: this._githubIssueUrl,
+      generationId: this._generationId,
+      week: this._week.toNumber(),
+      startDate: this._dateRange.startDate.toISOString(),
+      endDate: this._dateRange.endDate.toISOString(),
+      githubIssueUrl: this._githubIssueUrl?.value,
     };
   }
 }
 
 export interface CycleDTO {
   id: number;
+  generationId: number;
   week: number;
   startDate: string;
   endDate: string;

--- a/src/domain/cycle/cycle.repository.ts
+++ b/src/domain/cycle/cycle.repository.ts
@@ -1,0 +1,10 @@
+// Cycle Repository Interface
+
+import { CycleId, Cycle } from './cycle.domain';
+
+export interface CycleRepository {
+  findById(id: CycleId): Promise<Cycle | null>;
+  findByIssueUrl(issueUrl: string): Promise<Cycle | null>;
+  findByGeneration(generationId: number): Promise<Cycle[]>;
+  save(cycle: Cycle): Promise<void>;
+}

--- a/src/domain/cycle/cycle.repository.ts
+++ b/src/domain/cycle/cycle.repository.ts
@@ -3,8 +3,45 @@
 import { CycleId, Cycle } from './cycle.domain';
 
 export interface CycleRepository {
-  findById(id: CycleId): Promise<Cycle | null>;
-  findByIssueUrl(issueUrl: string): Promise<Cycle | null>;
-  findByGeneration(generationId: number): Promise<Cycle[]>;
+  /**
+   * 사이클 저장 (생성 또는 업데이트)
+   */
   save(cycle: Cycle): Promise<void>;
+
+  /**
+   * ID로 사이클 조회
+   */
+  findById(id: CycleId): Promise<Cycle | null>;
+
+  /**
+   * GitHub Issue URL로 사이클 조회
+   */
+  findByIssueUrl(issueUrl: string): Promise<Cycle | null>;
+
+  /**
+   * 기수와 주차로 사이클 조회 (중복 체크용)
+   */
+  findByGenerationAndWeek(
+    generationId: number,
+    week: number
+  ): Promise<Cycle | null>;
+
+  /**
+   * 기수별 모든 사이클 조회
+   */
+  findByGeneration(generationId: number): Promise<Cycle[]>;
+
+  /**
+   * 활성화된 기수의 진행 중인 사이클 조회
+   */
+  findActiveCyclesByGeneration(generationId: number): Promise<Cycle[]>;
+
+  /**
+   * 특정 시간 범위 내에 마감되는 사이클 조회 (리마인더용)
+   */
+  findCyclesWithDeadlineInRange(
+    generationId: number,
+    startTime: Date,
+    endTime: Date
+  ): Promise<Cycle[]>;
 }

--- a/src/domain/cycle/index.ts
+++ b/src/domain/cycle/index.ts
@@ -1,0 +1,4 @@
+// Cycle Domain exports
+
+export * from './cycle.domain';
+export * from './cycle.repository';

--- a/src/domain/cycle/vo/date-range.vo.ts
+++ b/src/domain/cycle/vo/date-range.vo.ts
@@ -1,0 +1,90 @@
+// Value Object: DateRange (날짜 범위)
+
+import { DomainError } from '../../common/errors';
+
+export class DateRange {
+  private constructor(
+    public readonly startDate: Date,
+    public readonly endDate: Date
+  ) {
+    if (startDate > endDate) {
+      throw new InvalidDateRangeError(startDate, endDate);
+    }
+  }
+
+  static create(startDate: Date, endDate: Date): DateRange {
+    // Date 객체 복사하여 불변성 보장
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    return new DateRange(start, end);
+  }
+
+  static fromWeek(startDate: Date): DateRange {
+    const start = new Date(startDate);
+    const end = new Date(start);
+    end.setDate(start.getDate() + 7);
+    return new DateRange(start, end);
+  }
+
+  equals(other: DateRange): boolean {
+    return (
+      this.startDate.getTime() === other.startDate.getTime() &&
+      this.endDate.getTime() === other.endDate.getTime()
+    );
+  }
+
+  /**
+   * 마감까지 남은 시간 (시간 단위)
+   */
+  getHoursRemaining(): number {
+    const now = Date.now();
+    const deadline = this.endDate.getTime();
+    return Math.floor((deadline - now) / (1000 * 60 * 60));
+  }
+
+  /**
+   * 마감까지 남은 일수
+   */
+  getDaysRemaining(): number {
+    return Math.floor(this.getHoursRemaining() / 24);
+  }
+
+  /**
+   * 마감이 지났는지 확인
+   */
+  isPast(): boolean {
+    return this.getHoursRemaining() < 0;
+  }
+
+  /**
+   * 현재 진행 중인지 확인
+   */
+  isActive(): boolean {
+    const now = Date.now();
+    return (
+      this.startDate.getTime() <= now && this.endDate.getTime() >= now
+    );
+  }
+
+  toDTO(): DateRangeDTO {
+    return {
+      startDate: this.startDate.toISOString(),
+      endDate: this.endDate.toISOString(),
+    };
+  }
+}
+
+export class InvalidDateRangeError extends DomainError {
+  readonly code = 'INVALID_DATE_RANGE' as const;
+
+  constructor(startDate: Date, endDate: Date) {
+    super(
+      `Start date (${startDate.toISOString()}) must be before end date (${endDate.toISOString()})`
+    );
+  }
+}
+
+export interface DateRangeDTO {
+  startDate: string;
+  endDate: string;
+}

--- a/src/domain/cycle/vo/date-range.vo.ts
+++ b/src/domain/cycle/vo/date-range.vo.ts
@@ -61,9 +61,7 @@ export class DateRange {
    */
   isActive(): boolean {
     const now = Date.now();
-    return (
-      this.startDate.getTime() <= now && this.endDate.getTime() >= now
-    );
+    return this.startDate.getTime() <= now && this.endDate.getTime() >= now;
   }
 
   toDTO(): DateRangeDTO {

--- a/src/domain/cycle/vo/github-issue-url.vo.ts
+++ b/src/domain/cycle/vo/github-issue-url.vo.ts
@@ -1,0 +1,53 @@
+// Value Object: GitHub Issue URL
+
+import { DomainError } from '../../common/errors';
+
+export class GitHubIssueUrl {
+  private constructor(public readonly value: string) {
+    if (!this.isValid(value)) {
+      throw new InvalidGitHubIssueUrlError(value);
+    }
+  }
+
+  private isValid(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      return (
+        parsed.protocol === 'https:' &&
+        parsed.hostname === 'github.com' &&
+        !!parsed.pathname.match(/\/issues\/\d+$/)
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  static create(url: string): GitHubIssueUrl {
+    return new GitHubIssueUrl(url);
+  }
+
+  static createOrNull(url: string | undefined | null): GitHubIssueUrl | null {
+    if (!url) return null;
+    try {
+      return new GitHubIssueUrl(url);
+    } catch {
+      return null;
+    }
+  }
+
+  equals(other: GitHubIssueUrl): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+export class InvalidGitHubIssueUrlError extends DomainError {
+  readonly code = 'INVALID_GITHUB_ISSUE_URL' as const;
+
+  constructor(url: string) {
+    super(`Invalid GitHub Issue URL: ${url}`);
+  }
+}

--- a/src/domain/cycle/vo/week.vo.ts
+++ b/src/domain/cycle/vo/week.vo.ts
@@ -1,0 +1,38 @@
+// Value Object: Week (주차)
+
+import { DomainError } from '../../common/errors';
+
+export class Week {
+  private constructor(public readonly value: number) {
+    if (value < 1) {
+      throw new InvalidWeekError(value);
+    }
+    if (value > 52) {
+      throw new InvalidWeekError(value);
+    }
+  }
+
+  static create(value: number): Week {
+    return new Week(value);
+  }
+
+  equals(other: Week): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return `${this.value}주차`;
+  }
+
+  toNumber(): number {
+    return this.value;
+  }
+}
+
+export class InvalidWeekError extends DomainError {
+  readonly code = 'INVALID_WEEK' as const;
+
+  constructor(week: number) {
+    super(`Week must be between 1 and 52, got ${week}`);
+  }
+}

--- a/src/domain/generation/generation.domain.ts
+++ b/src/domain/generation/generation.domain.ts
@@ -1,0 +1,64 @@
+// Generation Domain - 기수 도메인
+
+import { EntityId, AggregateRoot } from '../common/types';
+
+// Generation ID
+export class GenerationId extends EntityId {
+  static create(value: number): GenerationId {
+    return new GenerationId(value);
+  }
+}
+
+// 기수 엔티티
+export class Generation extends AggregateRoot<GenerationId> {
+  private constructor(
+    id: GenerationId,
+    private readonly _name: string,
+    private readonly _startedAt: Date,
+    private readonly _isActive: boolean
+  ) {
+    super(id);
+  }
+
+  static create(data: {
+    id: number;
+    name: string;
+    startedAt: Date;
+    isActive: boolean;
+  }): Generation {
+    return new Generation(
+      GenerationId.create(data.id),
+      data.name,
+      data.startedAt,
+      data.isActive
+    );
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  get startedAt(): Date {
+    return new Date(this._startedAt);
+  }
+
+  get isActive(): boolean {
+    return this._isActive;
+  }
+
+  toDTO(): GenerationDTO {
+    return {
+      id: this.id.value,
+      name: this._name,
+      startedAt: this._startedAt.toISOString(),
+      isActive: this._isActive,
+    };
+  }
+}
+
+export interface GenerationDTO {
+  id: number;
+  name: string;
+  startedAt: string;
+  isActive: boolean;
+}

--- a/src/domain/generation/generation.repository.ts
+++ b/src/domain/generation/generation.repository.ts
@@ -3,7 +3,8 @@
 import { GenerationId, Generation } from './generation.domain';
 
 export interface GenerationRepository {
-  findById(id: GenerationId): Promise<Generation | null>;
-  findActive(): Promise<Generation>;
   save(generation: Generation): Promise<void>;
+  findById(id: GenerationId): Promise<Generation | null>;
+  findActive(): Promise<Generation | null>;
+  findAll(): Promise<Generation[]>;
 }

--- a/src/domain/generation/generation.repository.ts
+++ b/src/domain/generation/generation.repository.ts
@@ -1,0 +1,9 @@
+// Generation Repository Interface
+
+import { GenerationId, Generation } from './generation.domain';
+
+export interface GenerationRepository {
+  findById(id: GenerationId): Promise<Generation | null>;
+  findActive(): Promise<Generation>;
+  save(generation: Generation): Promise<void>;
+}

--- a/src/domain/generation/generation.service.ts
+++ b/src/domain/generation/generation.service.ts
@@ -1,0 +1,104 @@
+// Generation Domain Service
+
+import { GenerationRepository } from './generation.repository';
+import { GenerationId, Generation } from './generation.domain';
+import { NotFoundError, ConflictError } from '../common/errors';
+
+/**
+ * 기수 도메인 서비스
+ *
+ * 책임:
+ * - 기수 조회 관련 비즈니스 로직
+ * - 기수 활성화/비활성화 관련 로직
+ */
+export class GenerationService {
+  constructor(private readonly generationRepo: GenerationRepository) {}
+
+  /**
+   * 활성화된 기수를 찾고, 없으면 에러를 발생
+   */
+  async findActiveGenerationOrThrow(): Promise<Generation> {
+    const generation = await this.generationRepo.findActive();
+    if (!generation) {
+      throw new NotFoundError('No active generation found');
+    }
+    return generation;
+  }
+
+  /**
+   * 기수 ID로 기수를 찾고, 없으면 에러를 발생
+   */
+  async findGenerationByIdOrThrow(id: GenerationId): Promise<Generation> {
+    const generation = await this.generationRepo.findById(id);
+    if (!generation) {
+      throw new NotFoundError(`Generation with ID ${id.value} not found`);
+    }
+    return generation;
+  }
+
+  /**
+   * 새 기수 생성 시 검증 (활성화된 기수가 이미 있는지 확인)
+   */
+  async validateNewGeneration(isActive: boolean): Promise<void> {
+    if (isActive) {
+      const activeGeneration = await this.generationRepo.findActive();
+      if (activeGeneration) {
+        throw new ConflictError(
+          `Cannot activate new generation: "${activeGeneration.name}" is already active`
+        );
+      }
+    }
+  }
+
+  /**
+   * 기수 활성화
+   */
+  async activateGeneration(id: GenerationId): Promise<void> {
+    const generation = await this.findGenerationByIdOrThrow(id);
+
+    if (generation.isActive) {
+      throw new ConflictError(
+        `Generation "${generation.name}" is already active`
+      );
+    }
+
+    // 다른 활성화된 기수가 있는지 확인
+    const activeGeneration = await this.generationRepo.findActive();
+    if (activeGeneration) {
+      throw new ConflictError(
+        `Cannot activate: "${activeGeneration.name}" is already active`
+      );
+    }
+
+    // 새로운 활성화된 기수 생성
+    const activatedGeneration = Generation.create({
+      id: generation.id.value,
+      name: generation.name,
+      startedAt: generation.startedAt,
+      isActive: true,
+    });
+
+    await this.generationRepo.save(activatedGeneration);
+  }
+
+  /**
+   * 기수 비활성화
+   */
+  async deactivateGeneration(id: GenerationId): Promise<void> {
+    const generation = await this.findGenerationByIdOrThrow(id);
+
+    if (!generation.isActive) {
+      throw new ConflictError(`Generation "${generation.name}" is not active`);
+    }
+
+    // 비활성화된 기수 생성
+    const deactivatedGeneration = Generation.create({
+      id: generation.id.value,
+      name: generation.name,
+      startedAt: generation.startedAt,
+      isActive: false,
+    });
+
+    await this.generationRepo.save(deactivatedGeneration);
+  }
+}

--- a/src/domain/generation/index.ts
+++ b/src/domain/generation/index.ts
@@ -1,0 +1,4 @@
+// Generation Domain exports
+
+export * from './generation.domain';
+export * from './generation.repository';

--- a/src/domain/member/index.ts
+++ b/src/domain/member/index.ts
@@ -1,0 +1,4 @@
+// Member Domain exports
+
+export * from './member.domain';
+export * from './member.repository';

--- a/src/domain/member/member.domain.ts
+++ b/src/domain/member/member.domain.ts
@@ -1,0 +1,64 @@
+// Member Domain - 회원 도메인
+
+import { EntityId, AggregateRoot } from '../common/types';
+
+// Member ID
+export class MemberId extends EntityId {
+  static create(value: number): MemberId {
+    return new MemberId(value);
+  }
+}
+
+// 회원 엔티티
+export class Member extends AggregateRoot<MemberId> {
+  private constructor(
+    id: MemberId,
+    private readonly _github: string,
+    private readonly _name: string,
+    private readonly _discordId?: string
+  ) {
+    super(id);
+  }
+
+  static create(data: {
+    id: number;
+    github: string;
+    name: string;
+    discordId?: string;
+  }): Member {
+    return new Member(
+      MemberId.create(data.id),
+      data.github,
+      data.name,
+      data.discordId
+    );
+  }
+
+  get github(): string {
+    return this._github;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  get discordId(): string | undefined {
+    return this._discordId;
+  }
+
+  toDTO(): MemberDTO {
+    return {
+      id: this.id.value,
+      github: this._github,
+      name: this._name,
+      discordId: this._discordId,
+    };
+  }
+}
+
+export interface MemberDTO {
+  id: number;
+  github: string;
+  name: string;
+  discordId?: string;
+}

--- a/src/domain/member/member.domain.ts
+++ b/src/domain/member/member.domain.ts
@@ -1,6 +1,7 @@
 // Member Domain - 회원 도메인
 
 import { EntityId, AggregateRoot } from '../common/types';
+import { MemberName, GithubUsername, DiscordId } from './member.vo';
 
 // Member ID
 export class MemberId extends EntityId {
@@ -9,56 +10,107 @@ export class MemberId extends EntityId {
   }
 }
 
-// 회원 엔티티
+// 도메인 이벤트
+export class MemberRegisteredEvent {
+  readonly type = 'MemberRegistered' as const;
+  readonly occurredAt: Date;
+
+  constructor(
+    public readonly memberId: MemberId,
+    public readonly githubUsername: GithubUsername
+  ) {
+    this.occurredAt = new Date();
+  }
+}
+
+// 회원 생성 데이터
+export interface CreateMemberData {
+  id?: number;
+  githubUsername: string;
+  name: string;
+  discordId?: string;
+}
+
+// 회원 엔티티 (Aggregate Root)
 export class Member extends AggregateRoot<MemberId> {
   private constructor(
     id: MemberId,
-    private readonly _github: string,
-    private readonly _name: string,
-    private readonly _discordId?: string
+    private readonly _githubUsername: GithubUsername,
+    private readonly _name: MemberName,
+    private readonly _discordId: DiscordId | null
   ) {
     super(id);
   }
 
-  static create(data: {
+  // 팩토리 메서드: 새 회원 생성
+  static create(data: CreateMemberData): Member {
+    const githubUsername = GithubUsername.create(data.githubUsername);
+    const name = MemberName.create(data.name);
+    const discordId = DiscordId.createOrNull(data.discordId);
+
+    const id = data.id ? MemberId.create(data.id) : MemberId.create(0);
+    const member = new Member(id, githubUsername, name, discordId);
+
+    // 도메인 이벤트 발행 (새 생성 시에만)
+    if (data.id === 0) {
+      member.addDomainEvent(new MemberRegisteredEvent(id, githubUsername));
+    }
+
+    return member;
+  }
+
+  // 팩토리 메서드: DB에서 조회한 엔티티 복원
+  static reconstitute(data: {
     id: number;
     github: string;
     name: string;
     discordId?: string;
   }): Member {
-    return new Member(
-      MemberId.create(data.id),
-      data.github,
-      data.name,
-      data.discordId
-    );
+    return Member.create({
+      id: data.id,
+      githubUsername: data.github,
+      name: data.name,
+      discordId: data.discordId,
+    });
   }
 
-  get github(): string {
-    return this._github;
+  // Getters
+  get githubUsername(): GithubUsername {
+    return this._githubUsername;
   }
 
-  get name(): string {
+  get name(): MemberName {
     return this._name;
   }
 
-  get discordId(): string | undefined {
+  get discordId(): DiscordId | null {
     return this._discordId;
   }
 
+  // 비즈니스 로직: GitHub 사용자명으로 회원 식별
+  matchesGithubUsername(username: string): boolean {
+    return this._githubUsername.value === username;
+  }
+
+  // 비즈니스 로직: Discord 연동되어 있는지 확인
+  hasDiscordLinked(): boolean {
+    return this._discordId !== null;
+  }
+
+  // DTO로 변환
   toDTO(): MemberDTO {
     return {
       id: this.id.value,
-      github: this._github,
-      name: this._name,
-      discordId: this._discordId,
+      githubUsername: this._githubUsername.value,
+      name: this._name.value,
+      discordId: this._discordId?.value,
     };
   }
 }
 
 export interface MemberDTO {
   id: number;
-  github: string;
+  githubUsername: string;
   name: string;
   discordId?: string;
 }

--- a/src/domain/member/member.repository.ts
+++ b/src/domain/member/member.repository.ts
@@ -1,0 +1,10 @@
+// Member Repository Interface
+
+import { MemberId, Member } from './member.domain';
+
+export interface MemberRepository {
+  findById(id: MemberId): Promise<Member | null>;
+  findByGithubUsername(githubUsername: string): Promise<Member | null>;
+  findAll(): Promise<Member[]>;
+  save(member: Member): Promise<void>;
+}

--- a/src/domain/member/member.repository.ts
+++ b/src/domain/member/member.repository.ts
@@ -3,8 +3,28 @@
 import { MemberId, Member } from './member.domain';
 
 export interface MemberRepository {
-  findById(id: MemberId): Promise<Member | null>;
-  findByGithubUsername(githubUsername: string): Promise<Member | null>;
-  findAll(): Promise<Member[]>;
+  /**
+   * 회원 저장 (생성 또는 업데이트)
+   */
   save(member: Member): Promise<void>;
+
+  /**
+   * ID로 회원 조회
+   */
+  findById(id: MemberId): Promise<Member | null>;
+
+  /**
+   * GitHub 사용자명으로 회원 조회
+   */
+  findByGithubUsername(githubUsername: string): Promise<Member | null>;
+
+  /**
+   * 전체 회원 조회
+   */
+  findAll(): Promise<Member[]>;
+
+  /**
+   * Discord ID로 회원 조회
+   */
+  findByDiscordId(discordId: string): Promise<Member | null>;
 }

--- a/src/domain/member/member.service.ts
+++ b/src/domain/member/member.service.ts
@@ -1,0 +1,78 @@
+// Member Domain Service
+
+import { MemberRepository } from './member.repository';
+import { MemberId, Member } from './member.domain';
+import { NotFoundError, ValidationError } from '../common/errors';
+
+/**
+ * 회원 도메인 서비스
+ *
+ * 책임:
+ * - 회원 조회 관련 비즈니스 로직
+ * - 회원 생성/수정 관련 검증 로직
+ */
+export class MemberService {
+  constructor(private readonly memberRepo: MemberRepository) {}
+
+  /**
+   * GitHub 사용자명으로 회원을 찾고, 없으면 에러를 발생
+   */
+  async findMemberByGithubOrThrow(githubUsername: string): Promise<Member> {
+    const member = await this.memberRepo.findByGithubUsername(githubUsername);
+    if (!member) {
+      throw new NotFoundError(
+        `Member with GitHub username "${githubUsername}" not found`
+      );
+    }
+    return member;
+  }
+
+  /**
+   * 회원 ID로 회원을 찾고, 없으면 에러를 발생
+   */
+  async findMemberByIdOrThrow(id: MemberId): Promise<Member> {
+    const member = await this.memberRepo.findById(id);
+    if (!member) {
+      throw new NotFoundError(`Member with ID ${id.value} not found`);
+    }
+    return member;
+  }
+
+  /**
+   * 새 회원 생성 (중복 검사 포함)
+   */
+  async validateNewMember(githubUsername: string): Promise<void> {
+    const existing = await this.memberRepo.findByGithubUsername(githubUsername);
+    if (existing) {
+      throw new ValidationError(
+        `Member with GitHub username "${githubUsername}" already exists`
+      );
+    }
+  }
+
+  /**
+   * 여러 GitHub 사용자명으로 회원들을 조회
+   */
+  async findMembersByGithubUsernames(
+    githubUsernames: string[]
+  ): Promise<Map<string, Member>> {
+    const members = new Map<string, Member>();
+
+    for (const username of githubUsernames) {
+      const member = await this.memberRepo.findByGithubUsername(username);
+      if (member) {
+        members.set(username, member);
+      }
+    }
+
+    return members;
+  }
+
+  /**
+   * 제출하지 않은 회원들을 조회
+   */
+  async findMembersNotInSet(memberIds: Set<number>): Promise<Member[]> {
+    const allMembers = await this.memberRepo.findAll();
+    return allMembers.filter((member) => !memberIds.has(member.id.value));
+  }
+}

--- a/src/domain/member/member.vo.ts
+++ b/src/domain/member/member.vo.ts
@@ -1,0 +1,95 @@
+// Member Value Objects
+
+import { InvalidValueError } from '../common/errors';
+
+// 회원 이름 Value Object
+export class MemberName {
+  private constructor(public readonly value: string) {
+    if (value.trim().length === 0) {
+      throw new InvalidValueError('Member name', value, 'Name cannot be empty');
+    }
+    if (value.length > 50) {
+      throw new InvalidValueError(
+        'Member name',
+        value,
+        'Name cannot exceed 50 characters'
+      );
+    }
+  }
+
+  static create(value: string): MemberName {
+    return new MemberName(value.trim());
+  }
+
+  equals(other: MemberName): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+// GitHub 사용자명 Value Object
+export class GithubUsername {
+  private constructor(public readonly value: string) {
+    // GitHub username: 1-39 characters, alphanumeric and hyphens only
+    const githubUsernameRegex = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+    if (!githubUsernameRegex.test(value) || value.length > 39) {
+      throw new InvalidValueError(
+        'GitHub username',
+        value,
+        'Invalid GitHub username format'
+      );
+    }
+  }
+
+  static create(value: string): GithubUsername {
+    return new GithubUsername(value);
+  }
+
+  equals(other: GithubUsername): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+// Discord ID Value Object
+export class DiscordId {
+  private constructor(public readonly value: string) {
+    // Discord snowflake ID: 17-19 digit number
+    const discordIdRegex = /^\d{17,19}$/;
+    if (!discordIdRegex.test(value)) {
+      throw new InvalidValueError(
+        'Discord ID',
+        value,
+        'Invalid Discord ID format (must be 17-19 digits)'
+      );
+    }
+  }
+
+  static create(value: string): DiscordId {
+    return new DiscordId(value);
+  }
+
+  static createOrNull(value: string | null | undefined): DiscordId | null {
+    if (!value) return null;
+    try {
+      return DiscordId.create(value);
+    } catch {
+      return null;
+    }
+  }
+
+  equals(other: DiscordId | null): boolean {
+    if (!other) return false;
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/src/domain/submission/index.ts
+++ b/src/domain/submission/index.ts
@@ -1,0 +1,6 @@
+// Submission Domain exports
+
+export * from './submission.vo';
+export * from './submission.domain';
+export * from './submission.repository';
+export * from './submission.service';

--- a/src/domain/submission/submission.domain.ts
+++ b/src/domain/submission/submission.domain.ts
@@ -1,0 +1,166 @@
+// Submission Domain Entity - 제출 도메인 엔티티
+
+import { AggregateRoot, EntityId } from '../common/types';
+import { BlogUrl, GithubCommentId } from './submission.vo';
+
+// Submission ID
+export class SubmissionId extends EntityId {
+  static create(value: number): SubmissionId {
+    return new SubmissionId(value);
+  }
+}
+
+// Member ID (Value Object - 외부 참조)
+export class MemberId extends EntityId {
+  static create(value: number): MemberId {
+    return new MemberId(value);
+  }
+}
+
+// Cycle ID (Value Object - 외부 참조)
+export class CycleId extends EntityId {
+  static create(value: number): CycleId {
+    return new CycleId(value);
+  }
+}
+
+// 도메인 이벤트
+export class SubmissionRecordedEvent {
+  readonly type = 'SubmissionRecorded' as const;
+  readonly occurredAt: Date;
+
+  constructor(
+    public readonly submissionId: SubmissionId,
+    public readonly memberId: MemberId,
+    public readonly cycleId: CycleId,
+    public readonly url: BlogUrl
+  ) {
+    this.occurredAt = new Date();
+  }
+}
+
+// 제출 생성 데이터
+export interface CreateSubmissionData {
+  id?: number; // Optional for new submissions
+  cycleId: number;
+  memberId: number;
+  url: string;
+  submittedAt?: Date;
+  githubCommentId: string;
+}
+
+// 제출 엔티티 (Aggregate Root)
+export class Submission extends AggregateRoot<SubmissionId> {
+  private constructor(
+    id: SubmissionId,
+    private readonly _cycleId: CycleId,
+    private readonly _memberId: MemberId,
+    private readonly _url: BlogUrl,
+    private readonly _submittedAt: Date,
+    private readonly _githubCommentId: GithubCommentId
+  ) {
+    super(id);
+  }
+
+  // 팩토리 메서드: 새 제출 생성
+  static create(data: CreateSubmissionData): Submission {
+    const blogUrl = BlogUrl.create(data.url);
+    const commentId = GithubCommentId.create(data.githubCommentId);
+
+    const id = data.id ? SubmissionId.create(data.id) : SubmissionId.create(0);
+    const cycleId = CycleId.create(data.cycleId);
+    const memberId = MemberId.create(data.memberId);
+    const submittedAt = data.submittedAt ?? new Date();
+
+    const submission = new Submission(
+      id,
+      cycleId,
+      memberId,
+      blogUrl,
+      submittedAt,
+      commentId
+    );
+
+    // 도메인 이벤트 발행
+    submission.addDomainEvent(
+      new SubmissionRecordedEvent(id, memberId, cycleId, blogUrl)
+    );
+
+    return submission;
+  }
+
+  // 팩토리 메서드: DB에서 조회한 엔티티 복원
+  static reconstitute(data: {
+    id: number;
+    cycleId: number;
+    memberId: number;
+    url: string;
+    submittedAt: Date;
+    githubCommentId: string;
+  }): Submission {
+    const blogUrl = BlogUrl.create(data.url);
+    const commentId = GithubCommentId.create(data.githubCommentId);
+
+    return new Submission(
+      SubmissionId.create(data.id),
+      CycleId.create(data.cycleId),
+      MemberId.create(data.memberId),
+      blogUrl,
+      data.submittedAt,
+      commentId
+    );
+  }
+
+  // Getters
+  get cycleId(): CycleId {
+    return this._cycleId;
+  }
+
+  get memberId(): MemberId {
+    return this._memberId;
+  }
+
+  get url(): BlogUrl {
+    return this._url;
+  }
+
+  get submittedAt(): Date {
+    return new Date(this._submittedAt);
+  }
+
+  get githubCommentId(): GithubCommentId {
+    return this._githubCommentId;
+  }
+
+  // 비즈니스 로직: 특정 회원의 제출인지 확인
+  isSubmittedBy(memberId: MemberId): boolean {
+    return this._memberId.equals(memberId);
+  }
+
+  // 비즈니스 로직: 특정 사이클의 제출인지 확인
+  isForCycle(cycleId: CycleId): boolean {
+    return this._cycleId.equals(cycleId);
+  }
+
+  // DTO로 변환 (외부 계층 전용)
+  toDTO(): SubmissionDTO {
+    return {
+      id: this.id.value,
+      cycleId: this._cycleId.value,
+      memberId: this._memberId.value,
+      url: this._url.value,
+      submittedAt: this._submittedAt.toISOString(),
+      githubCommentId: this._githubCommentId.value,
+    };
+  }
+}
+
+// DTO 타입
+export interface SubmissionDTO {
+  id: number;
+  cycleId: number;
+  memberId: number;
+  url: string;
+  submittedAt: string;
+  githubCommentId: string;
+}

--- a/src/domain/submission/submission.repository.ts
+++ b/src/domain/submission/submission.repository.ts
@@ -1,0 +1,48 @@
+// Submission Repository Interface - 제출 리포지토리 인터페이스
+
+import { SubmissionId, MemberId, CycleId } from './submission.domain';
+import { Submission } from './submission.domain';
+
+/**
+ * 제출 리포지토리 인터페이스
+ * 도메인 계층에서 정의하며, 구현은 인프라스트럭처 계층에서 제공
+ */
+export interface SubmissionRepository {
+  /**
+   * 제출 저장 (생성 또는 업데이트)
+   */
+  save(submission: Submission): Promise<void>;
+
+  /**
+   * ID로 제출 조회
+   */
+  findById(id: SubmissionId): Promise<Submission | null>;
+
+  /**
+   * 사이클과 회원으로 제출 조회 (중복 체크용)
+   */
+  findByCycleAndMember(
+    cycleId: CycleId,
+    memberId: MemberId
+  ): Promise<Submission | null>;
+
+  /**
+   * GitHub Comment ID로 제출 조회 (중복 방지용)
+   */
+  findByGithubCommentId(commentId: string): Promise<Submission | null>;
+
+  /**
+   * 사이클별 모든 제출 조회
+   */
+  findByCycle(cycleId: CycleId): Promise<Submission[]>;
+
+  /**
+   * 회원별 모든 제출 조회
+   */
+  findByMember(memberId: MemberId): Promise<Submission[]>;
+
+  /**
+   * 제출 삭제
+   */
+  delete(id: SubmissionId): Promise<void>;
+}

--- a/src/domain/submission/submission.repository.ts
+++ b/src/domain/submission/submission.repository.ts
@@ -37,6 +37,11 @@ export interface SubmissionRepository {
   findByCycle(cycleId: CycleId): Promise<Submission[]>;
 
   /**
+   * 사이클 ID로 모든 제출 조회
+   */
+  findByCycleId(cycleId: CycleId): Promise<Submission[]>;
+
+  /**
    * 회원별 모든 제출 조회
    */
   findByMember(memberId: MemberId): Promise<Submission[]>;

--- a/src/domain/submission/submission.service.ts
+++ b/src/domain/submission/submission.service.ts
@@ -1,0 +1,83 @@
+// Submission Domain Service - 제출 도메인 서비스
+
+import { MemberId, CycleId } from './submission.domain';
+import { SubmissionRepository } from './submission.repository';
+import { ConflictError } from '../common/errors';
+
+/**
+ * 제출 도메인 서비스
+ * 여러 애그리거트에 걸친 비즈니스 로직을 처리
+ */
+export class SubmissionService {
+  constructor(private readonly submissionRepo: SubmissionRepository) {}
+
+  /**
+   * 제출 가능 여부 확인
+   * - 이미 제출된 회원인지 확인
+   * - 중복 GitHub Comment ID인지 확인
+   */
+  async canSubmit(
+    cycleId: CycleId,
+    memberId: MemberId,
+    githubCommentId: string
+  ): Promise<{ canSubmit: boolean; reason?: string }> {
+    // 이미 제출되었는지 확인
+    const existing = await this.submissionRepo.findByCycleAndMember(
+      cycleId,
+      memberId
+    );
+    if (existing) {
+      return {
+        canSubmit: false,
+        reason: 'Already submitted for this cycle',
+      };
+    }
+
+    // GitHub Comment ID 중복 확인
+    const byCommentId = await this.submissionRepo.findByGithubCommentId(
+      githubCommentId
+    );
+    if (byCommentId) {
+      return {
+        canSubmit: false,
+        reason: 'GitHub comment ID already used',
+      };
+    }
+
+    return { canSubmit: true };
+  }
+
+  /**
+   * 제출 가능 여부를 검증하고, 불가능하면 에러를 던짐
+   */
+  async validateSubmission(
+    cycleId: CycleId,
+    memberId: MemberId,
+    githubCommentId: string
+  ): Promise<void> {
+    const result = await this.canSubmit(
+      cycleId,
+      memberId,
+      githubCommentId
+    );
+
+    if (!result.canSubmit) {
+      throw new ConflictError(result.reason ?? 'Cannot submit');
+    }
+  }
+
+  /**
+   * 사이클의 제출 통계 조회
+   */
+  async getCycleStats(cycleId: CycleId): Promise<{
+    totalSubmissions: number;
+    submittedMemberIds: MemberId[];
+  }> {
+    const submissions = await this.submissionRepo.findByCycle(cycleId);
+
+    return {
+      totalSubmissions: submissions.length,
+      submittedMemberIds: submissions.map((s) => s.memberId),
+    };
+  }
+}

--- a/src/domain/submission/submission.service.ts
+++ b/src/domain/submission/submission.service.ts
@@ -34,9 +34,8 @@ export class SubmissionService {
     }
 
     // GitHub Comment ID 중복 확인
-    const byCommentId = await this.submissionRepo.findByGithubCommentId(
-      githubCommentId
-    );
+    const byCommentId =
+      await this.submissionRepo.findByGithubCommentId(githubCommentId);
     if (byCommentId) {
       return {
         canSubmit: false,
@@ -55,11 +54,7 @@ export class SubmissionService {
     memberId: MemberId,
     githubCommentId: string
   ): Promise<void> {
-    const result = await this.canSubmit(
-      cycleId,
-      memberId,
-      githubCommentId
-    );
+    const result = await this.canSubmit(cycleId, memberId, githubCommentId);
 
     if (!result.canSubmit) {
       throw new ConflictError(result.reason ?? 'Cannot submit');

--- a/src/domain/submission/submission.vo.ts
+++ b/src/domain/submission/submission.vo.ts
@@ -1,0 +1,70 @@
+// Value Objects for Submission Domain
+
+import { DomainError } from '../common/errors';
+
+// 블로그 URL Value Object
+export class BlogUrl {
+  private constructor(public readonly value: string) {
+    if (!this.isValid(value)) {
+      throw new InvalidBlogUrlError(value);
+    }
+  }
+
+  private isValid(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  static create(url: string): BlogUrl {
+    return new BlogUrl(url);
+  }
+
+  equals(other: BlogUrl): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+export class InvalidBlogUrlError extends DomainError {
+  readonly code = 'INVALID_BLOG_URL' as const;
+
+  constructor(url: string) {
+    super(`Invalid blog URL: ${url}`);
+  }
+}
+
+// GitHub Comment ID Value Object
+export class GithubCommentId {
+  private constructor(public readonly value: string) {
+    if (!value || value.trim().length === 0) {
+      throw new InvalidGithubCommentIdError(value);
+    }
+  }
+
+  static create(id: string | number): GithubCommentId {
+    return new GithubCommentId(String(id));
+  }
+
+  equals(other: GithubCommentId): boolean {
+    return this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+export class InvalidGithubCommentIdError extends DomainError {
+  readonly code = 'INVALID_GITHUB_COMMENT_ID' as const;
+
+  constructor(id: string) {
+    super(`Invalid GitHub comment ID: ${id}`);
+  }
+}

--- a/src/infrastructure/external/discord/discord.interface.ts
+++ b/src/infrastructure/external/discord/discord.interface.ts
@@ -1,0 +1,65 @@
+// Discord Notification Interface
+
+/**
+ * Discord 메시지 포맷
+ */
+export interface DiscordMessage {
+  content?: string;
+  embeds?: DiscordEmbed[];
+}
+
+/**
+ * Discord Embed 포맷
+ */
+export interface DiscordEmbed {
+  title?: string;
+  description?: string;
+  color?: number;
+  fields?: Array<{ name: string; value: string; inline?: boolean }>;
+  timestamp?: string;
+}
+
+/**
+ * Discord Webhook 인터페이스
+ *
+ * 책임:
+ * - Discord webhook으로 메시지 전송
+ * - 다양한 형식의 알림 메시지 전송
+ */
+export interface IDiscordWebhookClient {
+  /**
+   * Discord webhook으로 메시지 전송
+   */
+  sendMessage(webhookUrl: string, message: DiscordMessage): Promise<void>;
+
+  /**
+   * 제출 알림 전송
+   */
+  sendSubmissionNotification(
+    webhookUrl: string,
+    memberName: string,
+    cycleName: string,
+    blogUrl: string
+  ): Promise<void>;
+
+  /**
+   * 마감 임박 알림 전송
+   */
+  sendReminderNotification(
+    webhookUrl: string,
+    cycleName: string,
+    endDate: Date,
+    notSubmittedNames: string[]
+  ): Promise<void>;
+
+  /**
+   * 제출 현황 전송
+   */
+  sendStatusNotification(
+    webhookUrl: string,
+    cycleName: string,
+    submittedNames: string[],
+    notSubmittedNames: string[],
+    endDate: Date
+  ): Promise<void>;
+}

--- a/src/infrastructure/external/discord/discord.webhook.ts
+++ b/src/infrastructure/external/discord/discord.webhook.ts
@@ -1,0 +1,28 @@
+// Discord Webhook Service
+
+import {
+  sendDiscordWebhook as originalSendDiscordWebhook,
+  createSubmissionMessage,
+} from '../../../services/discord';
+
+/**
+ * Discord 웹훅 전송 서비스
+ * (기존 discord.ts 서비스를 인프라스트럭처 계층으로 이동)
+ */
+export class DiscordWebhookService {
+  async sendSubmissionNotification(
+    memberName: string,
+    blogUrl: string,
+    cycleName: string
+  ): Promise<void> {
+    const message = createSubmissionMessage(memberName, blogUrl, cycleName);
+    const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+
+    if (!webhookUrl) {
+      console.warn('DISCORD_WEBHOOK_URL not set, skipping notification');
+      return;
+    }
+
+    await originalSendDiscordWebhook(webhookUrl, message);
+  }
+}

--- a/src/infrastructure/external/discord/discord.webhook.ts
+++ b/src/infrastructure/external/discord/discord.webhook.ts
@@ -1,28 +1,64 @@
-// Discord Webhook Service
+// Discord Webhook Service Implementation
 
 import {
   sendDiscordWebhook as originalSendDiscordWebhook,
   createSubmissionMessage,
+  createReminderMessage,
+  createStatusMessage,
 } from '../../../services/discord';
+import { IDiscordWebhookClient, DiscordMessage } from './discord.interface';
 
 /**
- * Discord 웹훅 전송 서비스
- * (기존 discord.ts 서비스를 인프라스트럭처 계층으로 이동)
+ * Discord 웹훅 클라이언트 구현
+ *
+ * 기존 discord.ts 서비스를 인프라스트럭처 계층으로 이동하고
+ * IDiscordWebhookClient 인터페이스를 구현
  */
-export class DiscordWebhookService {
+export class DiscordWebhookClient implements IDiscordWebhookClient {
+  async sendMessage(
+    webhookUrl: string,
+    message: DiscordMessage
+  ): Promise<void> {
+    await originalSendDiscordWebhook(webhookUrl, message);
+  }
+
   async sendSubmissionNotification(
+    webhookUrl: string,
     memberName: string,
-    blogUrl: string,
-    cycleName: string
+    cycleName: string,
+    blogUrl: string
   ): Promise<void> {
     const message = createSubmissionMessage(memberName, blogUrl, cycleName);
-    const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+    await this.sendMessage(webhookUrl, message);
+  }
 
-    if (!webhookUrl) {
-      console.warn('DISCORD_WEBHOOK_URL not set, skipping notification');
-      return;
-    }
+  async sendReminderNotification(
+    webhookUrl: string,
+    cycleName: string,
+    endDate: Date,
+    notSubmittedNames: string[]
+  ): Promise<void> {
+    const message = createReminderMessage(
+      cycleName,
+      endDate,
+      notSubmittedNames
+    );
+    await this.sendMessage(webhookUrl, message);
+  }
 
-    await originalSendDiscordWebhook(webhookUrl, message);
+  async sendStatusNotification(
+    webhookUrl: string,
+    cycleName: string,
+    submittedNames: string[],
+    notSubmittedNames: string[],
+    endDate: Date
+  ): Promise<void> {
+    const message = createStatusMessage(
+      cycleName,
+      submittedNames,
+      notSubmittedNames,
+      endDate
+    );
+    await this.sendMessage(webhookUrl, message);
   }
 }

--- a/src/infrastructure/external/discord/index.ts
+++ b/src/infrastructure/external/discord/index.ts
@@ -1,0 +1,4 @@
+// Discord Infrastructure exports
+
+export * from './discord.interface';
+export * from './discord.webhook';

--- a/src/infrastructure/persistence/drizzle/cycle.repository.impl.ts
+++ b/src/infrastructure/persistence/drizzle/cycle.repository.impl.ts
@@ -1,0 +1,76 @@
+// Cycle Repository Implementation - Drizzle ORM
+
+import { eq } from 'drizzle-orm';
+import { db } from '../../../lib/db';
+import { cycles } from '../../../db/schema';
+import { Cycle, CycleId } from '../../../domain/cycle/cycle.domain';
+import { CycleRepository } from '../../../domain/cycle/cycle.repository';
+
+export class DrizzleCycleRepository implements CycleRepository {
+  async findById(id: CycleId): Promise<Cycle | null> {
+    const result = await db
+      .select()
+      .from(cycles)
+      .where(eq(cycles.id, id.value))
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
+  async findByIssueUrl(issueUrl: string): Promise<Cycle | null> {
+    const result = await db
+      .select()
+      .from(cycles)
+      .where(eq(cycles.githubIssueUrl, issueUrl))
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
+  async findByGeneration(generationId: number): Promise<Cycle[]> {
+    const result = await db
+      .select()
+      .from(cycles)
+      .where(eq(cycles.generationId, generationId));
+
+    return result.map((row) => this.mapToEntity(row));
+  }
+
+  async save(cycle: Cycle): Promise<void> {
+    const dto = cycle.toDTO();
+    // 현재는 읽기 전용으로 사용
+    await db
+      .update(cycles)
+      .set({
+        week: dto.week,
+        startDate: new Date(dto.startDate),
+        endDate: new Date(dto.endDate),
+        githubIssueUrl: dto.githubIssueUrl,
+      })
+      .where(eq(cycles.id, dto.id));
+  }
+
+  private mapToEntity(row: {
+    id: number;
+    week: number;
+    startDate: Date;
+    endDate: Date;
+    githubIssueUrl: string | null;
+  }): Cycle {
+    return Cycle.create({
+      id: row.id,
+      week: row.week,
+      startDate: row.startDate,
+      endDate: row.endDate,
+      githubIssueUrl: row.githubIssueUrl ?? undefined,
+    });
+  }
+}

--- a/src/infrastructure/persistence/drizzle/cycle.repository.impl.ts
+++ b/src/infrastructure/persistence/drizzle/cycle.repository.impl.ts
@@ -1,12 +1,38 @@
 // Cycle Repository Implementation - Drizzle ORM
 
-import { eq } from 'drizzle-orm';
+import { eq, and, lt, gt } from 'drizzle-orm';
 import { db } from '../../../lib/db';
 import { cycles } from '../../../db/schema';
 import { Cycle, CycleId } from '../../../domain/cycle/cycle.domain';
 import { CycleRepository } from '../../../domain/cycle/cycle.repository';
 
 export class DrizzleCycleRepository implements CycleRepository {
+  async save(cycle: Cycle): Promise<void> {
+    const dto = cycle.toDTO();
+
+    // ID가 0이면 새로운 사이클 (생성)
+    if (dto.id === 0) {
+      await db.insert(cycles).values({
+        generationId: dto.generationId,
+        week: dto.week,
+        startDate: new Date(dto.startDate),
+        endDate: new Date(dto.endDate),
+        githubIssueUrl: dto.githubIssueUrl,
+      });
+    } else {
+      // 기존 사이클 업데이트
+      await db
+        .update(cycles)
+        .set({
+          week: dto.week,
+          startDate: new Date(dto.startDate),
+          endDate: new Date(dto.endDate),
+          githubIssueUrl: dto.githubIssueUrl,
+        })
+        .where(eq(cycles.id, dto.id));
+    }
+  }
+
   async findById(id: CycleId): Promise<Cycle | null> {
     const result = await db
       .select()
@@ -35,6 +61,23 @@ export class DrizzleCycleRepository implements CycleRepository {
     return this.mapToEntity(result[0]);
   }
 
+  async findByGenerationAndWeek(
+    generationId: number,
+    week: number
+  ): Promise<Cycle | null> {
+    const result = await db
+      .select()
+      .from(cycles)
+      .where(and(eq(cycles.generationId, generationId), eq(cycles.week, week)))
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
   async findByGeneration(generationId: number): Promise<Cycle[]> {
     const result = await db
       .select()
@@ -44,22 +87,45 @@ export class DrizzleCycleRepository implements CycleRepository {
     return result.map((row) => this.mapToEntity(row));
   }
 
-  async save(cycle: Cycle): Promise<void> {
-    const dto = cycle.toDTO();
-    // 현재는 읽기 전용으로 사용
-    await db
-      .update(cycles)
-      .set({
-        week: dto.week,
-        startDate: new Date(dto.startDate),
-        endDate: new Date(dto.endDate),
-        githubIssueUrl: dto.githubIssueUrl,
-      })
-      .where(eq(cycles.id, dto.id));
+  async findActiveCyclesByGeneration(generationId: number): Promise<Cycle[]> {
+    const now = new Date();
+
+    const result = await db
+      .select()
+      .from(cycles)
+      .where(
+        and(
+          eq(cycles.generationId, generationId),
+          lt(cycles.startDate, now),
+          gt(cycles.endDate, now)
+        )
+      );
+
+    return result.map((row) => this.mapToEntity(row));
+  }
+
+  async findCyclesWithDeadlineInRange(
+    generationId: number,
+    startTime: Date,
+    endTime: Date
+  ): Promise<Cycle[]> {
+    const result = await db
+      .select()
+      .from(cycles)
+      .where(
+        and(
+          eq(cycles.generationId, generationId),
+          lt(cycles.endDate, endTime),
+          gt(cycles.endDate, startTime)
+        )
+      );
+
+    return result.map((row) => this.mapToEntity(row));
   }
 
   private mapToEntity(row: {
     id: number;
+    generationId: number;
     week: number;
     startDate: Date;
     endDate: Date;
@@ -67,6 +133,7 @@ export class DrizzleCycleRepository implements CycleRepository {
   }): Cycle {
     return Cycle.create({
       id: row.id,
+      generationId: row.generationId,
       week: row.week,
       startDate: row.startDate,
       endDate: row.endDate,

--- a/src/infrastructure/persistence/drizzle/cycle.repository.impl.ts
+++ b/src/infrastructure/persistence/drizzle/cycle.repository.impl.ts
@@ -130,6 +130,7 @@ export class DrizzleCycleRepository implements CycleRepository {
     startDate: Date;
     endDate: Date;
     githubIssueUrl: string | null;
+    createdAt: Date;
   }): Cycle {
     return Cycle.create({
       id: row.id,
@@ -138,6 +139,7 @@ export class DrizzleCycleRepository implements CycleRepository {
       startDate: row.startDate,
       endDate: row.endDate,
       githubIssueUrl: row.githubIssueUrl ?? undefined,
+      createdAt: row.createdAt,
     });
   }
 }

--- a/src/infrastructure/persistence/drizzle/generation.repository.impl.ts
+++ b/src/infrastructure/persistence/drizzle/generation.repository.impl.ts
@@ -1,0 +1,65 @@
+// Generation Repository Implementation - Drizzle ORM
+
+import { eq } from 'drizzle-orm';
+import { db } from '../../../lib/db';
+import { generations } from '../../../db/schema';
+import { Generation, GenerationId } from '../../../domain/generation/generation.domain';
+import { GenerationRepository } from '../../../domain/generation/generation.repository';
+import { NotFoundError } from '../../../domain/common/errors';
+
+export class DrizzleGenerationRepository implements GenerationRepository {
+  async findById(id: GenerationId): Promise<Generation | null> {
+    const result = await db
+      .select()
+      .from(generations)
+      .where(eq(generations.id, id.value))
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
+  async findActive(): Promise<Generation> {
+    const result = await db
+      .select()
+      .from(generations)
+      .where(eq(generations.isActive, true))
+      .orderBy(generations.createdAt)
+      .limit(1);
+
+    if (result.length === 0) {
+      throw new NotFoundError('Active generation');
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
+  async save(generation: Generation): Promise<void> {
+    const dto = generation.toDTO();
+    await db
+      .update(generations)
+      .set({
+        name: dto.name,
+        startedAt: new Date(dto.startedAt),
+        isActive: dto.isActive,
+      })
+      .where(eq(generations.id, dto.id));
+  }
+
+  private mapToEntity(row: {
+    id: number;
+    name: string;
+    startedAt: Date;
+    isActive: boolean;
+  }): Generation {
+    return Generation.create({
+      id: row.id,
+      name: row.name,
+      startedAt: row.startedAt,
+      isActive: row.isActive,
+    });
+  }
+}

--- a/src/infrastructure/persistence/drizzle/generation.repository.impl.ts
+++ b/src/infrastructure/persistence/drizzle/generation.repository.impl.ts
@@ -3,7 +3,10 @@
 import { eq } from 'drizzle-orm';
 import { db } from '../../../lib/db';
 import { generations } from '../../../db/schema';
-import { Generation, GenerationId } from '../../../domain/generation/generation.domain';
+import {
+  Generation,
+  GenerationId,
+} from '../../../domain/generation/generation.domain';
 import { GenerationRepository } from '../../../domain/generation/generation.repository';
 import { NotFoundError } from '../../../domain/common/errors';
 

--- a/src/infrastructure/persistence/drizzle/generation.repository.impl.ts
+++ b/src/infrastructure/persistence/drizzle/generation.repository.impl.ts
@@ -8,9 +8,31 @@ import {
   GenerationId,
 } from '../../../domain/generation/generation.domain';
 import { GenerationRepository } from '../../../domain/generation/generation.repository';
-import { NotFoundError } from '../../../domain/common/errors';
 
 export class DrizzleGenerationRepository implements GenerationRepository {
+  async save(generation: Generation): Promise<void> {
+    const dto = generation.toDTO();
+
+    // ID가 0이면 새로운 기수 (생성)
+    if (dto.id === 0) {
+      await db.insert(generations).values({
+        name: dto.name,
+        startedAt: new Date(dto.startedAt),
+        isActive: dto.isActive,
+      });
+    } else {
+      // 기존 기수 업데이트
+      await db
+        .update(generations)
+        .set({
+          name: dto.name,
+          startedAt: new Date(dto.startedAt),
+          isActive: dto.isActive,
+        })
+        .where(eq(generations.id, dto.id));
+    }
+  }
+
   async findById(id: GenerationId): Promise<Generation | null> {
     const result = await db
       .select()
@@ -25,7 +47,7 @@ export class DrizzleGenerationRepository implements GenerationRepository {
     return this.mapToEntity(result[0]);
   }
 
-  async findActive(): Promise<Generation> {
+  async findActive(): Promise<Generation | null> {
     const result = await db
       .select()
       .from(generations)
@@ -34,22 +56,15 @@ export class DrizzleGenerationRepository implements GenerationRepository {
       .limit(1);
 
     if (result.length === 0) {
-      throw new NotFoundError('Active generation');
+      return null;
     }
 
     return this.mapToEntity(result[0]);
   }
 
-  async save(generation: Generation): Promise<void> {
-    const dto = generation.toDTO();
-    await db
-      .update(generations)
-      .set({
-        name: dto.name,
-        startedAt: new Date(dto.startedAt),
-        isActive: dto.isActive,
-      })
-      .where(eq(generations.id, dto.id));
+  async findAll(): Promise<Generation[]> {
+    const result = await db.select().from(generations);
+    return result.map((row) => this.mapToEntity(row));
   }
 
   private mapToEntity(row: {
@@ -58,7 +73,7 @@ export class DrizzleGenerationRepository implements GenerationRepository {
     startedAt: Date;
     isActive: boolean;
   }): Generation {
-    return Generation.create({
+    return Generation.reconstitute({
       id: row.id,
       name: row.name,
       startedAt: row.startedAt,

--- a/src/infrastructure/persistence/drizzle/member.repository.impl.ts
+++ b/src/infrastructure/persistence/drizzle/member.repository.impl.ts
@@ -1,0 +1,68 @@
+// Member Repository Implementation - Drizzle ORM
+
+import { eq } from 'drizzle-orm';
+import { db } from '../../../lib/db';
+import { members } from '../../../db/schema';
+import { Member, MemberId } from '../../../domain/member/member.domain';
+import { MemberRepository } from '../../../domain/member/member.repository';
+
+export class DrizzleMemberRepository implements MemberRepository {
+  async findById(id: MemberId): Promise<Member | null> {
+    const result = await db
+      .select()
+      .from(members)
+      .where(eq(members.id, id.value))
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
+  async findByGithubUsername(githubUsername: string): Promise<Member | null> {
+    const result = await db
+      .select()
+      .from(members)
+      .where(eq(members.github, githubUsername))
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
+  async findAll(): Promise<Member[]> {
+    const result = await db.select().from(members);
+    return result.map((row) => this.mapToEntity(row));
+  }
+
+  async save(member: Member): Promise<void> {
+    const dto = member.toDTO();
+    await db
+      .update(members)
+      .set({
+        github: dto.github,
+        name: dto.name,
+        discordId: dto.discordId,
+      })
+      .where(eq(members.id, dto.id));
+  }
+
+  private mapToEntity(row: {
+    id: number;
+    github: string;
+    name: string;
+    discordId: string | null;
+  }): Member {
+    return Member.create({
+      id: row.id,
+      github: row.github,
+      name: row.name,
+      discordId: row.discordId ?? undefined,
+    });
+  }
+}

--- a/src/infrastructure/persistence/drizzle/submission.repository.impl.ts
+++ b/src/infrastructure/persistence/drizzle/submission.repository.impl.ts
@@ -97,6 +97,10 @@ export class DrizzleSubmissionRepository implements SubmissionRepository {
     return result.map((row) => this.mapToEntity(row));
   }
 
+  async findByCycleId(cycleId: CycleId): Promise<Submission[]> {
+    return this.findByCycle(cycleId);
+  }
+
   async findByMember(memberId: MemberId): Promise<Submission[]> {
     const result = await db
       .select()

--- a/src/infrastructure/persistence/drizzle/submission.repository.impl.ts
+++ b/src/infrastructure/persistence/drizzle/submission.repository.impl.ts
@@ -1,0 +1,133 @@
+// Submission Repository Implementation - Drizzle ORM
+
+import { eq, and } from 'drizzle-orm';
+import { db } from '../../../lib/db';
+import { submissions } from '../../../db/schema';
+import {
+  Submission,
+  SubmissionId,
+  MemberId,
+  CycleId,
+} from '../../../domain/submission/submission.domain';
+import { SubmissionRepository } from '../../../domain/submission/submission.repository';
+
+/**
+ * Drizzle ORM을 사용한 SubmissionRepository 구현
+ */
+export class DrizzleSubmissionRepository implements SubmissionRepository {
+  async save(submission: Submission): Promise<void> {
+    const dto = submission.toDTO();
+
+    // ID가 0이면 새로운 제출 (생성)
+    if (dto.id === 0) {
+      await db.insert(submissions).values({
+        cycleId: dto.cycleId,
+        memberId: dto.memberId,
+        url: dto.url,
+        githubCommentId: dto.githubCommentId,
+        submittedAt: new Date(dto.submittedAt),
+      });
+    } else {
+      // 기존 제출 업데이트 (현재 요구사항에서는 사용하지 않음)
+      await db
+        .update(submissions)
+        .set({
+          url: dto.url,
+        })
+        .where(eq(submissions.id, dto.id));
+    }
+  }
+
+  async findById(id: SubmissionId): Promise<Submission | null> {
+    const result = await db
+      .select()
+      .from(submissions)
+      .where(eq(submissions.id, id.value))
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
+  async findByCycleAndMember(
+    cycleId: CycleId,
+    memberId: MemberId
+  ): Promise<Submission | null> {
+    const result = await db
+      .select()
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.cycleId, cycleId.value),
+          eq(submissions.memberId, memberId.value)
+        )
+      )
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
+  async findByGithubCommentId(commentId: string): Promise<Submission | null> {
+    const result = await db
+      .select()
+      .from(submissions)
+      .where(eq(submissions.githubCommentId, commentId))
+      .limit(1);
+
+    if (result.length === 0) {
+      return null;
+    }
+
+    return this.mapToEntity(result[0]);
+  }
+
+  async findByCycle(cycleId: CycleId): Promise<Submission[]> {
+    const result = await db
+      .select()
+      .from(submissions)
+      .where(eq(submissions.cycleId, cycleId.value));
+
+    return result.map((row) => this.mapToEntity(row));
+  }
+
+  async findByMember(memberId: MemberId): Promise<Submission[]> {
+    const result = await db
+      .select()
+      .from(submissions)
+      .where(eq(submissions.memberId, memberId.value));
+
+    return result.map((row) => this.mapToEntity(row));
+  }
+
+  async delete(id: SubmissionId): Promise<void> {
+    await db.delete(submissions).where(eq(submissions.id, id.value));
+  }
+
+  /**
+   * DB 레코드를 도메인 엔티티로 변환
+   */
+  private mapToEntity(row: {
+    id: number;
+    cycleId: number;
+    memberId: number;
+    url: string;
+    submittedAt: Date;
+    githubCommentId: string | null;
+  }): Submission {
+    return Submission.reconstitute({
+      id: row.id,
+      cycleId: row.cycleId,
+      memberId: row.memberId,
+      url: row.url,
+      submittedAt: row.submittedAt,
+      githubCommentId: row.githubCommentId ?? '',
+    });
+  }
+}

--- a/src/routes/github/github.handlers.ts
+++ b/src/routes/github/github.handlers.ts
@@ -7,7 +7,10 @@ import type {
 } from './github.routes';
 
 // DDD Layer imports
-import { RecordSubmissionCommand, CreateCycleCommand } from '@/application/commands';
+import {
+  RecordSubmissionCommand,
+  CreateCycleCommand,
+} from '@/application/commands';
 import { DrizzleSubmissionRepository } from '@/infrastructure/persistence/drizzle/submission.repository.impl';
 import { DrizzleCycleRepository } from '@/infrastructure/persistence/drizzle/cycle.repository.impl';
 import { DrizzleMemberRepository } from '@/infrastructure/persistence/drizzle/member.repository.impl';

--- a/src/routes/github/github.handlers.ts
+++ b/src/routes/github/github.handlers.ts
@@ -16,7 +16,11 @@ import { DrizzleCycleRepository } from '@/infrastructure/persistence/drizzle/cyc
 import { DrizzleMemberRepository } from '@/infrastructure/persistence/drizzle/member.repository.impl';
 import { SubmissionService } from '@/domain/submission/submission.service';
 import { DiscordWebhookService } from '@/infrastructure/external/discord/discord.webhook';
-import { ValidationError, NotFoundError, ConflictError } from '@/domain/common/errors';
+import {
+  ValidationError,
+  NotFoundError,
+  ConflictError,
+} from '@/domain/common/errors';
 
 // ========================================
 // Repository & Service Instances
@@ -127,17 +131,11 @@ export const handleIssueComment = async (c: AppContext) => {
       result.cycleName
     );
 
-    return c.json(
-      { message: 'Submission recorded' },
-      HttpStatusCodes.OK
-    );
+    return c.json({ message: 'Submission recorded' }, HttpStatusCodes.OK);
   } catch (error) {
     // 도메인 에러 처리
     if (error instanceof NotFoundError) {
-      return c.json(
-        { message: error.message },
-        HttpStatusCodes.NOT_FOUND
-      );
+      return c.json({ message: error.message }, HttpStatusCodes.NOT_FOUND);
     }
     if (error instanceof ConflictError) {
       return c.json(
@@ -146,10 +144,7 @@ export const handleIssueComment = async (c: AppContext) => {
       );
     }
     if (error instanceof ValidationError) {
-      return c.json(
-        { message: error.message },
-        HttpStatusCodes.BAD_REQUEST
-      );
+      return c.json({ message: error.message }, HttpStatusCodes.BAD_REQUEST);
     }
 
     // 알 수 없는 에러

--- a/src/routes/github/github.routes.ts
+++ b/src/routes/github/github.routes.ts
@@ -128,6 +128,10 @@ export const handleIssues = createRoute({
       WebhookSuccessResponseSchema,
       'Webhook processed but ignored'
     ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      NotFoundErrorSchema,
+      'Generation not found'
+    ),
     [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       InternalServerErrorSchema,
       'Internal server error'

--- a/src/routes/reminder/reminder.handlers.ts
+++ b/src/routes/reminder/reminder.handlers.ts
@@ -1,114 +1,78 @@
-import { db } from '@/lib/db';
-import { members, generations, cycles, submissions } from '@/db/schema';
-import { eq, and, lt, gt } from 'drizzle-orm';
 import type { AppContext } from '@/lib/router';
 import * as HttpStatusCodes from 'stoker/http-status-codes';
 import { sendDiscordWebhook, createReminderMessage } from '@/services/discord';
 
+// DDD Layer imports
+import { GetReminderTargetsQuery } from '@/application/queries';
+import { DrizzleCycleRepository } from '@/infrastructure/persistence/drizzle/cycle.repository.impl';
+import { DrizzleGenerationRepository } from '@/infrastructure/persistence/drizzle/generation.repository.impl';
+import { DrizzleSubmissionRepository } from '@/infrastructure/persistence/drizzle/submission.repository.impl';
+import { DrizzleMemberRepository } from '@/infrastructure/persistence/drizzle/member.repository.impl';
+import { NotFoundError } from '@/domain/common/errors';
+
+// ========================================
+// Repository & Query Instances
+// ========================================
+
+const cycleRepo = new DrizzleCycleRepository();
+const generationRepo = new DrizzleGenerationRepository();
+const submissionRepo = new DrizzleSubmissionRepository();
+const memberRepo = new DrizzleMemberRepository();
+
+const getReminderTargetsQuery = new GetReminderTargetsQuery(
+  cycleRepo,
+  generationRepo,
+  submissionRepo,
+  memberRepo
+);
+
+// ========================================
+// Handlers
+// ========================================
+
 // n8n용 리마인더 대상 목록 조회
 export const getReminderCycles = async (c: AppContext) => {
   const hoursBefore = parseInt(c.req.query('hoursBefore') ?? '24');
-  const now = new Date();
-  const deadline = new Date(now.getTime() + hoursBefore * 60 * 60 * 1000);
 
-  // 마감 시간이 deadline 근처인 활성화된 사이클 찾기
-  const activeCycles = await db
-    .select({
-      cycle: cycles,
-      generation: generations,
-    })
-    .from(cycles)
-    .innerJoin(generations, eq(cycles.generationId, generations.id))
-    .where(
-      and(
-        eq(generations.isActive, true),
-        lt(cycles.endDate, deadline),
-        gt(cycles.endDate, now)
-      )
+  try {
+    const cycles =
+      await getReminderTargetsQuery.getCyclesWithDeadlineIn(hoursBefore);
+    return c.json({ cycles }, HttpStatusCodes.OK);
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return c.json({ error: error.message }, HttpStatusCodes.NOT_FOUND);
+    }
+    console.error('Unexpected error in getReminderCycles:', error);
+    return c.json(
+      { error: 'Internal server error' },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
     );
-
-  const result = activeCycles.map(({ cycle, generation }) => ({
-    cycleId: cycle.id,
-    cycleName: `${generation.name} - ${cycle.week}주차`,
-    endDate: cycle.endDate.toISOString(),
-    githubIssueUrl: cycle.githubIssueUrl ?? undefined,
-  }));
-
-  return c.json({ cycles: result }, HttpStatusCodes.OK);
+  }
 };
 
 // 특정 사이클의 미제출자 목록 조회
 export const getNotSubmittedMembers = async (c: AppContext) => {
   const cycleId = parseInt(c.req.param('cycleId'));
 
-  // 사이클 정보 조회
-  const cycleList = await db
-    .select()
-    .from(cycles)
-    .where(eq(cycles.id, cycleId));
-
-  if (cycleList.length === 0) {
-    return c.json({ error: 'Cycle not found' }, HttpStatusCodes.NOT_FOUND);
+  try {
+    const result =
+      await getReminderTargetsQuery.getNotSubmittedMembers(cycleId);
+    return c.json(result, HttpStatusCodes.OK);
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return c.json({ error: error.message }, HttpStatusCodes.NOT_FOUND);
+    }
+    console.error('Unexpected error in getNotSubmittedMembers:', error);
+    return c.json(
+      { error: 'Internal server error' },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
+    );
   }
-
-  const cycle = cycleList[0];
-
-  // 기수의 모든 멤버 찾기
-  // TODO: 기수-멤버 연결 테이블이 필요할 수 있음
-  // 일단 전체 멤버 중에서 제출 안 된 사람 찾기
-  const allMembers = await db.select().from(members);
-
-  // 제출한 멤버 ID 목록
-  const submittedMembers = await db
-    .select({ memberId: submissions.memberId })
-    .from(submissions)
-    .where(eq(submissions.cycleId, cycleId));
-
-  const submittedIds = new Set(submittedMembers.map((s) => s.memberId));
-
-  // 미제출자 목록
-  const notSubmitted = allMembers
-    .filter((m) => !submittedIds.has(m.id))
-    .map((m) => ({
-      github: m.github,
-      name: m.name,
-      discordId: m.discordId,
-    }));
-
-  return c.json(
-    {
-      cycleId: cycle.id,
-      week: cycle.week,
-      endDate: cycle.endDate.toISOString(),
-      notSubmitted,
-      submittedCount: submittedMembers.length,
-      totalMembers: allMembers.length,
-    },
-    HttpStatusCodes.OK
-  );
 };
 
 // 리마인더 알림 발송 (GitHub Actions용)
 export const sendReminderNotifications = async (c: AppContext) => {
   const hoursBefore = parseInt(c.req.query('hoursBefore') ?? '24');
-  const now = new Date();
-  const deadline = new Date(now.getTime() + hoursBefore * 60 * 60 * 1000);
-
-  // 마감 시간이 deadline 근처인 활성화된 사이클 찾기
-  const activeCycles = await db
-    .select({
-      cycle: cycles,
-      generation: generations,
-    })
-    .from(cycles)
-    .innerJoin(generations, eq(cycles.generationId, generations.id))
-    .where(
-      and(
-        eq(generations.isActive, true),
-        lt(cycles.endDate, deadline),
-        gt(cycles.endDate, now)
-      )
-    );
 
   const discordWebhookUrl =
     c.env.DISCORD_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_URL;
@@ -120,43 +84,52 @@ export const sendReminderNotifications = async (c: AppContext) => {
     );
   }
 
-  const sentCycles: Array<{ cycleId: number; cycleName: string }> = [];
+  try {
+    const cycles =
+      await getReminderTargetsQuery.getCyclesWithDeadlineIn(hoursBefore);
 
-  for (const { cycle, generation } of activeCycles) {
-    // 제출한 멤버 ID 목록
-    const submittedMembers = await db
-      .select({ memberId: submissions.memberId })
-      .from(submissions)
-      .where(eq(submissions.cycleId, cycle.id));
+    const sentCycles: Array<{ cycleId: number; cycleName: string }> = [];
 
-    const submittedIds = new Set(submittedMembers.map((s) => s.memberId));
+    for (const cycleInfo of cycles) {
+      // 미제출자 목록 조회
+      const result = await getReminderTargetsQuery.getNotSubmittedMembers(
+        cycleInfo.cycleId
+      );
 
-    // 미제출자 목록
-    const allMembers = await db.select().from(members);
-    const notSubmitted = allMembers
-      .filter((m) => !submittedIds.has(m.id))
-      .map((m) => m.name);
+      if (result.notSubmitted.length === 0) {
+        continue; // 모두 제출했으면 알림 스킵
+      }
 
-    if (notSubmitted.length === 0) {
-      continue; // 모두 제출했으면 알림 스킵
+      const notSubmittedNames = result.notSubmitted.map((m) => m.name);
+      const endDate = new Date(result.endDate);
+
+      // Discord 알림 전송
+      await sendDiscordWebhook(
+        discordWebhookUrl,
+        createReminderMessage(cycleInfo.cycleName, endDate, notSubmittedNames)
+      );
+
+      sentCycles.push({
+        cycleId: cycleInfo.cycleId,
+        cycleName: cycleInfo.cycleName,
+      });
     }
 
-    const cycleName = `${generation.name} - ${cycle.week}주차`;
-
-    // Discord 알림 전송
-    await sendDiscordWebhook(
-      discordWebhookUrl,
-      createReminderMessage(cycleName, cycle.endDate, notSubmitted)
+    return c.json(
+      {
+        sent: sentCycles.length,
+        cycles: sentCycles,
+      },
+      HttpStatusCodes.OK
     );
-
-    sentCycles.push({ cycleId: cycle.id, cycleName });
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return c.json({ error: error.message }, HttpStatusCodes.NOT_FOUND);
+    }
+    console.error('Unexpected error in sendReminderNotifications:', error);
+    return c.json(
+      { error: 'Internal server error' },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
+    );
   }
-
-  return c.json(
-    {
-      sent: sentCycles.length,
-      cycles: sentCycles,
-    },
-    HttpStatusCodes.OK
-  );
 };

--- a/src/routes/reminder/reminder.routes.ts
+++ b/src/routes/reminder/reminder.routes.ts
@@ -10,7 +10,7 @@ const CycleInfoSchema = z.object({
   cycleId: z.number(),
   cycleName: z.string(),
   endDate: z.string().datetime(),
-  githubIssueUrl: z.string().optional(),
+  githubIssueUrl: z.string().nullable(),
 });
 
 const ReminderListResponseSchema = z.object({
@@ -45,6 +45,10 @@ export const getReminderCycles = createRoute({
     [HttpStatusCodes.OK]: jsonContent(
       ReminderListResponseSchema,
       'Reminder cycles retrieved'
+    ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      NotFoundErrorSchema,
+      'Generation not found'
     ),
     [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       InternalServerErrorSchema,
@@ -96,6 +100,10 @@ export const sendReminderNotifications = createRoute({
         ),
       }),
       'Reminder notifications sent'
+    ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      NotFoundErrorSchema,
+      'Generation not found'
     ),
     [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
       InternalServerErrorSchema,

--- a/src/routes/status/status.handlers.ts
+++ b/src/routes/status/status.handlers.ts
@@ -56,8 +56,17 @@ export const getCurrentCycle = async (c: AppContext) => {
 export const getCurrentCycleDiscord = async (c: AppContext) => {
   try {
     // 현재 진행 중인 사이클 찾기
+    const generation = await generationRepo.findActive();
+
+    if (!generation) {
+      return c.json(
+        { error: 'No active cycle found' },
+        HttpStatusCodes.NOT_FOUND
+      );
+    }
+
     const cycles = await cycleRepo.findActiveCyclesByGeneration(
-      (await generationRepo.findActive())!.id.value
+      generation.id.value
     );
 
     if (cycles.length === 0) {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,4 +11,6 @@ export default defineConfig({
   splitting: false,
   treeshake: true,
   outDir: 'dist',
+  // Ensure TypeScript path resolution works correctly
+  tsconfig: './tsconfig.json',
 });


### PR DESCRIPTION
## Summary

Phase 2 of DDD migration for 똥글똥글 API. Implements core submission domain following DDD principles.

### 🏗️ Architecture Changes
- **Domain Layer**: Submission entity, Value Objects, Repository interfaces
- **Application Layer**: Command pattern for submission recording
- **Infrastructure Layer**: Drizzle ORM implementations, Discord service separation

### 🔧 Key Changes
- Add domain models with strong typing
- Implement Repository pattern for data abstraction
- Refactor github.handlers.ts to use DDD Command pattern
- Maintain existing functionality while improving testability

### 📦 New Files
- `src/domain/` - Domain entities and services
- `src/application/commands/` - Use cases
- `src/infrastructure/` - Persistence implementations

### ✅ Validation
- Build passes: ✅
- Lint passes: ✅
- No breaking changes to existing API

## Technical Details
- Aggregate Root: `Submission` entity
- Value Objects: `BlogUrl`, `GithubCommentId`
- Repository Pattern for data access abstraction
- Command Pattern for use case encapsulation

## Migration Progress
- [x] Phase 1: Structure & common types ✅
- [x] Phase 2: Submission domain ✅
- [x] Phase 3: Cycle domain
- [x] Phase 4: Member/Generation
- [x] Phase 5: Full CQRS

## Next Steps
Continue with Phase 3 for cycle domain implementation and status queries.