### PR TITLE
Fix Discord ID validation error for placeholder values

### DIFF
--- a/apps/server/src/domain/member/member.domain.ts
+++ b/apps/server/src/domain/member/member.domain.ts
@@ -95,15 +95,27 @@ export class Member extends AggregateRoot<MemberId> {
     name: string;
     createdAt: Date;
   }): Member {
-    return Member.create({
-      id: data.id,
-      discordId: data.discordId,
-      discordUsername: data.discordUsername,
-      discordAvatar: data.discordAvatar,
-      githubUsername: data.githubUsername,
-      name: data.name,
-      createdAt: data.createdAt,
-    });
+    const id = MemberId.create(data.id);
+    const discordId = DiscordId.reconstitute(data.discordId);
+    const discordUsername = data.discordUsername
+      ? DiscordUsername.reconstitute(data.discordUsername)
+      : null;
+    const discordAvatar = data.discordAvatar ?? null;
+    const githubUsername = data.githubUsername
+      ? GithubUsername.reconstitute(data.githubUsername)
+      : null;
+    const name = MemberName.reconstitute(data.name);
+    const createdAt = data.createdAt;
+
+    return new Member(
+      id,
+      discordId,
+      discordUsername,
+      discordAvatar,
+      githubUsername,
+      name,
+      createdAt
+    );
   }
 
   // Getters

