### PR TITLE
fix: restrict discord bot execution to production only

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -126,24 +126,29 @@ export { graphql };
 // Discord Bot Integration
 // ========================================
 
-if (env.DISCORD_BOT_TOKEN && env.DISCORD_CLIENT_ID) {
-  void (async () => {
-    try {
-      const { createCommands } =
-        await import('./presentation/discord/commands');
-      const commands = createCommands();
-      await registerSlashCommands(commands);
+// Only start Discord Bot in production
+if (env.NODE_ENV === 'production') {
+  if (env.DISCORD_BOT_TOKEN && env.DISCORD_CLIENT_ID) {
+    void (async () => {
+      try {
+        const { createCommands } =
+          await import('./presentation/discord/commands');
+        const commands = createCommands();
+        await registerSlashCommands(commands);
 
-      const discordBot = createDiscordBot();
-      await discordBot.login(env.DISCORD_BOT_TOKEN);
-    } catch (error) {
-      console.error('❌ Failed to start Discord Bot:', error);
-    }
-  })();
+        const discordBot = createDiscordBot();
+        await discordBot.login(env.DISCORD_BOT_TOKEN);
+      } catch (error) {
+        console.error('❌ Failed to start Discord Bot:', error);
+      }
+    })();
+  } else {
+    console.log(
+      '⚠️  Discord Bot not configured. Set DISCORD_BOT_TOKEN and DISCORD_CLIENT_ID to enable.'
+    );
+  }
 } else {
-  console.log(
-    '⚠️  Discord Bot not configured. Set DISCORD_BOT_TOKEN and DISCORD_CLIENT_ID to enable.'
-  );
+  console.log('ℹ️  Discord Bot is disabled in development mode');
 }
 
 serve(app, (info) => {


### PR DESCRIPTION
## Summary
- Prevents Discord bot from starting in development mode
- Only registers slash commands in production to avoid duplicates
- Adds informative logging when bot is disabled in development

## Test plan
- Verify bot doesn't start in development mode (shows "Discord Bot is disabled in development mode" log)
- Verify bot starts normally in production with slash commands registered
- Ensure no duplicate command registrations between local and production

🤖 Generated with [Claude Code](https://claude.com/claude-code)