### PR TITLE
feat: add organization filtering to Discord commands

### DIFF
--- a/apps/server/src/presentation/discord/autocompletions/GenerationAutocomplete.ts
+++ b/apps/server/src/presentation/discord/autocompletions/GenerationAutocomplete.ts
@@ -1,5 +1,6 @@
 import { AutocompleteInteraction } from 'discord.js';
 import { GenerationRepository } from '@/domain/generation/generation.repository';
+import { Generation } from '@/domain/generation/generation.domain';
 import { OrganizationRepository } from '@/domain/organization/organization.repository';
 
 export class GenerationAutocomplete {
@@ -14,7 +15,7 @@ export class GenerationAutocomplete {
     // organization 옵션이 있는 경우 해당 조직의 기수만 표시
     const organizationSlug = interaction.options.getString('organization');
 
-    let generations;
+    let generations: Generation[];
 
     if (organizationSlug) {
       // 조직으로 필터링

--- a/apps/server/src/presentation/discord/autocompletions/GenerationAutocomplete.ts
+++ b/apps/server/src/presentation/discord/autocompletions/GenerationAutocomplete.ts
@@ -1,12 +1,36 @@
 import { AutocompleteInteraction } from 'discord.js';
 import { GenerationRepository } from '@/domain/generation/generation.repository';
+import { OrganizationRepository } from '@/domain/organization/organization.repository';
 
 export class GenerationAutocomplete {
-  constructor(private readonly generationRepo: GenerationRepository) {}
+  constructor(
+    private readonly generationRepo: GenerationRepository,
+    private readonly organizationRepo: OrganizationRepository
+  ) {}
 
   async execute(interaction: AutocompleteInteraction): Promise<void> {
     const focusedValue = interaction.options.getFocused();
-    const generations = await this.generationRepo.findAll();
+
+    // organization 옵션이 있는 경우 해당 조직의 기수만 표시
+    const organizationSlug = interaction.options.getString('organization');
+
+    let generations;
+
+    if (organizationSlug) {
+      // 조직으로 필터링
+      const organization =
+        await this.organizationRepo.findBySlug(organizationSlug);
+      if (organization) {
+        generations = await this.generationRepo.findByOrganization(
+          organization.id.value
+        );
+      } else {
+        generations = [];
+      }
+    } else {
+      // 모든 기수 표시
+      generations = await this.generationRepo.findAll();
+    }
 
     const filtered = generations
       .filter((gen) => gen.name.includes(focusedValue))

--- a/apps/server/src/presentation/discord/commands/CycleCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CycleCommand.ts
@@ -23,9 +23,17 @@ export class CycleCommand implements DiscordCommand {
         .setDescription('특정 기수의 주차 목록을 확인합니다')
         .addStringOption((option) =>
           option
+            .setName('organization')
+            .setDescription('조직')
+            .setRequired(true)
+            .setAutocomplete(true)
+        )
+        .addStringOption((option) =>
+          option
             .setName('generation')
             .setDescription('기수 이름 (예: 똥글똥글 1기)')
             .setRequired(true)
+            .setAutocomplete(true)
         )
     );
 
@@ -143,8 +151,8 @@ export class CycleCommand implements DiscordCommand {
     }
 
     try {
+      const organizationSlug = interaction.options.getString('organization', true);
       const generationName = interaction.options.getString('generation', true);
-      const organizationSlug = 'dongueldonguel';
 
       const cycles = await this.findCyclesByGeneration(
         generationName,

--- a/apps/server/src/presentation/discord/commands/CycleCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CycleCommand.ts
@@ -151,7 +151,10 @@ export class CycleCommand implements DiscordCommand {
     }
 
     try {
-      const organizationSlug = interaction.options.getString('organization', true);
+      const organizationSlug = interaction.options.getString(
+        'organization',
+        true
+      );
       const generationName = interaction.options.getString('generation', true);
 
       const cycles = await this.findCyclesByGeneration(

--- a/apps/server/src/presentation/discord/commands/GenerationCommand.ts
+++ b/apps/server/src/presentation/discord/commands/GenerationCommand.ts
@@ -37,7 +37,9 @@ export class GenerationCommand implements DiscordCommand {
         .addStringOption((option) =>
           option
             .setName('organization')
-            .setDescription('조직 (선택사항 - 미입력 시 모든 활성화된 조직 표시)')
+            .setDescription(
+              '조직 (선택사항 - 미입력 시 모든 활성화된 조직 표시)'
+            )
             .setRequired(false)
             .setAutocomplete(true)
         )
@@ -96,7 +98,10 @@ export class GenerationCommand implements DiscordCommand {
     await interaction.deferReply({ ephemeral: true });
 
     try {
-      const organizationSlug = interaction.options.getString('organization', true);
+      const organizationSlug = interaction.options.getString(
+        'organization',
+        true
+      );
       const generationName = interaction.options.getString('name', true);
 
       if (!interaction.user) {
@@ -234,7 +239,10 @@ export class GenerationCommand implements DiscordCommand {
     await interaction.deferReply();
 
     try {
-      const organizationSlug = interaction.options.getString('organization', true);
+      const organizationSlug = interaction.options.getString(
+        'organization',
+        true
+      );
       const generationName = interaction.options.getString('name', true);
 
       // 조직 찾기

--- a/apps/server/src/presentation/discord/commands/GenerationCommand.ts
+++ b/apps/server/src/presentation/discord/commands/GenerationCommand.ts
@@ -17,6 +17,13 @@ export class GenerationCommand implements DiscordCommand {
         .setDescription('기수에 참여합니다 (조직원만 가능)')
         .addStringOption((option) =>
           option
+            .setName('organization')
+            .setDescription('조직')
+            .setRequired(true)
+            .setAutocomplete(true)
+        )
+        .addStringOption((option) =>
+          option
             .setName('name')
             .setDescription('기수 이름 (예: 똥글똥글 1기)')
             .setRequired(true)
@@ -27,11 +34,25 @@ export class GenerationCommand implements DiscordCommand {
       subcommand
         .setName('current')
         .setDescription('현재 활성화된 기수 정보를 확인합니다')
+        .addStringOption((option) =>
+          option
+            .setName('organization')
+            .setDescription('조직 (선택사항 - 미입력 시 모든 활성화된 조직 표시)')
+            .setRequired(false)
+            .setAutocomplete(true)
+        )
     )
     .addSubcommand((subcommand) =>
       subcommand
         .setName('status')
         .setDescription('기수 참여 현황을 확인합니다')
+        .addStringOption((option) =>
+          option
+            .setName('organization')
+            .setDescription('조직')
+            .setRequired(true)
+            .setAutocomplete(true)
+        )
         .addStringOption((option) =>
           option
             .setName('name')
@@ -75,6 +96,7 @@ export class GenerationCommand implements DiscordCommand {
     await interaction.deferReply({ ephemeral: true });
 
     try {
+      const organizationSlug = interaction.options.getString('organization', true);
       const generationName = interaction.options.getString('name', true);
 
       if (!interaction.user) {
@@ -93,12 +115,24 @@ export class GenerationCommand implements DiscordCommand {
         return;
       }
 
-      // 기수 찾기
-      const generations = await this.generationRepo.findAll();
+      // 조직 찾기
+      const organization =
+        await this.organizationRepo.findBySlug(organizationSlug);
+      if (!organization) {
+        await interaction.editReply({
+          content: '❌ 조직을 찾을 수 없습니다.',
+        });
+        return;
+      }
+
+      // 해당 조직의 기수 찾기
+      const generations = await this.generationRepo.findByOrganization(
+        organization.id.value
+      );
       const generation = generations.find((g) => g.name === generationName);
       if (!generation) {
         await interaction.editReply({
-          content: '❌ 기수를 찾을 수 없습니다.',
+          content: `❌ "${organizationSlug}" 조직에서 "${generationName}" 기수를 찾을 수 없습니다.`,
         });
         return;
       }
@@ -200,14 +234,27 @@ export class GenerationCommand implements DiscordCommand {
     await interaction.deferReply();
 
     try {
+      const organizationSlug = interaction.options.getString('organization', true);
       const generationName = interaction.options.getString('name', true);
 
-      // 기수 찾기
-      const generations = await this.generationRepo.findAll();
+      // 조직 찾기
+      const organization =
+        await this.organizationRepo.findBySlug(organizationSlug);
+      if (!organization) {
+        await interaction.editReply({
+          content: `❌ "${organizationSlug}" 조직을 찾을 수 없습니다.`,
+        });
+        return;
+      }
+
+      // 해당 조직의 기수 찾기
+      const generations = await this.generationRepo.findByOrganization(
+        organization.id.value
+      );
       const generation = generations.find((g) => g.name === generationName);
       if (!generation) {
         await interaction.editReply({
-          content: `❌ "${generationName}" 기수를 찾을 수 없습니다.`,
+          content: `❌ "${organizationSlug}" 조직에서 "${generationName}" 기수를 찾을 수 없습니다.`,
         });
         return;
       }

--- a/apps/server/src/shared/di/registry.ts
+++ b/apps/server/src/shared/di/registry.ts
@@ -237,7 +237,11 @@ export function registerDependencies(): void {
 
   container.register(
     GENERATION_AUTOCOMPLETE_TOKEN,
-    () => new GenerationAutocomplete(container.resolve(GENERATION_REPO_TOKEN)),
+    () =>
+      new GenerationAutocomplete(
+        container.resolve(GENERATION_REPO_TOKEN),
+        container.resolve(ORGANIZATION_REPO_TOKEN)
+      ),
     'singleton'
   );
 }


### PR DESCRIPTION
## Summary
- Add organization parameter to /cycle list command
- Add organization filtering to /generation join and status commands  
- Add organization option to /generation current (optional)
- Update GenerationAutocomplete to filter by organization
- Add OrganizationRepository dependency to GenerationAutocomplete
- Remove hardcoded organization slug from CycleCommand

Changes improve user experience by allowing organization-specific command usage and preventing cross-organization data access.

## Test plan
- Test `/cycle list` with different organizations
- Test `/generation join` with organization + generation filtering
- Test `/generation status` with organization + generation filtering  
- Test `/generation current` with and without organization parameter
- Verify autocomplete only shows relevant generations for selected organization
- Ensure no breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)