### PR TITLE
fix: add autocomplete to approve-member command organization option

### DIFF
--- a/apps/server/src/presentation/discord/commands/ApproveMemberCommand.ts
+++ b/apps/server/src/presentation/discord/commands/ApproveMemberCommand.ts
@@ -12,8 +12,9 @@ export class ApproveMemberCommand implements DiscordCommand {
     .addStringOption((option) =>
       option
         .setName('organization')
-        .setDescription('조직 슬러그')
+        .setDescription('조직')
         .setRequired(true)
+        .setAutocomplete(true)
     )
     .addUserOption((option) =>
       option.setName('user').setDescription('승인할 사용자').setRequired(true)


### PR DESCRIPTION
## Summary
- Fix `/approve-member` command to show searchable select dropdown instead of raw text input for organization option
- Add `.setAutocomplete(true)` to enable dynamic organization selection
- Update organization option description from '조직 슬러그' to '조직'

## Test plan
- Test `/approve-member` command in Discord
- Verify organization field shows select dropdown with search functionality
- Test filtering organizations by name or slug
- Ensure command still works correctly with autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)