--- a/apps/server/src/domain/member/member.vo.ts
+++ b/apps/server/src/domain/member/member.vo.ts
@@ -4,21 +4,38 @@ import { InvalidValueError } from '../common/errors';
 
 // 회원 이름 Value Object
 export class MemberName {
-  private constructor(public readonly value: string) {
-    if (value.trim().length === 0) {
-      throw new InvalidValueError('Member name', value, 'Name cannot be empty');
-    }
-    if (value.length > 50) {
-      throw new InvalidValueError(
-        'Member name',
-        value,
-        'Name cannot exceed 50 characters'
-      );
+  private constructor(
+    public readonly value: string,
+    validate = true
+  ) {
+    if (validate) {
+      if (value.trim().length === 0) {
+        throw new InvalidValueError(
+          'Member name',
+          value,
+          'Name cannot be empty'
+        );
+      }
+      if (value.length > 50) {
+        throw new InvalidValueError(
+          'Member name',
+          value,
+          'Name cannot exceed 50 characters'
+        );
+      }
     }
   }
 
   static create(value: string): MemberName {
     return new MemberName(value.trim());
+  }
+
+  /**
+   * Reconstitute from database without validation.
+   * Use only when loading from trusted data source.
+   */
+  static reconstitute(value: string): MemberName {
+    return new MemberName(value, false);
   }
 
   equals(other: MemberName): boolean {
@@ -32,20 +49,33 @@ export class MemberName {
 
 // GitHub 사용자명 Value Object
 export class GithubUsername {
-  private constructor(public readonly value: string) {
-    // GitHub username: 1-39 characters, alphanumeric and hyphens only
-    const githubUsernameRegex = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
-    if (!githubUsernameRegex.test(value) || value.length > 39) {
-      throw new InvalidValueError(
-        'GitHub username',
-        value,
-        'Invalid GitHub username format'
-      );
+  private constructor(
+    public readonly value: string,
+    validate = true
+  ) {
+    if (validate) {
+      // GitHub username: 1-39 characters, alphanumeric and hyphens only
+      const githubUsernameRegex = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+      if (!githubUsernameRegex.test(value) || value.length > 39) {
+        throw new InvalidValueError(
+          'GitHub username',
+          value,
+          'Invalid GitHub username format'
+        );
+      }
     }
   }
 
   static create(value: string): GithubUsername {
     return new GithubUsername(value);
+  }
+
+  /**
+   * Reconstitute from database without validation.
+   * Use only when loading from trusted data source.
+   */
+  static reconstitute(value: string): GithubUsername {
+    return new GithubUsername(value, false);
   }
 
   equals(other: GithubUsername): boolean {
@@ -59,20 +89,33 @@ export class GithubUsername {
 
 // Discord ID Value Object
 export class DiscordId {
-  private constructor(public readonly value: string) {
+  private constructor(
+    public readonly value: string,
+    validate = true
+  ) {
     // Discord snowflake ID: 17-19 digit number
-    const discordIdRegex = /^\d{17,19}$/;
-    if (!discordIdRegex.test(value)) {
-      throw new InvalidValueError(
-        'Discord ID',
-        value,
-        'Invalid Discord ID format (must be 17-19 digits)'
-      );
+    if (validate) {
+      const discordIdRegex = /^\d{17,19}$/;
+      if (!discordIdRegex.test(value)) {
+        throw new InvalidValueError(
+          'Discord ID',
+          value,
+          'Invalid Discord ID format (must be 17-19 digits)'
+        );
+      }
     }
   }
 
   static create(value: string): DiscordId {
     return new DiscordId(value);
+  }
+
+  /**
+   * Reconstitute from database without validation.
+   * Use only when loading from trusted data source.
+   */
+  static reconstitute(value: string): DiscordId {
+    return new DiscordId(value, false);
   }
 
   static createOrNull(value: string | null | undefined): DiscordId | null {
@@ -96,20 +139,33 @@ export class DiscordId {
 
 // Discord Username Value Object
 export class DiscordUsername {
-  private constructor(public readonly value: string) {
-    // Discord username: 2-32 characters, alphanumeric and underscore
-    const discordUsernameRegex = /^[a-zA-Z0-9_]{2,32}$/;
-    if (!discordUsernameRegex.test(value)) {
-      throw new InvalidValueError(
-        'Discord username',
-        value,
-        'Invalid Discord username format (must be 2-32 characters, alphanumeric and underscore only)'
-      );
+  private constructor(
+    public readonly value: string,
+    validate = true
+  ) {
+    if (validate) {
+      // Discord username: 2-32 characters, alphanumeric and underscore
+      const discordUsernameRegex = /^[a-zA-Z0-9_]{2,32}$/;
+      if (!discordUsernameRegex.test(value)) {
+        throw new InvalidValueError(
+          'Discord username',
+          value,
+          'Invalid Discord username format (must be 2-32 characters, alphanumeric and underscore only)'
+        );
+      }
     }
   }
 
   static create(value: string): DiscordUsername {
     return new DiscordUsername(value);
+  }
+
+  /**
+   * Reconstitute from database without validation.
+   * Use only when loading from trusted data source.
+   */
+  static reconstitute(value: string): DiscordUsername {
+    return new DiscordUsername(value, false);
   }
 
   static createOrNull(


### PR DESCRIPTION
## Summary

This PR fixes the Discord ID validation error that occurred when querying members via GraphQL. The error was caused by placeholder Discord IDs like `'placeholder_1'` in the database, which don't match the strict 17-19 digit format required for actual Discord snowflake IDs.

## Problem

- Database migration `003_add_multi_tenant_support_compatible.sql` created placeholder Discord IDs for existing members: `'placeholder_1'`, `'placeholder_2'`, etc.
- When GraphQL query tried to fetch members, `Member.reconstitute()` called `DiscordId.create()` which strictly validates Discord ID format
- This caused `InvalidValueError: Discord ID: Invalid Discord ID format (must be 17-19 digits)`

## Solution

- Added `validate` parameter to all value object constructors (`MemberName`, `GithubUsername`, `DiscordId`, `DiscordUsername`)
- Added `reconstitute()` static method to each value object that bypasses validation when loading from database
- Updated `Member.reconstitute()` to use reconstitute methods instead of `Member.create()`

## Changes

- `apps/server/src/domain/member/member.vo.ts`: Add reconstitute methods and validation parameter
- `apps/server/src/domain/member/member.domain.ts`: Update reconstitute method to bypass validation

## Test Plan

- GraphQL query `query { members { name } }` should now return all members without validation errors
- New member creation still enforces valid Discord ID format
- Database integrity is maintained while allowing legacy placeholder values

🤖 Generated with [Claude Code](https://claude.com/claude-code)