### PR TITLE
feat(graphql): add organization/generation member queries and mutations

### DIFF
--- a/apps/server/src/application/commands/change-member-role.command.ts
+++ b/apps/server/src/application/commands/change-member-role.command.ts
@@ -1,0 +1,94 @@
+// ChangeMemberRoleCommand - 조직원 역할 변경 Command
+
+import { Organization } from '../../domain/organization/organization.domain';
+import { Member } from '../../domain/member/member.domain';
+import {
+  OrganizationMember,
+  OrganizationRole,
+} from '../../domain/organization-member/organization-member.domain';
+import { OrganizationRepository } from '../../domain/organization/organization.repository';
+import { MemberRepository } from '../../domain/member/member.repository';
+import { OrganizationMemberRepository } from '../../domain/organization-member/organization-member.repository';
+
+/**
+ * 조직원 역할 변경 요청 데이터
+ */
+export interface ChangeMemberRoleRequest {
+  organizationSlug: string;
+  memberDiscordId: string;
+  newRole: OrganizationRole;
+}
+
+/**
+ * 조직원 역할 변경 결과
+ */
+export interface ChangeMemberRoleResult {
+  organizationMember: OrganizationMember;
+  organization: Organization;
+  member: Member;
+}
+
+/**
+ * 조직원 역할 변경 Command (Use Case)
+ *
+ * 책임:
+ * 1. 조직 존재 확인
+ * 2. 멤버 존재 확인
+ * 3. 조직원 존재 확인
+ * 4. 역할 변경
+ * 5. 저장
+ */
+export class ChangeMemberRoleCommand {
+  constructor(
+    private readonly organizationRepo: OrganizationRepository,
+    private readonly memberRepo: MemberRepository,
+    private readonly organizationMemberRepo: OrganizationMemberRepository
+  ) {}
+
+  async execute(
+    request: ChangeMemberRoleRequest
+  ): Promise<ChangeMemberRoleResult> {
+    // 1. 조직 존재 확인
+    const organization = await this.organizationRepo.findBySlug(
+      request.organizationSlug
+    );
+    if (!organization) {
+      throw new Error(`Organization "${request.organizationSlug}" not found`);
+    }
+
+    // 2. 멤버 존재 확인
+    const member = await this.memberRepo.findByDiscordId(
+      request.memberDiscordId
+    );
+    if (!member) {
+      throw new Error(
+        `Member with Discord ID ${request.memberDiscordId} not found`
+      );
+    }
+
+    // 3. 조직원 존재 확인
+    const organizationMember =
+      await this.organizationMemberRepo.findByOrganizationAndMember(
+        organization.id,
+        member.id
+      );
+
+    if (!organizationMember) {
+      throw new Error(
+        `Member is not part of organization "${request.organizationSlug}"`
+      );
+    }
+
+    // 4. 역할 변경
+    organizationMember.changeRole(request.newRole);
+
+    // 5. 저장
+    await this.organizationMemberRepo.save(organizationMember);
+
+    return {
+      organizationMember,
+      organization,
+      member,
+    };
+  }
+}

--- a/apps/server/src/application/commands/index.ts
+++ b/apps/server/src/application/commands/index.ts
@@ -10,3 +10,4 @@ export * from './add-member-to-organization.command';
 export * from './update-member-status.command';
 export * from './join-organization.command';
 export * from './join-generation.command';
+export * from './change-member-role.command';

--- a/apps/server/src/presentation/graphql/mappers/index.ts
+++ b/apps/server/src/presentation/graphql/mappers/index.ts
@@ -4,3 +4,4 @@ export * from './member.mapper';
 export * from './generation.mapper';
 export * from './cycle.mapper';
 export * from './organization.mapper';
+export * from './organization-member.mapper';

--- a/apps/server/src/presentation/graphql/mappers/organization-member.mapper.ts
+++ b/apps/server/src/presentation/graphql/mappers/organization-member.mapper.ts
@@ -1,0 +1,11 @@
+// OrganizationMember Mapper
+
+import { OrganizationMember } from '@/domain/organization-member/organization-member.domain';
+import { GqlOrganizationMember, GqlMember } from '../types';
+
+export const domainToGraphqlOrganizationMember = (
+  organizationMember: OrganizationMember,
+  member?: GqlMember
+): GqlOrganizationMember => {
+  return new GqlOrganizationMember(organizationMember, member);
+};

