### PR TITLE
fix: Update Dockerfile to copy .pylon folder instead of dist

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --no-cache libc6-compat curl && \
     addgroup --system --gid 1001 hono && \
     adduser --system --uid 1001 -G hono hono
 
-COPY --from=builder /app/apps/server/dist ./apps/server/dist
+COPY --from=builder /app/apps/server/.pylon ./apps/server/.pylon
 COPY --from=installer /app/. .
 
 RUN chown -R hono:hono /app


### PR DESCRIPTION
## Summary
- Update Dockerfile to copy `.pylon` folder instead of `dist` folder
- Change in `apps/server/Dockerfile:41`

## Test plan
- Build Docker image with updated Dockerfile
- Verify the container starts correctly
- Check that `.pylon` folder is properly copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)