### PR TITLE
Reorganize README and rename packages

### DIFF
--- a/.claude/agents/codebase-extractor.md
+++ b/.claude/agents/codebase-extractor.md
@@ -20,7 +20,7 @@ color: blue
 ## 프로젝트 개요
 
 - **구조**: Turborepo Monorepo
-- **Apps**: server (@dongueldonguel/server), client (@dongueldonguel/client)
+- **Apps**: server (@hanghae-study/server), client (@hanghae-study/client)
 - **Server 스택**: Hono (TypeScript), Drizzle ORM, PostgreSQL
 - **목적**: 격주 글쓰기 모임 자동화 시스템
 
@@ -84,8 +84,8 @@ apps/server/src/
 
 - **Root**: `/baku/`
 - **Apps**:
-  - `server` (@dongueldonguel/server)
-  - `client` (@dongueldonguel/client)
+  - `server` (@hanghae-study/server)
+  - `client` (@hanghae-study/client)
 - **Packages**: None yet
 ```
 

--- a/.claude/docs/workspace/architecture.md
+++ b/.claude/docs/workspace/architecture.md
@@ -23,7 +23,7 @@
 
 ## Application Architecture
 
-### server (@dongueldonguel/server)
+### server (@hanghae-study/server)
 
 [server 앱 아키텍처 문서](../apps/server/facts/) 참조
 
@@ -48,7 +48,7 @@ apps/server/src/
     └── external/       # 외부 서비스
 ```
 
-### client (@dongueldonguel/client)
+### client (@hanghae-study/client)
 
 개발 예정
 

--- a/.claude/docs/workspace/index.md
+++ b/.claude/docs/workspace/index.md
@@ -13,8 +13,8 @@
 ```
 baku/
 ├── apps/
-│   ├── server/          # 메인 API 서버 (@dongueldonguel/server)
-│   └── client/          # 클라이언트 앱 (@dongueldonguel/client) - 개발 예정
+│   ├── server/          # 메인 API 서버 (@hanghae-study/server)
+│   └── client/          # 클라이언트 앱 (@hanghae-study/client) - 개발 예정
 ├── packages/            # 공유 패키지 - 향후 추가 예정
 ├── .claude/             # Claude Code 설정 및 문서
 └── test-webhook/        # GitHub 웹훅 테스트 페이로드
@@ -22,7 +22,7 @@ baku/
 
 ## Applications
 
-### server (@dongueldonguel/server)
+### server (@hanghae-study/server)
 
 격주 글쓰기 모임을 위한 자동화 API 서버입니다.
 
@@ -31,7 +31,7 @@ baku/
 - **Architecture**: Domain-Driven Design (DDD)
 - **Documentation**: [apps/server/](../apps/server/)
 
-### client (@dongueldonguel/client)
+### client (@hanghae-study/client)
 
 클라이언트 애플리케이션 (개발 예정)
 

--- a/README.md
+++ b/README.md
@@ -1,405 +1,68 @@
-# 똥글똥글 API 서버
+# 똥글똥글 (Donguel-Donguel)
 
-2주마다 글을 쓰는 모임의 자동화 시스템 API 서버
+2주마다 글을 쓰는 모임의 자동화 플랫폼
 
-## 기술스택
+## 개요
 
-- **Hono** - 웹 프레임워크
-- **TypeScript**
-- **Drizzle ORM** - DB ORM
-- **Neon PostgreSQL** - 데이터베이스 (Serverless Postgres)
+똥글똥글은 글쓰기 모임을 운영하기 위한 전체 자동화 시스템입니다. 멤버들이 GitHub Issue에 댓글로 글을 제출하면 자동으로 기록되고, Discord로 알림이 발송됩니다.
 
-## 기능
+## 프로젝트 구조
 
-1. **GitHub Issue 댓글 감지** - 글 제출 시 Discord 알림
-2. **리마인더 API** - n8n에서 주기적으로 호출하여 미제출자 알림
-3. **제출 현황 조회** - Discord 슬래시 명령어 `/check-submission` 지원
-
-## 시작하기
-
-### 0. Direnv 설정 (권장, 워크트리 사용 시 필수)
-
-여러 git worktree에서 개발할 때 환경변수를 자동으로 로드하기 위해 **direnv**를 사용합니다.
-
-#### 설치
-
-```bash
-# macOS
-brew install direnv
-
-# 셸 설정 추가 (zsh)
-echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
-source ~/.zshrc
-
-# 셸 설정 추가 (bash)
-echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
-source ~/.bashrc
+```
+zagreb/
+├── apps/
+│   ├── server/          # API 서버 (Hono + TypeScript)
+│   └── client/          # 클라이언트 앱
+├── packages/            # 공유 패키지
+└── .claude/docs/        # 코드베이스 문서
 ```
 
