### PR TITLE
feat: add Discord bot commands with modular structure

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -76,7 +76,9 @@ const { env } = await import('./env');
 if (env.DISCORD_BOT_TOKEN && env.DISCORD_CLIENT_ID) {
   try {
     // 슬래시 명령어 등록
-    await registerSlashCommands();
+    const { createCommands } = await import('./presentation/discord/commands');
+    const commands = createCommands();
+    await registerSlashCommands(commands);
 
     // Discord Bot 로그인
     const discordBot = createDiscordBot();

--- a/apps/server/src/presentation/discord/bot.ts
+++ b/apps/server/src/presentation/discord/bot.ts
@@ -7,7 +7,7 @@ const commands = createCommands();
 const commandMap = new Map<string, DiscordCommand>();
 
 commands.forEach((cmd) => {
-  commandMap.set(cmd.definition.name, cmd);
+  commandMap.set(cmd.definition.toJSON().name, cmd);
 });
 
 export const createDiscordBot = (): Client => {

--- a/apps/server/src/presentation/discord/bot.ts
+++ b/apps/server/src/presentation/discord/bot.ts
@@ -1,66 +1,36 @@
 import {
   Client,
   GatewayIntentBits,
-  REST,
-  Routes,
-  SlashCommandBuilder,
-  ChatInputCommandInteraction,
 } from 'discord.js';
-import { env } from '@/env';
-import { createStatusMessage } from '@/infrastructure/external/discord';
+import { createCommands } from './commands';
+import { registerSlashCommands } from './commands/index';
+import { DiscordCommand } from './commands/types';
 
-// DDD Layer imports
-import { GetCycleStatusQuery } from '@/application/queries';
-import { DrizzleCycleRepository } from '@/infrastructure/persistence/drizzle/cycle.repository.impl';
-import { DrizzleGenerationRepository } from '@/infrastructure/persistence/drizzle/generation.repository.impl';
-import { DrizzleSubmissionRepository } from '@/infrastructure/persistence/drizzle/submission.repository.impl';
-import { DrizzleMemberRepository } from '@/infrastructure/persistence/drizzle/member.repository.impl';
-import { DrizzleOrganizationRepository } from '@/infrastructure/persistence/drizzle/organization.repository.impl';
-import { DrizzleOrganizationMemberRepository } from '@/infrastructure/persistence/drizzle/organization-member.repository.impl';
+const commands = createCommands();
+const commandMap = new Map<string, DiscordCommand>();
 
-// ========================================
-// Repository & Query Instances
-// ========================================
+commands.forEach((cmd) => {
+  commandMap.set(cmd.definition.name, cmd);
+});
 
-const cycleRepo = new DrizzleCycleRepository();
-const generationRepo = new DrizzleGenerationRepository();
-const submissionRepo = new DrizzleSubmissionRepository();
-const memberRepo = new DrizzleMemberRepository();
-const organizationRepo = new DrizzleOrganizationRepository();
-const organizationMemberRepo = new DrizzleOrganizationMemberRepository();
-
-const getCycleStatusQuery = new GetCycleStatusQuery(
-  cycleRepo,
-  generationRepo,
-  organizationRepo,
-  submissionRepo,
-  organizationMemberRepo,
-  memberRepo
-);
-
-// Discord Bot 클라이언트 생성
 export const createDiscordBot = (): Client => {
   const client = new Client({
     intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
   });
 
-  // 봇 준비 완료 시
   client.once('ready', () => {
     console.log(`✅ Discord Bot logged in as ${client.user?.tag}`);
   });
 
-  // 슬래시 명령어 핸들러
   client.on('interactionCreate', async (interaction) => {
     if (!interaction.isChatInputCommand()) return;
 
     const { commandName } = interaction;
-
     console.log(`📝 Received command: ${commandName}`);
 
-    if (commandName === 'check-submission') {
-      await handleCheckSubmission(interaction);
-    } else if (commandName === 'current-cycle') {
-      await handleCurrentCycle(interaction);
+    const command = commandMap.get(commandName);
+    if (command) {
+      await command.execute(interaction);
     } else {
       console.log(`⚠️  Unknown command: ${commandName}`);
     }
@@ -69,155 +39,4 @@ export const createDiscordBot = (): Client => {
   return client;
 };
 
-// 슬래시 명령어 등록
-export const registerSlashCommands = async (): Promise<void> => {
-  const commands = [
-    new SlashCommandBuilder()
-      .setName('check-submission')
-      .setDescription('현재 활성화된 주차의 제출 현황을 확인합니다'),
-    new SlashCommandBuilder()
-      .setName('current-cycle')
-      .setDescription('현재 진행 중인 주차 정보를 확인합니다'),
-  ].map((command) => command.toJSON());
-
-  const botToken = env.DISCORD_BOT_TOKEN;
-
-  if (!botToken) {
-    throw new Error('DISCORD_BOT_TOKEN is not set');
-  }
-
-  const rest = new REST({ version: '10' }).setToken(botToken);
-
-  try {
-    console.log('🔄 Started refreshing application (/) commands.');
-
-    const clientId = env.DISCORD_CLIENT_ID;
-
-    if (!clientId) {
-      throw new Error('DISCORD_CLIENT_ID is not set');
-    }
-
-    const guildId = env.DISCORD_GUILD_ID;
-
-    if (guildId) {
-      // 길드 명령어로 등록 (즉시 반영)
-      await rest.put(Routes.applicationGuildCommands(clientId, guildId), {
-        body: commands,
-      });
-      console.log(
-        `✅ Successfully registered guild commands for server: ${guildId}`
-      );
-    } else {
-      // 글로벌 명령어로 등록 (최대 1시간 소요)
-      await rest.put(Routes.applicationCommands(clientId), { body: commands });
-      console.log(
-        '✅ Successfully registered global commands (may take up to 1 hour to propagate)'
-      );
-    }
-
-    console.log('✅ Successfully reloaded application (/) commands.');
-  } catch (error) {
-    console.error('❌ Error registering slash commands:', error);
-    throw error;
-  }
-};
-
-// /current-cycle 명령어 핸들러
-const handleCurrentCycle = async (
-  interaction: ChatInputCommandInteraction
-): Promise<void> => {
-  console.log('🔵 handleCurrentCycle: Starting...');
-
-  try {
-    console.log('🔵 handleCurrentCycle: Calling deferReply...');
-    await interaction.deferReply();
-    console.log('🔵 handleCurrentCycle: deferReply succeeded');
-  } catch (error) {
-    console.error('❌ handleCurrentCycle: deferReply failed:', error);
-    return;
-  }
-
-  try {
-    console.log('🔵 handleCurrentCycle: Querying getCurrentCycle...');
-    const currentCycle =
-      await getCycleStatusQuery.getCurrentCycle('dongueldonguel');
-    console.log('🔵 handleCurrentCycle: getCurrentCycle result:', currentCycle);
-
-    if (!currentCycle) {
-      console.log('🔵 handleCurrentCycle: No current cycle found');
-      await interaction.editReply({
-        content: '❌ 현재 진행 중인 주차가 없습니다.',
-      });
-      return;
-    }
-
-    const daysUntilDeadline = currentCycle.daysLeft;
-
-    console.log('🔵 handleCurrentCycle: Sending reply...');
-    await interaction.editReply({
-      content: `📅 **현재 주차 정보**\n\n**기수**: ${currentCycle.generationName}\n**주차**: ${currentCycle.week}주차\n**마감일**: ${new Date(currentCycle.endDate).toLocaleDateString('ko-KR')} (${
-        daysUntilDeadline > 0 ? `D-${daysUntilDeadline}` : '오늘 마감'
-      })\n\n이슈 링크: ${currentCycle.githubIssueUrl}`,
-    });
-    console.log('🔵 handleCurrentCycle: Reply sent successfully');
-  } catch (error) {
-    console.error('❌ Error handling current-cycle command:', error);
-    try {
-      await interaction.editReply({
-        content: '❌ 주차 정보 조회 중 오류가 발생했습니다.',
-      });
-    } catch (editError) {
-      console.error('❌ Failed to send error reply:', editError);
-    }
-  }
-};
-
-// /check-submission 명령어 핸들러
-const handleCheckSubmission = async (
-  interaction: ChatInputCommandInteraction
-): Promise<void> => {
-  // 응답 지연 (데이터 조회 시간 필요)
-  await interaction.deferReply();
-
-  try {
-    // 현재 진행 중인 사이클 찾기
-    const currentCycle =
-      await getCycleStatusQuery.getCurrentCycle('dongueldonguel');
-
-    if (!currentCycle) {
-      await interaction.editReply({
-        content: '❌ 현재 진행 중인 주차가 없습니다.',
-      });
-      return;
-    }
-
-    // 제출 현황 조회
-    const participantNames = await getCycleStatusQuery.getCycleParticipantNames(
-      currentCycle.id,
-      'dongueldonguel'
-    );
-
-    if (!participantNames) {
-      await interaction.editReply({
-        content: '❌ 제출 현황 조회 중 오류가 발생했습니다.',
-      });
-      return;
-    }
-
-    // Discord 메시지 생성
-    const discordMessage = createStatusMessage(
-      participantNames.cycleName,
-      participantNames.submittedNames,
-      participantNames.notSubmittedNames,
-      participantNames.endDate
-    );
-
-    // 응답 전송
-    await interaction.editReply(discordMessage);
-  } catch (error) {
-    console.error('Error handling check-submission command:', error);
-    await interaction.editReply({
-      content: '❌ 제출 현황 조회 중 오류가 발생했습니다.',
-    });
-  }
-};
+export { registerSlashCommands };

--- a/apps/server/src/presentation/discord/bot.ts
+++ b/apps/server/src/presentation/discord/bot.ts
@@ -1,7 +1,4 @@
-import {
-  Client,
-  GatewayIntentBits,
-} from 'discord.js';
+import { Client, GatewayIntentBits } from 'discord.js';
 import { createCommands } from './commands';
 import { registerSlashCommands } from './commands/index';
 import { DiscordCommand } from './commands/types';

--- a/apps/server/src/presentation/discord/commands/CheckSubmissionCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CheckSubmissionCommand.ts
@@ -1,0 +1,54 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { GetCycleStatusQuery } from '@/application/queries';
+import { createStatusMessage } from '@/infrastructure/external/discord';
+import { DiscordCommand } from './types';
+
+export class CheckSubmissionCommand implements DiscordCommand {
+  readonly definition = new SlashCommandBuilder()
+    .setName('check-submission')
+    .setDescription('현재 활성화된 주차의 제출 현황을 확인합니다');
+
+  constructor(private readonly getCycleStatusQuery: GetCycleStatusQuery) {}
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    await interaction.deferReply();
+
+    try {
+      const currentCycle =
+        await this.getCycleStatusQuery.getCurrentCycle('dongueldonguel');
+
+      if (!currentCycle) {
+        await interaction.editReply({
+          content: '❌ 현재 진행 중인 주차가 없습니다.',
+        });
+        return;
+      }
+
+      const participantNames = await this.getCycleStatusQuery.getCycleParticipantNames(
+        currentCycle.id,
+        'dongueldonguel'
+      );
+
+      if (!participantNames) {
+        await interaction.editReply({
+          content: '❌ 제출 현황 조회 중 오류가 발생했습니다.',
+        });
+        return;
+      }
+
+      const discordMessage = createStatusMessage(
+        participantNames.cycleName,
+        participantNames.submittedNames,
+        participantNames.notSubmittedNames,
+        participantNames.endDate
+      );
+
+      await interaction.editReply(discordMessage);
+    } catch (error) {
+      console.error('Error handling check-submission command:', error);
+      await interaction.editReply({
+        content: '❌ 제출 현황 조회 중 오류가 발생했습니다.',
+      });
+    }
+  }
+}

--- a/apps/server/src/presentation/discord/commands/CheckSubmissionCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CheckSubmissionCommand.ts
@@ -24,10 +24,11 @@ export class CheckSubmissionCommand implements DiscordCommand {
         return;
       }
 
-      const participantNames = await this.getCycleStatusQuery.getCycleParticipantNames(
-        currentCycle.id,
-        'dongueldonguel'
-      );
+      const participantNames =
+        await this.getCycleStatusQuery.getCycleParticipantNames(
+          currentCycle.id,
+          'dongueldonguel'
+        );
 
       if (!participantNames) {
         await interaction.editReply({

--- a/apps/server/src/presentation/discord/commands/CreateMemberCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CreateMemberCommand.ts
@@ -8,10 +8,16 @@ export class CreateMemberCommand implements DiscordCommand {
     .setName('create-member')
     .setDescription('새로운 회원을 생성합니다 (어떤 조직에도 속하지 않은 회원)')
     .addStringOption((option) =>
-      option.setName('name').setDescription('회원의 실제 이름').setRequired(true)
+      option
+        .setName('name')
+        .setDescription('회원의 실제 이름')
+        .setRequired(true)
     )
     .addStringOption((option) =>
-      option.setName('github').setDescription('GitHub 사용자명 (선택사항)').setRequired(false)
+      option
+        .setName('github')
+        .setDescription('GitHub 사용자명 (선택사항)')
+        .setRequired(false)
     );
 
   constructor(

--- a/apps/server/src/presentation/discord/commands/CreateMemberCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CreateMemberCommand.ts
@@ -1,0 +1,72 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { CreateMemberCommand as AppCreateMemberCommand } from '@/application/commands';
+import { MemberRepository } from '@/domain/member/member.repository';
+import { DiscordCommand } from './types';
+
+export class CreateMemberCommand implements DiscordCommand {
+  readonly definition = new SlashCommandBuilder()
+    .setName('create-member')
+    .setDescription('새로운 회원을 생성합니다 (어떤 조직에도 속하지 않은 회원)')
+    .addStringOption((option) =>
+      option.setName('name').setDescription('회원의 실제 이름').setRequired(true)
+    )
+    .addStringOption((option) =>
+      option.setName('github').setDescription('GitHub 사용자명 (선택사항)').setRequired(false)
+    );
+
+  constructor(
+    private readonly createMemberCommand: AppCreateMemberCommand,
+    private readonly memberRepo: MemberRepository
+  ) {}
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      const name = interaction.options.getString('name', true);
+      const githubUsername = interaction.options.getString('github', false);
+
+      if (!interaction.user) {
+        await interaction.editReply({
+          content: '❌ 사용자 정보를 가져올 수 없습니다.',
+        });
+        return;
+      }
+
+      const discordId = interaction.user.id;
+      const discordUsername = interaction.user.username;
+      const discordAvatar = interaction.user.avatar;
+
+      const result = await this.createMemberCommand.execute({
+        githubUsername: githubUsername ?? '',
+        name,
+        discordId,
+      });
+
+      const member = result.member;
+      member.updateDiscordUsername(discordUsername);
+      if (discordAvatar) {
+        member.updateDiscordAvatar(discordAvatar);
+      }
+      await this.memberRepo.save(member);
+
+      await interaction.editReply({
+        content: `✅ 회원이 생성되었습니다!\n\n**이름**: ${name}\n**Discord**: ${discordUsername}\n**GitHub**: ${githubUsername || '미연동'}\n\n조직에 가입하려면 조직 관리자에게 문의하세요.`,
+      });
+    } catch (error) {
+      console.error('Error handling create-member command:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : '알 수 없는 오류';
+
+      if (errorMessage.includes('이미 존재')) {
+        await interaction.editReply({
+          content: '❌ 이미 등록된 회원입니다.',
+        });
+      } else {
+        await interaction.editReply({
+          content: `❌ 회원 생성 중 오류가 발생했습니다: ${errorMessage}`,
+        });
+      }
+    }
+  }
+}

--- a/apps/server/src/presentation/discord/commands/CreateOrganizationCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CreateOrganizationCommand.ts
@@ -7,13 +7,22 @@ export class CreateOrganizationCommand implements DiscordCommand {
     .setName('create-organization')
     .setDescription('새로운 조직을 생성합니다')
     .addStringOption((option) =>
-      option.setName('name').setDescription('조직 이름 (예: 똥글똥글)').setRequired(true)
+      option
+        .setName('name')
+        .setDescription('조직 이름 (예: 똥글똥글)')
+        .setRequired(true)
     )
     .addStringOption((option) =>
-      option.setName('slug').setDescription('URL 친화적 식별자 (선택사항)').setRequired(false)
+      option
+        .setName('slug')
+        .setDescription('URL 친화적 식별자 (선택사항)')
+        .setRequired(false)
     )
     .addStringOption((option) =>
-      option.setName('webhook').setDescription('Discord 웹훅 URL (선택사항)').setRequired(false)
+      option
+        .setName('webhook')
+        .setDescription('Discord 웹훅 URL (선택사항)')
+        .setRequired(false)
     );
 
   constructor(
@@ -41,7 +50,8 @@ export class CreateOrganizationCommand implements DiscordCommand {
       });
     } catch (error) {
       console.error('Error handling create-organization command:', error);
-      const errorMessage = error instanceof Error ? error.message : '알 수 없는 오류';
+      const errorMessage =
+        error instanceof Error ? error.message : '알 수 없는 오류';
 
       if (errorMessage.includes('already exists')) {
         await interaction.editReply({

--- a/apps/server/src/presentation/discord/commands/CreateOrganizationCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CreateOrganizationCommand.ts
@@ -1,0 +1,57 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { CreateOrganizationCommand as AppCreateOrganizationCommand } from '@/application/commands';
+import { DiscordCommand } from './types';
+
+export class CreateOrganizationCommand implements DiscordCommand {
+  readonly definition = new SlashCommandBuilder()
+    .setName('create-organization')
+    .setDescription('새로운 조직을 생성합니다')
+    .addStringOption((option) =>
+      option.setName('name').setDescription('조직 이름 (예: 똥글똥글)').setRequired(true)
+    )
+    .addStringOption((option) =>
+      option.setName('slug').setDescription('URL 친화적 식별자 (선택사항)').setRequired(false)
+    )
+    .addStringOption((option) =>
+      option.setName('webhook').setDescription('Discord 웹훅 URL (선택사항)').setRequired(false)
+    );
+
+  constructor(
+    private readonly createOrganizationCommand: AppCreateOrganizationCommand
+  ) {}
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      const name = interaction.options.getString('name', true);
+      const slug = interaction.options.getString('slug', false);
+      const webhookUrl = interaction.options.getString('webhook', false);
+
+      const result = await this.createOrganizationCommand.execute({
+        name,
+        slug: slug ?? undefined,
+        discordWebhookUrl: webhookUrl ?? undefined,
+      });
+
+      const organization = result.organization;
+
+      await interaction.editReply({
+        content: `✅ 조직이 생성되었습니다!\n\n**조직명**: ${organization.name.value}\n**슬러그**: ${organization.slug.value}\n**활성화**: ${organization.isActive ? '활성' : '비활성'}\n${webhookUrl ? `**웹훅**: ${webhookUrl}` : ''}`,
+      });
+    } catch (error) {
+      console.error('Error handling create-organization command:', error);
+      const errorMessage = error instanceof Error ? error.message : '알 수 없는 오류';
+
+      if (errorMessage.includes('already exists')) {
+        await interaction.editReply({
+          content: '❌ 이미 존재하는 슬러그입니다. 다른 슬러그를 사용해주세요.',
+        });
+      } else {
+        await interaction.editReply({
+          content: `❌ 조직 생성 중 오류가 발생했습니다: ${errorMessage}`,
+        });
+      }
+    }
+  }
+}

--- a/apps/server/src/presentation/discord/commands/CurrentCycleCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CurrentCycleCommand.ts
@@ -1,0 +1,51 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { GetCycleStatusQuery } from '@/application/queries';
+import { DiscordCommand } from './types';
+
+export class CurrentCycleCommand implements DiscordCommand {
+  readonly definition = new SlashCommandBuilder()
+    .setName('current-cycle')
+    .setDescription('현재 진행 중인 주차 정보를 확인합니다');
+
+  constructor(private readonly getCycleStatusQuery: GetCycleStatusQuery) {}
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    console.log('🔵 handleCurrentCycle: Starting...');
+
+    try {
+      await interaction.deferReply();
+    } catch (error) {
+      console.error('❌ handleCurrentCycle: deferReply failed:', error);
+      return;
+    }
+
+    try {
+      const currentCycle =
+        await this.getCycleStatusQuery.getCurrentCycle('dongueldonguel');
+
+      if (!currentCycle) {
+        await interaction.editReply({
+          content: '❌ 현재 진행 중인 주차가 없습니다.',
+        });
+        return;
+      }
+
+      const daysUntilDeadline = currentCycle.daysLeft;
+
+      await interaction.editReply({
+        content: `📅 **현재 주차 정보**\n\n**기수**: ${currentCycle.generationName}\n**주차**: ${currentCycle.week}주차\n**마감일**: ${new Date(currentCycle.endDate).toLocaleDateString('ko-KR')} (${
+          daysUntilDeadline > 0 ? `D-${daysUntilDeadline}` : '오늘 마감'
+        })\n\n이슈 링크: ${currentCycle.githubIssueUrl}`,
+      });
+    } catch (error) {
+      console.error('❌ Error handling current-cycle command:', error);
+      try {
+        await interaction.editReply({
+          content: '❌ 주차 정보 조회 중 오류가 발생했습니다.',
+        });
+      } catch (editError) {
+        console.error('❌ Failed to send error reply:', editError);
+      }
+    }
+  }
+}

--- a/apps/server/src/presentation/discord/commands/ListOrganizationsCommand.ts
+++ b/apps/server/src/presentation/discord/commands/ListOrganizationsCommand.ts
@@ -1,0 +1,56 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { OrganizationRepository } from '@/domain/organization/organization.repository';
+import { DiscordCommand } from './types';
+
+export class ListOrganizationsCommand implements DiscordCommand {
+  readonly definition = new SlashCommandBuilder()
+    .setName('list-organizations')
+    .setDescription('등록된 모든 스터디(조직) 목록을 조회합니다');
+
+  constructor(private readonly organizationRepo: OrganizationRepository) {}
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    await interaction.deferReply();
+
+    try {
+      const allOrgs = await this.organizationRepo.findAll();
+
+      if (allOrgs.length === 0) {
+        await interaction.editReply({
+          content: '📋 등록된 스터디가 없습니다.',
+        });
+        return;
+      }
+
+      const activeOrgs = allOrgs.filter((org) => org.isActive);
+
+      if (activeOrgs.length === 0) {
+        await interaction.editReply({
+          content: '📋 활성화된 스터디가 없습니다.',
+        });
+        return;
+      }
+
+      let message = `📋 **스터디 목록** (총 ${activeOrgs.length}개)\n\n`;
+
+      activeOrgs.forEach((org, index) => {
+        const dto = org.toDTO();
+        message += `**${index + 1}. ${dto.name}**\n`;
+        message += `   슬러그: \`${dto.slug}\`\n`;
+        if (dto.discordWebhookUrl) {
+          message += `   웹훅: 연결됨\n`;
+        }
+        message += '\n';
+      });
+
+      await interaction.editReply({
+        content: message,
+      });
+    } catch (error) {
+      console.error('Error handling list-organizations command:', error);
+      await interaction.editReply({
+        content: '❌ 스터디 목록 조회 중 오류가 발생했습니다.',
+      });
+    }
+  }
+}

--- a/apps/server/src/presentation/discord/commands/index.ts
+++ b/apps/server/src/presentation/discord/commands/index.ts
@@ -1,4 +1,4 @@
-import { REST, Routes, SlashCommandBuilder } from 'discord.js';
+import { REST, Routes } from 'discord.js';
 import { env } from '@/env';
 import { DiscordCommand } from './types';
 import { CheckSubmissionCommand } from './CheckSubmissionCommand';
@@ -7,7 +7,10 @@ import { CreateMemberCommand } from './CreateMemberCommand';
 import { CreateOrganizationCommand } from './CreateOrganizationCommand';
 import { ListOrganizationsCommand } from './ListOrganizationsCommand';
 import { GetCycleStatusQuery } from '@/application/queries';
-import { CreateMemberCommand as AppCreateMemberCommand, CreateOrganizationCommand as AppCreateOrganizationCommand } from '@/application/commands';
+import {
+  CreateMemberCommand as AppCreateMemberCommand,
+  CreateOrganizationCommand as AppCreateOrganizationCommand,
+} from '@/application/commands';
 import { DrizzleCycleRepository } from '@/infrastructure/persistence/drizzle/cycle.repository.impl';
 import { DrizzleGenerationRepository } from '@/infrastructure/persistence/drizzle/generation.repository.impl';
 import { DrizzleSubmissionRepository } from '@/infrastructure/persistence/drizzle/submission.repository.impl';
@@ -26,8 +29,13 @@ const organizationMemberRepo = new DrizzleOrganizationMemberRepository();
 
 // Application layer instances
 const memberService = new MemberService(memberRepo);
-const createMemberCommand = new AppCreateMemberCommand(memberRepo, memberService);
-const createOrganizationCommand = new AppCreateOrganizationCommand(organizationRepo);
+const createMemberCommand = new AppCreateMemberCommand(
+  memberRepo,
+  memberService
+);
+const createOrganizationCommand = new AppCreateOrganizationCommand(
+  organizationRepo
+);
 
 const getCycleStatusQuery = new GetCycleStatusQuery(
   cycleRepo,
@@ -49,7 +57,9 @@ export const createCommands = (): DiscordCommand[] => {
   ];
 };
 
-export const registerSlashCommands = async (commands: DiscordCommand[]): Promise<void> => {
+export const registerSlashCommands = async (
+  commands: DiscordCommand[]
+): Promise<void> => {
   const commandDefinitions = commands.map((cmd) => cmd.definition.toJSON());
 
   const botToken = env.DISCORD_BOT_TOKEN;
@@ -77,7 +87,9 @@ export const registerSlashCommands = async (commands: DiscordCommand[]): Promise
         `✅ Successfully registered guild commands for server: ${guildId}`
       );
     } else {
-      await rest.put(Routes.applicationCommands(clientId), { body: commandDefinitions });
+      await rest.put(Routes.applicationCommands(clientId), {
+        body: commandDefinitions,
+      });
       console.log(
         '✅ Successfully registered global commands (may take up to 1 hour to propagate)'
       );

--- a/apps/server/src/presentation/discord/commands/index.ts
+++ b/apps/server/src/presentation/discord/commands/index.ts
@@ -1,0 +1,91 @@
+import { REST, Routes, SlashCommandBuilder } from 'discord.js';
+import { env } from '@/env';
+import { DiscordCommand } from './types';
+import { CheckSubmissionCommand } from './CheckSubmissionCommand';
+import { CurrentCycleCommand } from './CurrentCycleCommand';
+import { CreateMemberCommand } from './CreateMemberCommand';
+import { CreateOrganizationCommand } from './CreateOrganizationCommand';
+import { ListOrganizationsCommand } from './ListOrganizationsCommand';
+import { GetCycleStatusQuery } from '@/application/queries';
+import { CreateMemberCommand as AppCreateMemberCommand, CreateOrganizationCommand as AppCreateOrganizationCommand } from '@/application/commands';
+import { DrizzleCycleRepository } from '@/infrastructure/persistence/drizzle/cycle.repository.impl';
+import { DrizzleGenerationRepository } from '@/infrastructure/persistence/drizzle/generation.repository.impl';
+import { DrizzleSubmissionRepository } from '@/infrastructure/persistence/drizzle/submission.repository.impl';
+import { DrizzleMemberRepository } from '@/infrastructure/persistence/drizzle/member.repository.impl';
+import { DrizzleOrganizationRepository } from '@/infrastructure/persistence/drizzle/organization.repository.impl';
+import { DrizzleOrganizationMemberRepository } from '@/infrastructure/persistence/drizzle/organization-member.repository.impl';
+import { MemberService } from '@/domain/member/member.service';
+
+// Repository instances
+const cycleRepo = new DrizzleCycleRepository();
+const generationRepo = new DrizzleGenerationRepository();
+const submissionRepo = new DrizzleSubmissionRepository();
+const memberRepo = new DrizzleMemberRepository();
+const organizationRepo = new DrizzleOrganizationRepository();
+const organizationMemberRepo = new DrizzleOrganizationMemberRepository();
+
+// Application layer instances
+const memberService = new MemberService(memberRepo);
+const createMemberCommand = new AppCreateMemberCommand(memberRepo, memberService);
+const createOrganizationCommand = new AppCreateOrganizationCommand(organizationRepo);
+
+const getCycleStatusQuery = new GetCycleStatusQuery(
+  cycleRepo,
+  generationRepo,
+  organizationRepo,
+  submissionRepo,
+  organizationMemberRepo,
+  memberRepo
+);
+
+// Command instances
+export const createCommands = (): DiscordCommand[] => {
+  return [
+    new CheckSubmissionCommand(getCycleStatusQuery),
+    new CurrentCycleCommand(getCycleStatusQuery),
+    new CreateMemberCommand(createMemberCommand, memberRepo),
+    new CreateOrganizationCommand(createOrganizationCommand),
+    new ListOrganizationsCommand(organizationRepo),
+  ];
+};
+
+export const registerSlashCommands = async (commands: DiscordCommand[]): Promise<void> => {
+  const commandDefinitions = commands.map((cmd) => cmd.definition.toJSON());
+
+  const botToken = env.DISCORD_BOT_TOKEN;
+  if (!botToken) {
+    throw new Error('DISCORD_BOT_TOKEN is not set');
+  }
+
+  const rest = new REST({ version: '10' }).setToken(botToken);
+
+  try {
+    console.log('🔄 Started refreshing application (/) commands.');
+
+    const clientId = env.DISCORD_CLIENT_ID;
+    if (!clientId) {
+      throw new Error('DISCORD_CLIENT_ID is not set');
+    }
+
+    const guildId = env.DISCORD_GUILD_ID;
+
+    if (guildId) {
+      await rest.put(Routes.applicationGuildCommands(clientId, guildId), {
+        body: commandDefinitions,
+      });
+      console.log(
+        `✅ Successfully registered guild commands for server: ${guildId}`
+      );
+    } else {
+      await rest.put(Routes.applicationCommands(clientId), { body: commandDefinitions });
+      console.log(
+        '✅ Successfully registered global commands (may take up to 1 hour to propagate)'
+      );
+    }
+
+    console.log('✅ Successfully reloaded application (/) commands.');
+  } catch (error) {
+    console.error('❌ Error registering slash commands:', error);
+    throw error;
+  }
+};

--- a/apps/server/src/presentation/discord/commands/types.ts
+++ b/apps/server/src/presentation/discord/commands/types.ts
@@ -1,7 +1,4 @@
-import {
-  SlashCommandBuilder,
-  ChatInputCommandInteraction,
-} from 'discord.js';
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
 
 export interface DiscordCommand {
   readonly definition: SlashCommandBuilder;

--- a/apps/server/src/presentation/discord/commands/types.ts
+++ b/apps/server/src/presentation/discord/commands/types.ts
@@ -1,0 +1,11 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+} from 'discord.js';
+
+export interface DiscordCommand {
+  readonly definition: SlashCommandBuilder;
+  execute(interaction: ChatInputCommandInteraction): Promise<void>;
+}
+
+export type DiscordCommandConstructor = new () => DiscordCommand;

--- a/apps/server/src/presentation/discord/commands/types.ts
+++ b/apps/server/src/presentation/discord/commands/types.ts
@@ -1,5 +1,4 @@
 import {
-  SlashCommandBuilder,
   ChatInputCommandInteraction,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord.js';

--- a/apps/server/src/presentation/discord/commands/types.ts
+++ b/apps/server/src/presentation/discord/commands/types.ts
@@ -1,7 +1,13 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  RESTPostAPIChatInputApplicationCommandsJSONBody,
+} from 'discord.js';
 
 export interface DiscordCommand {
-  readonly definition: SlashCommandBuilder;
+  readonly definition: {
+    toJSON: () => RESTPostAPIChatInputApplicationCommandsJSONBody;
+  };
   execute(interaction: ChatInputCommandInteraction): Promise<void>;
 }
 


### PR DESCRIPTION
## Summary
- Add Discord slash commands for member and organization management
- Modularize bot commands into separate classes in commands/ directory
- Support for `/create-member`, `/create-organization`, and `/list-organizations` commands

## Test plan
- Verify Discord bot starts successfully
- Test all new slash commands work correctly
- Check command registrations on Discord server

🤖 Generated with [Claude Code](https://claude.com/claude-code)