--- a/apps/server/src/presentation/graphql/resolvers/generation.resolver.ts
+++ b/apps/server/src/presentation/graphql/resolvers/generation.resolver.ts
@@ -3,17 +3,25 @@
 import {
   container,
   GENERATION_REPO_TOKEN,
+  MEMBER_REPO_TOKEN,
   ORGANIZATION_REPO_TOKEN,
 } from '@/shared/di';
-import type { GenerationRepository, OrganizationRepository } from '@/domain';
+import type {
+  GenerationRepository,
+  MemberRepository,
+  OrganizationRepository,
+} from '@/domain';
 import {
   CreateGenerationCommand,
   GetAllGenerationsQuery,
   GetGenerationByIdQuery,
 } from '@/application';
 import { OrganizationId } from '@/domain/organization/organization.domain';
+import { DrizzleGenerationMemberRepository } from '@/infrastructure/persistence/drizzle';
 import { domainToGraphqlOrganization } from '../mappers';
-import { GqlGeneration } from '../types';
+import { GqlGeneration, GqlGenerationMember, GqlMember } from '../types';
+import { GenerationMember } from '@/domain/generation-member/generation-member.domain';
+import type { GenerationMemberRepository } from '@/domain/generation-member/generation-member.repository';
 
 // ========================================
 // Lazy Dependency Resolution
@@ -26,6 +34,8 @@ let getGenerationByIdQuery: GetGenerationByIdQuery | null = null;
 let createGenerationCommand: CreateGenerationCommand | null = null;
 let generationRepo: GenerationRepository | null = null;
 let organizationRepo: OrganizationRepository | null = null;