-#### 프로젝트 설정
+### 앱 안내
 
-```bash
-# 프로젝트 루트에서 .envrc 활성화
-direnv allow
+- **[Server](./apps/server/README.md)** - API 서버, GitHub Webhook, Discord Bot
+- **[Client](./apps/client/README.md)** - 웹 인터페이스
 
-# 워크트리를 사용하는 경우, 메인 워크트리의 .envrc를 심링크로 연결
-ln -s /path/to/main/worktree/.envrc .envrc
-direnv allow
-```
+## 빠른 시작
 
-이제 프로젝트 디렉토리에 진입하면 `.env` 파일의 환경변수가 자동으로 로드되고, 나가면 자동으로 언로드됩니다.
+### 사전 요구사항
 
-### 1. 의존성 설치
+- Node.js >= 18.0.0
+- pnpm 10.0.0
+
+### 설치
 
 ```bash
 pnpm install
 ```
 
-### 2. 환경 변수 설정
-
-`.env` 파일 생성:
-
-```env
-# Neon PostgreSQL (브랜치별로 다른 URL 사용)
-DATABASE_URL=postgresql://user:password@ep-xxx.aws.neon.tech/neondb?sslmode=require
-
-# Discord Webhook (제출/리마인더 알림)
-DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
-
-# Discord Bot (슬래시 명령어용)
-DISCORD_BOT_TOKEN=your_bot_token_here
-DISCORD_CLIENT_ID=your_application_id_here
-DISCORD_GUILD_ID=your_server_id_here
-
-# Server
-PORT=3000
-```
-
-### 3. DB 마이그레이션
+### 개발
 
 ```bash
-pnpm run db:push
+# 모든 앱 개발 모드 시작
+pnpm dev
+
+# 특정 앱만 시작
+pnpm --filter server dev
+pnpm --filter client dev
 ```
 
-### 4. 실행
-
-direnv가 설정된 경우 환경변수가 자동으로 로드됩니다:
+### 빌드
 
 ```bash
-# direnv로 자동 로드되는지 확인
-echo $DATABASE_URL
-
-# 개발 서버 시작
-pnpm run dev
+pnpm build
 ```
 
-**참고**: direnv를 사용하지 않는 경우 `dotenv` 클라이언트가 `.env`를 로드합니다.
+## 기술 스택
 
-## API 명세
+- **Build System**: Turborepo + pnpm workspaces
+- **Server**: Hono, TypeScript, Drizzle ORM, PostgreSQL
+- **Database**: Neon PostgreSQL (Serverless)
 
-### GraphQL API (Pylon)
+## 문서
 
-#### `http://localhost:3000/graphql` - GraphQL Playground
+- **[코드베이스 문서](./.claude/docs/apps/server/README.md)** - 아키텍처, 도메인, API 상세 문서
+- **[기여 가이드](./CONTRIBUTING.md)** - 개발 환경 설정 및 기여 방법
 
-Pylon 프레임워크가 제공하는 내장 GraphQL Playground입니다. 쿼리와 뮤테이션을 테스트할 수 있는 그래픽 인터페이스입니다.
+## 라이선스
 
