### PR TITLE
fix: resolve N+1 query issues in Discord commands

### DIFF
--- a/apps/server/src/domain/generation-member/generation-member.repository.ts
+++ b/apps/server/src/domain/generation-member/generation-member.repository.ts
@@ -36,6 +36,23 @@ export interface GenerationMemberRepository {
   findByMember(memberId: MemberId): Promise<GenerationMember[]>;
 
   /**
+   * 멤버가 속한 모든 기수를 기수 및 조직 정보와 함께 조회 (N+1 해결)
+   */
+  findByMemberWithGenerations(memberId: MemberId): Promise<
+    Array<{
+      generationMember: GenerationMember;
+      generation: {
+        id: number;
+        name: string;
+        organizationId: number;
+        startedAt: Date;
+        isActive: boolean;
+      } | null;
+      organization: { id: number; name: string } | null;
+    }>
+  >;
+
+  /**
    * 기수원 삭제
    */
   delete(generationMember: GenerationMember): Promise<void>;

--- a/apps/server/src/domain/generation/generation.repository.ts
+++ b/apps/server/src/domain/generation/generation.repository.ts
@@ -9,4 +9,13 @@ export interface GenerationRepository {
   findActiveByOrganization(organizationId: number): Promise<Generation | null>;
   findByOrganization(organizationId: number): Promise<Generation[]>;
   findAll(): Promise<Generation[]>;
+
+  // 모든 기수를 사이클 수와 기수원 수와 함께 조회 (N+1 해결)
+  findAllWithStats(): Promise<
+    Array<{
+      generation: Generation;
+      cycleCount: number;
+      memberCount: number;
+    }>
+  >;
 }

--- a/apps/server/src/domain/organization-member/organization-member.repository.ts
+++ b/apps/server/src/domain/organization-member/organization-member.repository.ts
@@ -59,4 +59,12 @@ export interface OrganizationMemberRepository {
 
   // 조직의 활성 멤버 수 조회
   countActiveByOrganization(organizationId: OrganizationId): Promise<number>;
+
+  // 멤버가 속한 모든 조직을 조직 정보와 함께 조회 (N+1 해결)
+  findByMemberWithOrganizations(memberId: MemberId): Promise<
+    Array<{
+      organizationMember: OrganizationMember;
+      organization: { id: number; name: string } | null;
+    }>
+  >;
 }

--- a/apps/server/src/presentation/discord/commands/GenerationCommand.ts
+++ b/apps/server/src/presentation/discord/commands/GenerationCommand.ts
@@ -310,7 +310,7 @@ export class GenerationCommand implements DiscordCommand {
     await interaction.deferReply();
 
     try {
-      const allGenerations = await this.generationRepo.findAll();
+      const allGenerations = await this.generationRepo.findAllWithStats();
 
       if (allGenerations.length === 0) {
         await interaction.editReply({
@@ -321,16 +321,10 @@ export class GenerationCommand implements DiscordCommand {
 
       let message = `📋 **기수 목록** (총 ${allGenerations.length}개)\n\n`;
 
-      for (const generation of allGenerations) {
-        const cycles = await this.cycleRepo.findByGeneration(
-          generation.id.value
-        );
-        const generationMembers =
-          await this.generationMemberRepo.findByGeneration(generation.id.value);
-
+      for (const { generation, cycleCount, memberCount } of allGenerations) {
         message += `**${generation.name}**\n`;
-        message += `   참여자: ${generationMembers.length}명 | `;
-        message += `진행 주차: ${cycles.length}주차\n`;
+        message += `   참여자: ${memberCount}명 | `;
+        message += `진행 주차: ${cycleCount}주차\n`;
         message += `   시작일: ${new Date(generation.startedAt).toLocaleDateString('ko-KR')}\n\n`;
       }
 

--- a/apps/server/src/presentation/discord/commands/index.ts
+++ b/apps/server/src/presentation/discord/commands/index.ts
@@ -70,13 +70,7 @@ const getCycleStatusQuery = new GetCycleStatusQuery(
 // Command instances
 export const createCommands = (): DiscordCommand[] => {
   return [
-    new MeCommand(
-      memberRepo,
-      organizationRepo,
-      organizationMemberRepo,
-      generationRepo,
-      generationMemberRepo
-    ),
+    new MeCommand(memberRepo, organizationMemberRepo, generationMemberRepo),
     new MemberCommand(
       createMemberCommand,
       updateMemberStatusCommand,


### PR DESCRIPTION
## Summary
This PR resolves N+1 query issues in Discord commands that were causing performance problems when fetching member organizations, generation memberships, and generation lists.

### Changes Made
- Added optimized repository methods to fetch related data in single queries
- Updated command handlers to use these optimized methods
- Cleaned up unused dependencies
- Fixed formatting and linting issues

### Detailed Changes

#### Repository Methods Added
1. **OrganizationMemberRepository.findByMemberWithOrganizations()**
   - Before: 1 query to find org members + N queries for org details
   - After: Single LEFT JOIN query

2. **GenerationMemberRepository.findByMemberWithGenerations()**
   - Before: 1 query to find gen members + N queries for gens + N queries for orgs
   - After: Single INNER JOIN query for all related data

3. **GenerationRepository.findAllWithStats()**
   - Before: 1 query to find generations + N queries for cycles + N queries for members
   - After: Single query with LEFT JOIN and GROUP BY for stats

#### Command Updates
- **MeCommand.handleOrganizations**: Now uses `findByMemberWithOrganizations()` instead of looping and calling `organizationRepo.findById()`
- **MeCommand.handleGenerations**: Now uses `findByMemberWithGenerations()` instead of calling multiple queries
- **GenerationCommand.handleList**: Now uses `findAllWithStats()` instead of querying cycles and members separately

### Performance Impact
- **Before**: Operations required 1 + N + M database queries
- **After**: Single JOIN query fetches all required data
- Significant improvement for lists with many items (e.g., member organizations, generation lists)

### Testing
- All ESLint checks pass
- TypeScript compilation succeeds  
- Prettier formatting verified
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)