+let generationMemberRepo: GenerationMemberRepository | null = null;
+let memberRepo: MemberRepository | null = null;
 
 const getQueries = () => {
   if (
@@ -39,6 +49,8 @@ const getQueries = () => {
     organizationRepo = container.resolve<OrganizationRepository>(
       ORGANIZATION_REPO_TOKEN
     );
+    generationMemberRepo = new DrizzleGenerationMemberRepository();
+    memberRepo = container.resolve<MemberRepository>(MEMBER_REPO_TOKEN);
 
     getAllGenerationsQuery = new GetAllGenerationsQuery(generationRepo);
     getGenerationByIdQuery = new GetGenerationByIdQuery(generationRepo);
@@ -51,8 +63,10 @@ const getQueries = () => {
     getAllGenerationsQuery,
     getGenerationByIdQuery,
     createGenerationCommand,
-    generationRepo,
-    organizationRepo,
+    generationRepo: generationRepo!,
+    organizationRepo: organizationRepo!,
+    generationMemberRepo: generationMemberRepo!,
+    memberRepo: memberRepo!,
   };
 };
 
@@ -60,18 +74,53 @@ const getQueries = () => {
 // Helper Functions
 // ========================================
 
-async function loadGenerationWithOrganization(
+// Helper 함수: GenerationMember를 GqlGenerationMember로 변환
+async function mapToGqlGenerationMember(
+  generationMember: GenerationMember,
+  memberRepo: MemberRepository
+): Promise<GqlGenerationMember> {
+  const member = await memberRepo.findById(generationMember.memberId);
+  if (!member) {
+    throw new Error(`Member ${generationMember.memberId.value} not found`);
+  }
+
+  return new GqlGenerationMember(generationMember, new GqlMember(member));
+}
+
+async function loadGenerationMembers(
+  generationMemberRepo: GenerationMemberRepository,
+  memberRepo: MemberRepository,
+  generationId: number
+): Promise<GqlGenerationMember[]> {
+  const generationMembers =
+    await generationMemberRepo.findByGeneration(generationId);
+  return Promise.all(
+    generationMembers.map((generationMember) =>
+      mapToGqlGenerationMember(generationMember, memberRepo)
+    )
+  );
+}
+
+async function loadGenerationWithOrganizationAndMembers(
   generation: Awaited<ReturnType<GetGenerationByIdQuery['execute']>>
 ): Promise<GqlGeneration | null> {
   if (!generation) return null;
 
-  const { organizationRepo } = getQueries();
-  const organization = await organizationRepo!.findById(
+  const { organizationRepo, generationMemberRepo, memberRepo } = getQueries();
+  const organization = await organizationRepo.findById(
     OrganizationId.create(generation.organizationId)
   );
+  const members = await loadGenerationMembers(
+    generationMemberRepo,
+    memberRepo,
+    generation.id.value
+  );
+
   return new GqlGeneration(
     generation,
-    organization ? domainToGraphqlOrganization(organization) : undefined
+    organization ? domainToGraphqlOrganization(organization) : undefined,
+    undefined,
+    members
   );
 }
 
@@ -82,39 +131,51 @@ async function loadGenerationWithOrganization(
 export const generationQueries = {
   // 기수 전체 조회
   generations: async (organizationSlug?: string): Promise<GqlGeneration[]> => {
-    const { getAllGenerationsQuery, generationRepo, organizationRepo } =
-      getQueries();
+    const {
+      getAllGenerationsQuery,
+      generationRepo,
+      organizationRepo,
+      generationMemberRepo,
+      memberRepo,
+    } = getQueries();
     let generations;
 
     if (organizationSlug) {
-      const organization = await organizationRepo!.findBySlug(organizationSlug);
+      const organization = await organizationRepo.findBySlug(organizationSlug);
       if (!organization) return [];
-      generations = await generationRepo!.findByOrganization(
+      generations = await generationRepo.findByOrganization(
         organization.id.value
       );
     } else {
       generations = await getAllGenerationsQuery.execute();
     }
 
-    const results = await Promise.all(
+    return Promise.all(
       generations.map(async (gen) => {
-        const organization = await organizationRepo!.findById(
+        const organization = await organizationRepo.findById(
           OrganizationId.create(gen.organizationId)
         );
+        const members = await loadGenerationMembers(
+          generationMemberRepo,
+          memberRepo,
+          gen.id.value
+        );
+
         return new GqlGeneration(
           gen,
-          organization ? domainToGraphqlOrganization(organization) : undefined
+          organization ? domainToGraphqlOrganization(organization) : undefined,
+          undefined,
+          members
         );
       })
     );
-    return results;
   },
 
   // 기수 단건 조회
   generation: async (id: number): Promise<GqlGeneration | null> => {
     const { getGenerationByIdQuery } = getQueries();
     const generation = await getGenerationByIdQuery.execute(id);
-    return loadGenerationWithOrganization(generation);
+    return loadGenerationWithOrganizationAndMembers(generation);
   },
 
   // 활성화된 기수 조회
@@ -125,14 +186,12 @@ export const generationQueries = {
     const generation = organizationSlug
       ? await (async () => {
           const organization =
-            await organizationRepo!.findBySlug(organizationSlug);
+            await organizationRepo.findBySlug(organizationSlug);
           if (!organization) return null;
-          return generationRepo!.findActiveByOrganization(
-            organization.id.value
-          );
+          return generationRepo.findActiveByOrganization(organization.id.value);
         })()
-      : await generationRepo!.findActive();
-    return loadGenerationWithOrganization(generation);
+      : await generationRepo.findActive();
+    return loadGenerationWithOrganizationAndMembers(generation);
   },
 };
 
@@ -143,18 +202,19 @@ export const generationMutations = {
     startedAt: string,
     organizationSlug: string
   ): Promise<GqlGeneration> => {
-    const { createGenerationCommand, organizationRepo } = getQueries();
+    const { createGenerationCommand } = getQueries();
     const result = await createGenerationCommand.execute({
       name,
       startedAt: new Date(startedAt),
       organizationSlug,
     });
-    const organization = await organizationRepo!.findById(
-      OrganizationId.create(result.generation.organizationId)
+
+    const generation = await loadGenerationWithOrganizationAndMembers(
+      result.generation
     );
-    return new GqlGeneration(
-      result.generation,
-      organization ? domainToGraphqlOrganization(organization) : undefined
-    );
+    if (!generation) {
+      throw new Error('Created generation could not be loaded');
+    }
+    return generation;
   },
 };

--- a/apps/server/src/presentation/graphql/resolvers/index.ts
+++ b/apps/server/src/presentation/graphql/resolvers/index.ts
@@ -7,6 +7,10 @@ import {
   organizationQueries,
   organizationMutations,
 } from './organization.resolver';
+import {
+  organizationMemberQueries,
+  organizationMemberMutations,
+} from './organization-member.resolver';
 
 // ========================================
 // Query Resolvers 합치기
@@ -17,6 +21,7 @@ export const queryResolvers = {
   ...generationQueries,
   ...cycleQueries,
   ...organizationQueries,
+  ...organizationMemberQueries,
 };
 
 // ========================================
@@ -28,4 +33,5 @@ export const mutationResolvers = {
   ...generationMutations,
   ...cycleMutations,
   ...organizationMutations,
+  ...organizationMemberMutations,
 };

--- a/apps/server/src/presentation/graphql/resolvers/organization-member.resolver.ts
+++ b/apps/server/src/presentation/graphql/resolvers/organization-member.resolver.ts
@@ -1,0 +1,137 @@
+// OrganizationMember Domain Resolvers
+
+import { GetOrganizationMembersQuery } from '@/application';
+import { ChangeMemberRoleCommand } from '@/application';
+import { DrizzleOrganizationMemberRepository } from '@/infrastructure/persistence/drizzle';
+import { DrizzleOrganizationRepository } from '@/infrastructure/persistence/drizzle';
+import { DrizzleMemberRepository } from '@/infrastructure/persistence/drizzle';
+import { GqlOrganizationMember } from '../types';
+import {
+  OrganizationMemberStatus,
+  OrganizationRole,
+} from '@/domain/organization-member/organization-member.vo';
+import { OrganizationMember } from '@/domain/organization-member/organization-member.domain';
+import { Member } from '@/domain/member/member.domain';
+import type { OrganizationMemberDTO } from '@/application/queries/get-organization-members.query';
+
+// ========================================
+// Repository Instances
+// ========================================
+
+const organizationMemberRepo = new DrizzleOrganizationMemberRepository();
+const organizationRepo = new DrizzleOrganizationRepository();
+const memberRepo = new DrizzleMemberRepository();
+
+// ========================================
+// Query & Command Instances
+// ========================================
+
+const getOrganizationMembersQuery = new GetOrganizationMembersQuery(
+  organizationRepo,
+  organizationMemberRepo,
+  memberRepo
+);
+
+const changeMemberRoleCommand = new ChangeMemberRoleCommand(
+  organizationRepo,
+  memberRepo,
+  organizationMemberRepo
+);
+
+// ========================================
+// Helper Functions
+// ========================================
+
+// DTO를 GraphQL 타입으로 변환하는 헬퍼 함수
+function mapToGqlOrganizationMember(
+  memberDTO: OrganizationMemberDTO
+): GqlOrganizationMember {
+  // OrganizationMember 도메인 객체 생성
+  const organizationMember = OrganizationMember.reconstitute({
+    id: memberDTO.id,
+    organizationId: 0, // Not needed for this response
+    memberId: memberDTO.memberId,
+    role: memberDTO.role,
+    status: memberDTO.status,
+    joinedAt: new Date(memberDTO.joinedAt),
+    updatedAt: new Date(),
+  });
+
+  // Member 도메인 객체 생성
+  const member = Member.reconstitute({
+    id: memberDTO.memberId,
+    discordId: memberDTO.memberDiscordId,
+    name: memberDTO.memberName,
+    createdAt: new Date(),
+  });
+
+  return new GqlOrganizationMember(organizationMember, {
+    id: member.id.value,
+    github: member.githubUsername?.value ?? '',
+    discordId: member.discordId.value,
+    name: member.name.value,
+    createdAt: member.createdAt.toISOString(),
+  });
+}
+
+// ========================================
+// Resolvers
+// ========================================
+
+export const organizationMemberQueries = {
+  // 조직의 가입 신청 중(PENDING)인 멤버 목록 조회
+  pendingOrganizationMembers: async (
+    organizationSlug: string
+  ): Promise<GqlOrganizationMember[]> => {
+    const result = await getOrganizationMembersQuery.execute({
+      organizationSlug,
+      status: OrganizationMemberStatus.PENDING,
+    });
+
+    return result.members.map(mapToGqlOrganizationMember);
+  },
+
+  // 조직의 전체 멤버 목록 조회 (상태 필터 지원)
+  organizationMembers: async (
+    organizationSlug: string,
+    status?: string
+  ): Promise<GqlOrganizationMember[]> => {
+    const result = await getOrganizationMembersQuery.execute({
+      organizationSlug,
+      status: status as OrganizationMemberStatus,
+    });
+
+    return result.members.map(mapToGqlOrganizationMember);
+  },
+};
+
+export const organizationMemberMutations = {
+  // 조직원 역할 변경
+  changeMemberRole: async (
+    organizationSlug: string,
+    memberDiscordId: string,
+    newRole: string
+  ): Promise<GqlOrganizationMember> => {
+    const result = await changeMemberRoleCommand.execute({
+      organizationSlug,
+      memberDiscordId,
+      newRole: newRole.toUpperCase() as OrganizationRole,
+    });
+
+    // Member 도메인 객체 생성
+    const member = Member.reconstitute({
+      id: result.member.id.value,
+      discordId: result.member.discordId.value,
+      name: result.member.name.value,
+      createdAt: result.member.createdAt,
+    });
+
+    return new GqlOrganizationMember(result.organizationMember, {
+      id: member.id.value,
+      github: member.githubUsername?.value ?? '',
+      discordId: member.discordId.value,
+      name: member.name.value,
+      createdAt: member.createdAt.toISOString(),
+    });
+  },
+};

--- a/apps/server/src/presentation/graphql/resolvers/organization-member.resolver.ts
+++ b/apps/server/src/presentation/graphql/resolvers/organization-member.resolver.ts
@@ -5,7 +5,7 @@ import { ChangeMemberRoleCommand } from '@/application';
 import { DrizzleOrganizationMemberRepository } from '@/infrastructure/persistence/drizzle';
 import { DrizzleOrganizationRepository } from '@/infrastructure/persistence/drizzle';
 import { DrizzleMemberRepository } from '@/infrastructure/persistence/drizzle';
-import { GqlOrganizationMember } from '../types';
+import { GqlMember, GqlOrganizationMember } from '../types';
 import {
   OrganizationMemberStatus,
   OrganizationRole,
@@ -65,13 +65,7 @@ function mapToGqlOrganizationMember(
     createdAt: new Date(),
   });
 
-  return new GqlOrganizationMember(organizationMember, {
-    id: member.id.value,
-    github: member.githubUsername?.value ?? '',
-    discordId: member.discordId.value,
-    name: member.name.value,
-    createdAt: member.createdAt.toISOString(),
-  });
+  return new GqlOrganizationMember(organizationMember, new GqlMember(member));
 }
 
 // ========================================
@@ -126,12 +120,9 @@ export const organizationMemberMutations = {
       createdAt: result.member.createdAt,
     });
 
-    return new GqlOrganizationMember(result.organizationMember, {
-      id: member.id.value,
-      github: member.githubUsername?.value ?? '',
-      discordId: member.discordId.value,
-      name: member.name.value,
-      createdAt: member.createdAt.toISOString(),
-    });
+    return new GqlOrganizationMember(
+      result.organizationMember,
+      new GqlMember(member)
+    );
   },
 };

--- a/apps/server/src/presentation/graphql/resolvers/organization.resolver.ts
+++ b/apps/server/src/presentation/graphql/resolvers/organization.resolver.ts
@@ -1,10 +1,20 @@
 // Organization Domain Resolvers
 
-import { container, ORGANIZATION_REPO_TOKEN } from '@/shared/di';
-import type { OrganizationRepository } from '@/domain';
+import {
+  container,
+  MEMBER_REPO_TOKEN,
+  ORGANIZATION_MEMBER_REPO_TOKEN,
+  ORGANIZATION_REPO_TOKEN,
+} from '@/shared/di';
+import type {
+  MemberRepository,
+  OrganizationMemberRepository,
+  OrganizationRepository,
+} from '@/domain';
 import { GetOrganizationQuery } from '@/application';
-import { GqlOrganization } from '../types';
+import { GqlOrganization, GqlOrganizationMember } from '../types';
 import { domainToGraphqlOrganization } from '../mappers';
+import { OrganizationMember } from '@/domain/organization-member/organization-member.domain';
 
 // ========================================
 // Lazy Dependency Resolution
@@ -14,43 +24,114 @@ import { domainToGraphqlOrganization } from '../mappers';
 
 let getOrganizationQuery: GetOrganizationQuery | null = null;
 let organizationRepo: OrganizationRepository | null = null;
+let organizationMemberRepo: OrganizationMemberRepository | null = null;
+let memberRepo: MemberRepository | null = null;
 
 const getQueries = () => {
   if (!getOrganizationQuery) {
     organizationRepo = container.resolve<OrganizationRepository>(
       ORGANIZATION_REPO_TOKEN
     );
+    organizationMemberRepo = container.resolve<OrganizationMemberRepository>(
+      ORGANIZATION_MEMBER_REPO_TOKEN
+    );
+    memberRepo = container.resolve<MemberRepository>(MEMBER_REPO_TOKEN);
     getOrganizationQuery = new GetOrganizationQuery(organizationRepo);
   }
-  return { getOrganizationQuery, organizationRepo };
+  return {
+    getOrganizationQuery,
+    organizationRepo: organizationRepo!,
+    organizationMemberRepo: organizationMemberRepo!,
+    memberRepo: memberRepo!,
+  };
 };
 
 // ========================================
 // Resolvers
 // ========================================
 
+// Helper 함수: OrganizationMember를 GqlOrganizationMember로 변환
+async function mapToGqlOrganizationMember(
+  organizationMember: OrganizationMember,
+  memberRepo: MemberRepository
+): Promise<GqlOrganizationMember> {
+  const member = await memberRepo.findById(organizationMember.memberId);
+  if (!member) {
+    throw new Error(`Member ${organizationMember.memberId.value} not found`);
+  }
+
+  return new GqlOrganizationMember(organizationMember, {
+    id: member.id.value,
+    github: member.githubUsername?.value ?? '',
+    discordId: member.discordId.value,
+    name: member.name.value,
+    createdAt: member.createdAt.toISOString(),
+  });
+}
+
+async function loadOrganizationMembers(
+  organizationMemberRepo: OrganizationMemberRepository,
+  memberRepo: MemberRepository,
+  organizationId: Parameters<OrganizationMemberRepository['findByOrganization']>[0]
+): Promise<GqlOrganizationMember[]> {
+  const organizationMembers =
+    await organizationMemberRepo.findByOrganization(organizationId);
+  return Promise.all(
+    organizationMembers.map((organizationMember) =>
+      mapToGqlOrganizationMember(organizationMember, memberRepo)
+    )
+  );
+}
+
 export const organizationQueries = {
   // 조직 전체 조회
   organizations: async (): Promise<GqlOrganization[]> => {
-    const { organizationRepo } = getQueries();
-    const orgs = await organizationRepo!.findAll();
-    return orgs.map((org) => domainToGraphqlOrganization(org));
+    const { organizationRepo, organizationMemberRepo, memberRepo } =
+      getQueries();
+    const orgs = await organizationRepo.findAll();
+    return Promise.all(
+      orgs.map(async (org) => {
+        const members = await loadOrganizationMembers(
+          organizationMemberRepo,
+          memberRepo,
+          org.id
+        );
+        return domainToGraphqlOrganization(org, members);
+      })
+    );
   },
 
   // 활성화된 조직 조회
   activeOrganizations: async (): Promise<GqlOrganization[]> => {
-    const { organizationRepo } = getQueries();
-    const orgs = await organizationRepo!.findActive();
-    return orgs.map((org) => domainToGraphqlOrganization(org));
+    const { organizationRepo, organizationMemberRepo, memberRepo } =
+      getQueries();
+    const orgs = await organizationRepo.findActive();
+    return Promise.all(
+      orgs.map(async (org) => {
+        const members = await loadOrganizationMembers(
+          organizationMemberRepo,
+          memberRepo,
+          org.id
+        );
+        return domainToGraphqlOrganization(org, members);
+      })
+    );
   },
 
   // 조직 단건 조회 (slug로)
   organization: async (slug: string): Promise<GqlOrganization | null> => {
-    const { getOrganizationQuery } = getQueries();
+    const { getOrganizationQuery, organizationMemberRepo, memberRepo } =
+      getQueries();
     const result = await getOrganizationQuery.execute({ slug });
-    return result.organization
-      ? domainToGraphqlOrganization(result.organization)
-      : null;
+    if (!result.organization) return null;
+
+    const members = await loadOrganizationMembers(
+      organizationMemberRepo,
+      memberRepo,
+      result.organization.id
+    );
+
+    return domainToGraphqlOrganization(result.organization, members);
   },
 };
 

--- a/apps/server/src/presentation/graphql/resolvers/organization.resolver.ts
+++ b/apps/server/src/presentation/graphql/resolvers/organization.resolver.ts
@@ -12,7 +12,7 @@ import type {
   OrganizationRepository,
 } from '@/domain';
 import { GetOrganizationQuery } from '@/application';
-import { GqlOrganization, GqlOrganizationMember } from '../types';
+import { GqlMember, GqlOrganization, GqlOrganizationMember } from '../types';
 import { domainToGraphqlOrganization } from '../mappers';
 import { OrganizationMember } from '@/domain/organization-member/organization-member.domain';
 
@@ -60,19 +60,15 @@ async function mapToGqlOrganizationMember(
     throw new Error(`Member ${organizationMember.memberId.value} not found`);
   }
 
-  return new GqlOrganizationMember(organizationMember, {
-    id: member.id.value,
-    github: member.githubUsername?.value ?? '',
-    discordId: member.discordId.value,
-    name: member.name.value,
-    createdAt: member.createdAt.toISOString(),
-  });
+  return new GqlOrganizationMember(organizationMember, new GqlMember(member));
 }
 
 async function loadOrganizationMembers(
   organizationMemberRepo: OrganizationMemberRepository,
   memberRepo: MemberRepository,
-  organizationId: Parameters<OrganizationMemberRepository['findByOrganization']>[0]
+  organizationId: Parameters<
+    OrganizationMemberRepository['findByOrganization']
+  >[0]
 ): Promise<GqlOrganizationMember[]> {
   const organizationMembers =
     await organizationMemberRepo.findByOrganization(organizationId);


### PR DESCRIPTION
## Summary

- 조직원 조회 및 역할 변경 GraphQL API 추가
- `organizations` 및 `generations` 쿼리에서 `members` 필드 로드 지원

## Changes

### 1. 조직원 쿼리 기능 추가
- `pendingOrganizationMembers(organizationSlug)` - PENDING 상태인 가입 신청자 목록 조회
- `organizationMembers(organizationSlug, status?)` - 조직원 목록 조회 (상태 필터 지원)

### 2. 조직원 역할 변경 Mutation 추가
- `changeMemberRole(organizationSlug, memberDiscordId, newRole)` - 조직원 역할 변경
- 지원 역할: `OWNER`, `ADMIN`, `MEMBER`

### 3. Organizations 쿼리에서 members 로드
- 이전: `organizations.members` → `null`
- 변경: `organizations.members` → 조직원 목록 반환

### 4. Generations 쿼리에서 members 로드
- 이전: `generations.members` → `null`
- 변경: `generations.members` → 기수원 목록 반환

## Test Plan

- [ ] `pendingOrganizationMembers` 쿼리로 PENDING 상태 멤버 조회 확인
- [ ] `changeMemberRole` mutation으로 역할 변경 확인
- [ ] `organizations` 쿼리 시 `members` 필드 반환 확인
- [ ] `generations` 쿼리 시 `members` 필드 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)