-**주요 쿼리**:
-```graphql
-# 조직 조회
-query {
-  organization(slug: "dongueldonguel") {
-    id
-    name
-    slug
-    discordWebhookUrl
-    isActive
-    createdAt
-  }
-}
-
-# 전체 멤버 조회
-query {
-  members {
-    id
-    github
-    name
-    discordId
-  }
-}
-
-# 활성화된 기수 조회
-query {
-  activeGeneration {
-    id
-    name
-    startedAt
-    isActive
-  }
-}
-
-# 사이클 제출 현황
-query {
-  cycleStatus(cycleId: 1, organizationSlug: "dongueldonguel") {
-    cycle {
-      id
-      week
-      startDate
-      endDate
-    }
-    summary {
-      total
-      submitted
-      notSubmitted
-    }
-    submitted {
-      member { name github }
-      url
-      submittedAt
-    }
-    notSubmitted {
-      name
-      github
-    }
-  }
-}
-```
-
-**주요 뮤테이션**:
-```graphql
-# 멤버 추가
-mutation {
-  addMember(
-    github: "newuser"
-    name: "새 사용자"
-    discordId: "123456789"
-  ) {
-    id
-    github
-    name
-  }
-}
-
-# 기수 생성
-mutation {
-  addGeneration(
-    name: "똥글똥글 2기"
-    startedAt: "2025-01-01T00:00:00Z"
-    organizationSlug: "dongueldonguel"
-  ) {
-    id
-    name
-  }
-}
-```
-
-#### `http://localhost:3000/viewer` - GraphQL Viewer
-
-스키마를 시각적으로 탐색할 수 있는 뷰어입니다. 타입, 쿼리, 뮤테이션의 구조를 실시간으로 확인할 수 있습니다.
-
-### GitHub Webhook
-
-#### `POST /webhook/github`
-
-GitHub Issue 댓글 이벤트를 받아 제출을 기록하고 Discord 알림을 보냅니다.
-
-**요청**: GitHub webhook payload
-
-**동작**:
-1. 댓글에서 URL 추출
-2. 해당 Issue에 연결된 사이클 찾기
-3. 제출 저장
-4. Discord 알림 전송
-
-### 리마인더 API (n8n용)
-
-#### `GET /api/reminder?hoursBefore=24`
-
-마감 일정이 임박한 사이클 목록을 반환합니다.
-
-**응답**:
-```json
-{
-  "cycles": [
-    {
-      "cycleId": 1,
-      "cycleName": "똥글똥글 1기 - 1주차",
-      "endDate": "2024-10-11T23:59:59.000Z",
-      "githubIssueUrl": "https://github.com/hanghae-story-forge/archive/issues/1"
-    }
-  ]
-}
-```
-
-#### `GET /api/reminder/:cycleId/not-submitted`
-
-특정 사이클의 미제출자 목록을 반환합니다.
-
-**응답**:
-```json
-{
-  "cycleId": 1,
-  "week": 1,
-  "endDate": "2024-10-11T23:59:59.000Z",
-  "notSubmitted": [
-    { "github": "user1", "name": "홍길동", "discordId": "123456" }
-  ],
-  "submittedCount": 3,
-  "totalMembers": 5
-}
-```
-
-### 제출 현황 API (Discord용)
-
-#### `GET /api/status/:cycleId`
-
-특정 사이클의 제출 현황을 반환합니다.
-
-**응답**:
-```json
-{
-  "cycle": {
-    "id": 1,
-    "week": 1,
-    "startDate": "2024-09-28T00:00:00.000Z",
-    "endDate": "2024-10-11T23:59:59.000Z",
-    "generationName": "똥글똥글 1기"
-  },
-  "summary": {
-    "total": 5,
-    "submitted": 3,
-    "notSubmitted": 2
-  },
-  "submitted": [
-    { "name": "홍길동", "github": "user1", "url": "https://...", "submittedAt": "..." }
-  ],
-  "notSubmitted": [
-    { "name": "김철수", "github": "user2" }
-  ]
-}
-```
-
-#### `GET /api/status/:cycleId/discord`
-
-Discord 메시지 포맷으로 제출 현황을 반환합니다.
-
-**응답**: Discord webhook payload 형식
-
-## DB 스키마
-
-### `members`
-- `id` (PK)
-- `github` - GitHub username
-- `discordId` - Discord ID
-- `name` - 이름
-- `createdAt`
-
-### `generations`
-- `id` (PK)
-- `name` - 기수 이름 (예: "똥글똥글 1기")
-- `startedAt` - 시작일
-- `isActive` - 활성화 여부
-- `createdAt`
-
-### `cycles`
-- `id` (PK)
-- `generationId` (FK)
-- `week` - 주차 (1, 2, 3...)
-- `startDate` - 시작일시
-- `endDate` - 마감일시
-- `githubIssueUrl` - GitHub Issue URL
-- `createdAt`
-
-### `submissions`
-- `id` (PK)
-- `cycleId` (FK)
-- `memberId` (FK)
-- `url` - 블로그 글 URL
-- `submittedAt` - 제출일시
-- `githubCommentId` - GitHub 댓글 ID
-
-## n8n 연동
-
-### 리마인더 워크플로우
-
-1. **Schedule Trigger** - 3일전, 2일전, 1일전, 6시간전, 1시간전 설정
-2. **HTTP Request** - `GET /api/reminder?hoursBefore=X`
-3. **Loop** - 각 사이클에 대해:
-   - `GET /api/reminder/:cycleId/not-submitted`
-   - Discord webhook으로 미제출자 알림
-
-### 제출 현황 워크플로우
-
-1. **Discord Trigger** - `/현황` 명령어
-2. **HTTP Request** - `GET /api/status/:cycleId/discord`
-3. **Discord** - webhook으로 응답 전송
-
-## GitHub Webhook 설정
-
-1. GitHub 레포 Settings > Webhooks > Add webhook
-2. Payload URL: `https://your-server.com/webhook/github`
-3. Content type: `application/json`
-4. Events: Issue comments > `Comment created`
-5. Secret 설정 (선택)
-
-## Discord Bot 설정
-
-`/check-submission` 슬래시 명령어를 사용하려면 Discord Bot이 필요합니다.
-
-### 1. Discord 앱 생성
-
-1. [Discord Developer Portal](https://discord.com/developers/applications) 접속
-2. **New Application** 클릭 → 이름 입력
-3. **Bot** 탭 → **Add Bot** 클릭
-4. **Reset Token**으로 토큰 복사 → `DISCORD_BOT_TOKEN`
-
-### 2. 봇을 서버에 초대
-
-1. **OAuth2** → **URL Generator** 탭
-2. Scopes: `bot`, `applications.commands` 체크
-3. Bot Permissions: `Send Messages`, `Embed Links` 체크
-4. 생성된 URL로 접속하여 봇을 서버에 초대
-
-### 3. 서버 ID 확인
-
-1. Discord 설정 → **고급** → **개발자 모드** 켜기
-2. 서버 우클릭 → **ID 복사** → `DISCORD_GUILD_ID`
-
-### 4. Application ID 확인
-
-**General Information** 탭에서 **Application ID** 복사 → `DISCORD_CLIENT_ID`
-
-## Neon DB 브랜치 간 데이터 마이그레이션
-
-Neon DB의 develop 브랜치에서 production 브랜치로 데이터를 옮겨야 할 때 사용합니다.
-
-### 마이그레이션 스크립트 실행
-
-```bash
-# 환경 변수 설정
-export SOURCE_DB_URL="postgresql://user:password@ep-develop-xxx.aws.neon.tech/neondb?sslmode=require"
-export TARGET_DB_URL="postgresql://user:password@ep-production-xxx.aws.neon.tech/neondb?sslmode=require"
-
-# 스크립트 실행
-pnpm tsx scripts/migrate-branch-to-production.ts
-```
-
-### 마이그레이션 과정
-
-1. **데이터 내보내기** - 소스 브랜치에서 모든 테이블 데이터 추출
-2. **타겟 비우기** - 타겟 브랜치의 기존 데이터 삭제 (참조 무결성 유지)
-3. **데이터 가져오기** - 타겟 브랜치에 데이터 삽입
-4. **검증** - 데이터 일치 여부 확인
-
-### 주의사항
-
-- 타겟 브랜치의 **모든 기존 데이터가 삭제됩니다**
-- 외래 키 참조 무결성을 위해 테이블 순서를 자동으로 처리합니다
-- 시퀀스(ID 자동 증가)가 올바르게 재설정됩니다
-
-### 마이그레이션 대상 테이블
-
-- `members` - 멤버 정보
-- `generations` - 기수 정보
-- `generation_members` - 기수-멤버 조인 테이블
-- `cycles` - 주차 사이클
-- `submissions` - 제출 기록
+MIT

--- a/apps/client/eslint.config.mjs
+++ b/apps/client/eslint.config.mjs
@@ -1,3 +1,3 @@
-import config from '@dongueldonguel/config-eslint';
+import config from '@hanghae-study/config-eslint';
 
 export default config;

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dongueldonguel/client",
+  "name": "@hanghae-study/client",
   "version": "1.0.0",
   "private": true,
   "description": "똥글똥글 클라이언트 애플리케이션",
@@ -14,9 +14,9 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@dongueldonguel/config-eslint": "workspace:*",
-    "@dongueldonguel/config-prettier": "workspace:*",
-    "@dongueldonguel/config-typescript": "workspace:*",
+    "@hanghae-study/config-eslint": "workspace:*",
+    "@hanghae-study/config-prettier": "workspace:*",
+    "@hanghae-study/config-typescript": "workspace:*",
     "typescript": "^5.8.3"
   }
 }

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -13,7 +13,7 @@ COPY apps/client/package.json ./apps/client/
 # Copy source files for turbo prune
 COPY apps/server ./apps/server
 
-RUN turbo prune --docker --out-dir=output --scope=@dongueldonguel/server
+RUN turbo prune --docker --out-dir=output --scope=@hanghae-study/server
 
 FROM base AS installer
 RUN apk add --no-cache libc6-compat curl
@@ -26,7 +26,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY --from=installer /app .
 COPY --from=pruner /app/output/full ./
-RUN corepack enable pnpm && pnpm build --filter=@dongueldonguel/server
+RUN corepack enable pnpm && pnpm build --filter=@hanghae-study/server
 
 FROM base AS runner
 WORKDIR /app

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,405 @@
+# 똥글똥글 API 서버
+
+2주마다 글을 쓰는 모임의 자동화 시스템 API 서버
+
+## 기술스택
+
+- **Hono** - 웹 프레임워크
+- **TypeScript**
+- **Drizzle ORM** - DB ORM
+- **Neon PostgreSQL** - 데이터베이스 (Serverless Postgres)
+
+## 기능
+
+1. **GitHub Issue 댓글 감지** - 글 제출 시 Discord 알림
+2. **리마인더 API** - n8n에서 주기적으로 호출하여 미제출자 알림
+3. **제출 현황 조회** - Discord 슬래시 명령어 `/check-submission` 지원
+
+## 시작하기
+
+### 0. Direnv 설정 (권장, 워크트리 사용 시 필수)
+
+여러 git worktree에서 개발할 때 환경변수를 자동으로 로드하기 위해 **direnv**를 사용합니다.
+
+#### 설치
+
+```bash
+# macOS
+brew install direnv
+
+# 셸 설정 추가 (zsh)
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+source ~/.zshrc
+
+# 셸 설정 추가 (bash)
+echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+#### 프로젝트 설정
+
+```bash
+# 프로젝트 루트에서 .envrc 활성화
+direnv allow
+
+# 워크트리를 사용하는 경우, 메인 워크트리의 .envrc를 심링크로 연결
+ln -s /path/to/main/worktree/.envrc .envrc
+direnv allow
+```
+
+이제 프로젝트 디렉토리에 진입하면 `.env` 파일의 환경변수가 자동으로 로드되고, 나가면 자동으로 언로드됩니다.
+
+### 1. 의존성 설치
+
+```bash
+pnpm install
+```
+
+### 2. 환경 변수 설정
+
+`.env` 파일 생성:
+
+```env
+# Neon PostgreSQL (브랜치별로 다른 URL 사용)
+DATABASE_URL=postgresql://user:password@ep-xxx.aws.neon.tech/neondb?sslmode=require
+
+# Discord Webhook (제출/리마인더 알림)
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+
+# Discord Bot (슬래시 명령어용)
+DISCORD_BOT_TOKEN=your_bot_token_here
+DISCORD_CLIENT_ID=your_application_id_here
+DISCORD_GUILD_ID=your_server_id_here
+
+# Server
+PORT=3000
+```
+
+### 3. DB 마이그레이션
+
+```bash
+pnpm run db:push
+```
+
+### 4. 실행
+
+direnv가 설정된 경우 환경변수가 자동으로 로드됩니다:
+
+```bash
+# direnv로 자동 로드되는지 확인
+echo $DATABASE_URL
+
+# 개발 서버 시작
+pnpm run dev
+```
+
+**참고**: direnv를 사용하지 않는 경우 `dotenv` 클라이언트가 `.env`를 로드합니다.
+
+## API 명세
+
+### GraphQL API (Pylon)
+
+#### `http://localhost:3000/graphql` - GraphQL Playground
+
+Pylon 프레임워크가 제공하는 내장 GraphQL Playground입니다. 쿼리와 뮤테이션을 테스트할 수 있는 그래픽 인터페이스입니다.
+
+**주요 쿼리**:
+```graphql
+# 조직 조회
+query {
+  organization(slug: "dongueldonguel") {
+    id
+    name
+    slug
+    discordWebhookUrl
+    isActive
+    createdAt
+  }
+}
+
+# 전체 멤버 조회
+query {
+  members {
+    id
+    github
+    name
+    discordId
+  }
+}
+
+# 활성화된 기수 조회
+query {
+  activeGeneration {
+    id
+    name
+    startedAt
+    isActive
+  }
+}
+
+# 사이클 제출 현황
+query {
+  cycleStatus(cycleId: 1, organizationSlug: "dongueldonguel") {
+    cycle {
+      id
+      week
+      startDate
+      endDate
+    }
+    summary {
+      total
+      submitted
+      notSubmitted
+    }
+    submitted {
+      member { name github }
+      url
+      submittedAt
+    }
+    notSubmitted {
+      name
+      github
+    }
+  }
+}
+```
+
+**주요 뮤테이션**:
+```graphql
+# 멤버 추가
+mutation {
+  addMember(
+    github: "newuser"
+    name: "새 사용자"
+    discordId: "123456789"
+  ) {
+    id
+    github
+    name
+  }
+}
+
+# 기수 생성
+mutation {
+  addGeneration(
+    name: "똥글똥글 2기"
+    startedAt: "2025-01-01T00:00:00Z"
+    organizationSlug: "dongueldonguel"
+  ) {
+    id
+    name
+  }
+}
+```
+
+#### `http://localhost:3000/viewer` - GraphQL Viewer
+
+스키마를 시각적으로 탐색할 수 있는 뷰어입니다. 타입, 쿼리, 뮤테이션의 구조를 실시간으로 확인할 수 있습니다.
+
+### GitHub Webhook
+
+#### `POST /webhook/github`
+
+GitHub Issue 댓글 이벤트를 받아 제출을 기록하고 Discord 알림을 보냅니다.
+
+**요청**: GitHub webhook payload
+
+**동작**:
+1. 댓글에서 URL 추출
+2. 해당 Issue에 연결된 사이클 찾기
+3. 제출 저장
+4. Discord 알림 전송
+
+### 리마인더 API (n8n용)
+
+#### `GET /api/reminder?hoursBefore=24`
+
+마감 일정이 임박한 사이클 목록을 반환합니다.
+
+**응답**:
+```json
+{
+  "cycles": [
+    {
+      "cycleId": 1,
+      "cycleName": "똥글똥글 1기 - 1주차",
+      "endDate": "2024-10-11T23:59:59.000Z",
+      "githubIssueUrl": "https://github.com/hanghae-story-forge/archive/issues/1"
+    }
+  ]
+}
+```
+
+#### `GET /api/reminder/:cycleId/not-submitted`
+
+특정 사이클의 미제출자 목록을 반환합니다.
+
+**응답**:
+```json
+{
+  "cycleId": 1,
+  "week": 1,
+  "endDate": "2024-10-11T23:59:59.000Z",
+  "notSubmitted": [
+    { "github": "user1", "name": "홍길동", "discordId": "123456" }
+  ],
+  "submittedCount": 3,
+  "totalMembers": 5
+}
+```
+
+### 제출 현황 API (Discord용)
+
+#### `GET /api/status/:cycleId`
+
+특정 사이클의 제출 현황을 반환합니다.
+
+**응답**:
+```json
+{
+  "cycle": {
+    "id": 1,
+    "week": 1,
+    "startDate": "2024-09-28T00:00:00.000Z",
+    "endDate": "2024-10-11T23:59:59.000Z",
+    "generationName": "똥글똥글 1기"
+  },
+  "summary": {
+    "total": 5,
+    "submitted": 3,
+    "notSubmitted": 2
+  },
+  "submitted": [
+    { "name": "홍길동", "github": "user1", "url": "https://...", "submittedAt": "..." }
+  ],
+  "notSubmitted": [
+    { "name": "김철수", "github": "user2" }
+  ]
+}
+```
+
+#### `GET /api/status/:cycleId/discord`
+
+Discord 메시지 포맷으로 제출 현황을 반환합니다.
+
+**응답**: Discord webhook payload 형식
+
+## DB 스키마
+
+### `members`
+- `id` (PK)
+- `github` - GitHub username
+- `discordId` - Discord ID
+- `name` - 이름
+- `createdAt`
+
+### `generations`
+- `id` (PK)
+- `name` - 기수 이름 (예: "똥글똥글 1기")
+- `startedAt` - 시작일
+- `isActive` - 활성화 여부
+- `createdAt`
+
+### `cycles`
+- `id` (PK)
+- `generationId` (FK)
+- `week` - 주차 (1, 2, 3...)
+- `startDate` - 시작일시
+- `endDate` - 마감일시
+- `githubIssueUrl` - GitHub Issue URL
+- `createdAt`
+
+### `submissions`
+- `id` (PK)
+- `cycleId` (FK)
+- `memberId` (FK)
+- `url` - 블로그 글 URL
+- `submittedAt` - 제출일시
+- `githubCommentId` - GitHub 댓글 ID
+
+## n8n 연동
+
+### 리마인더 워크플로우
+
+1. **Schedule Trigger** - 3일전, 2일전, 1일전, 6시간전, 1시간전 설정
+2. **HTTP Request** - `GET /api/reminder?hoursBefore=X`
+3. **Loop** - 각 사이클에 대해:
+   - `GET /api/reminder/:cycleId/not-submitted`
+   - Discord webhook으로 미제출자 알림
+
+### 제출 현황 워크플로우
+
+1. **Discord Trigger** - `/현황` 명령어
+2. **HTTP Request** - `GET /api/status/:cycleId/discord`
+3. **Discord** - webhook으로 응답 전송
+
+## GitHub Webhook 설정
+
+1. GitHub 레포 Settings > Webhooks > Add webhook
+2. Payload URL: `https://your-server.com/webhook/github`
+3. Content type: `application/json`
+4. Events: Issue comments > `Comment created`
+5. Secret 설정 (선택)
+
+## Discord Bot 설정
+
+`/check-submission` 슬래시 명령어를 사용하려면 Discord Bot이 필요합니다.
+
+### 1. Discord 앱 생성
+
+1. [Discord Developer Portal](https://discord.com/developers/applications) 접속
+2. **New Application** 클릭 → 이름 입력
+3. **Bot** 탭 → **Add Bot** 클릭
+4. **Reset Token**으로 토큰 복사 → `DISCORD_BOT_TOKEN`
+
+### 2. 봇을 서버에 초대
+
+1. **OAuth2** → **URL Generator** 탭
+2. Scopes: `bot`, `applications.commands` 체크
+3. Bot Permissions: `Send Messages`, `Embed Links` 체크
+4. 생성된 URL로 접속하여 봇을 서버에 초대
+
+### 3. 서버 ID 확인
+
+1. Discord 설정 → **고급** → **개발자 모드** 켜기
+2. 서버 우클릭 → **ID 복사** → `DISCORD_GUILD_ID`
+
+### 4. Application ID 확인
+
+**General Information** 탭에서 **Application ID** 복사 → `DISCORD_CLIENT_ID`
+
+## Neon DB 브랜치 간 데이터 마이그레이션
+
+Neon DB의 develop 브랜치에서 production 브랜치로 데이터를 옮겨야 할 때 사용합니다.
+
+### 마이그레이션 스크립트 실행
+
+```bash
+# 환경 변수 설정
+export SOURCE_DB_URL="postgresql://user:password@ep-develop-xxx.aws.neon.tech/neondb?sslmode=require"
+export TARGET_DB_URL="postgresql://user:password@ep-production-xxx.aws.neon.tech/neondb?sslmode=require"
+
+# 스크립트 실행
+pnpm tsx scripts/migrate-branch-to-production.ts
+```
+
+### 마이그레이션 과정
+
+1. **데이터 내보내기** - 소스 브랜치에서 모든 테이블 데이터 추출
+2. **타겟 비우기** - 타겟 브랜치의 기존 데이터 삭제 (참조 무결성 유지)
+3. **데이터 가져오기** - 타겟 브랜치에 데이터 삽입
+4. **검증** - 데이터 일치 여부 확인
+
+### 주의사항
+
+- 타겟 브랜치의 **모든 기존 데이터가 삭제됩니다**
+- 외래 키 참조 무결성을 위해 테이블 순서를 자동으로 처리합니다
+- 시퀀스(ID 자동 증가)가 올바르게 재설정됩니다
+
+### 마이그레이션 대상 테이블
+
+- `members` - 멤버 정보
+- `generations` - 기수 정보
+- `generation_members` - 기수-멤버 조인 테이블
+- `cycles` - 주차 사이클
+- `submissions` - 제출 기록

--- a/apps/server/eslint.config.mjs
+++ b/apps/server/eslint.config.mjs
@@ -1,3 +1,3 @@
-import config from '@dongueldonguel/config-eslint';
+import config from '@hanghae-study/config-eslint';
 
 export default config;

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dongueldonguel/server",
+  "name": "@hanghae-study/server",
   "version": "1.0.0",
   "description": "똥글똥글 자동화 API 서버",
   "type": "module",
@@ -48,9 +48,9 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@dongueldonguel/config-eslint": "workspace:*",
-    "@dongueldonguel/config-prettier": "workspace:*",
-    "@dongueldonguel/config-typescript": "workspace:*",
+    "@hanghae-study/config-eslint": "workspace:*",
+    "@hanghae-study/config-prettier": "workspace:*",
+    "@hanghae-study/config-typescript": "workspace:*",
     "@getcronit/pylon-dev": "^1.0.6",
     "@hono/node-server": "^1.14.1",
     "@hono/zod-openapi": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dongueldonguel-monorepo",
+  "name": "hanghae-study-monorepo",
   "version": "1.0.0",
   "private": true,
   "description": "똥글똥글 - Bi-weekly writing group automation platform",

--- a/packages/config/eslint/package.json
+++ b/packages/config/eslint/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dongueldonguel/config-eslint",
+  "name": "@hanghae-study/config-eslint",
   "version": "1.0.0",
   "private": true,
   "description": "Shared ESLint configuration",

--- a/packages/config/prettier/package.json
+++ b/packages/config/prettier/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dongueldonguel/config-prettier",
+  "name": "@hanghae-study/config-prettier",
   "version": "1.0.0",
   "private": true,
   "description": "Shared Prettier configuration",

--- a/packages/config/typescript/package.json
+++ b/packages/config/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dongueldonguel/config-typescript",
+  "name": "@hanghae-study/config-typescript",
   "version": "1.0.0",
   "private": true,
   "description": "Shared TypeScript configuration"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,13 +17,13 @@ importers:
 
   apps/client:
     devDependencies:
-      '@dongueldonguel/config-eslint':
+      '@hanghae-study/config-eslint':
         specifier: workspace:*
         version: link:../../packages/config/eslint
-      '@dongueldonguel/config-prettier':
+      '@hanghae-study/config-prettier':
         specifier: workspace:*
         version: link:../../packages/config/prettier
-      '@dongueldonguel/config-typescript':
+      '@hanghae-study/config-typescript':
         specifier: workspace:*
         version: link:../../packages/config/typescript
       typescript:
@@ -69,18 +69,18 @@ importers:
         specifier: ^4.3.5
         version: 4.3.5
     devDependencies:
-      '@dongueldonguel/config-eslint':
-        specifier: workspace:*
-        version: link:../../packages/config/eslint
-      '@dongueldonguel/config-prettier':
-        specifier: workspace:*
-        version: link:../../packages/config/prettier
-      '@dongueldonguel/config-typescript':
-        specifier: workspace:*
-        version: link:../../packages/config/typescript
       '@getcronit/pylon-dev':
         specifier: ^1.0.6
         version: 1.0.6(@types/node@22.19.3)(hono@4.11.3)(typescript@5.9.3)
+      '@hanghae-study/config-eslint':
+        specifier: workspace:*
+        version: link:../../packages/config/eslint
+      '@hanghae-study/config-prettier':
+        specifier: workspace:*
+        version: link:../../packages/config/prettier
+      '@hanghae-study/config-typescript':
+        specifier: workspace:*
+        version: link:../../packages/config/typescript
       '@hono/node-server':
         specifier: ^1.14.1
         version: 1.19.7(hono@4.11.3)


### PR DESCRIPTION
## Summary
- Reorganize README structure for monorepo project
- Move server-specific content to apps/server/README.md
- Update root README with project overview
- Rename packages from @dongueldonguel to @hanghae-study

🤖 Generated with [Claude Code](https://claude.com/claude-code)