### PR TITLE
chore: add Cloudflare Workers migration scaffold

### DIFF
--- a/apps/server/src/infrastructure/external/discord/discord.messages.test.ts
+++ b/apps/server/src/infrastructure/external/discord/discord.messages.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createReminderMessage,
+  createStatusMessage,
+  createSubmissionMessage,
+  sendDiscordWebhook,
+} from './discord.messages';
+
+describe('Discord message UX', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-09T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('creates an action-oriented submission completion message', () => {
+    const message = createSubmissionMessage(
+      '박준형',
+      'https://blog.example.com/post',
+      '똥글똥글 2기 7주차'
+    );
+
+    expect(message.content).toContain('박준형님 제출 완료');
+    expect(message.embeds?.[0]?.title).toBe('똥글똥글 2기 7주차 제출 완료');
+    expect(message.embeds?.[0]?.description).toContain('정상 기록됐어요');
+    expect(message.embeds?.[0]?.description).toContain('[글 보러가기](https://blog.example.com/post)');
+    expect(message.embeds?.[0]?.description).toContain('/cycle status');
+  });
+
+  it('creates an action-oriented reminder for deadlines more than a day away', () => {
+    const deadline = new Date('2026-05-10T03:00:00.000Z');
+
+    const message = createReminderMessage('똥글똥글 2기 7주차', deadline, [
+      '김항해',
+      '박준형',
+    ]);
+
+    expect(message.content).toContain('마감이 얼마 남지 않았어요');
+    expect(message.embeds?.[0]?.description).toContain('남은 시간: 1일 3시간');
+    expect(message.embeds?.[0]?.description).toContain('아직 제출 전: 2명');
+    expect(message.embeds?.[0]?.description).toContain('- 김항해');
+    expect(message.embeds?.[0]?.description).toContain('GitHub 이슈 댓글에 링크를 남깁니다');
+    expect(message.embeds?.[0]?.description).toContain('/me info');
+  });
+
+  it('formats reminders below one day in hours', () => {
+    const deadline = new Date('2026-05-09T05:00:00.000Z');
+
+    const message = createReminderMessage('똥글똥글 2기 7주차', deadline, ['박준형']);
+
+    expect(message.embeds?.[0]?.description).toContain('남은 시간: 5시간');
+  });
+
+  it('creates a progress-focused status message for partial submissions', () => {
+    const message = createStatusMessage(
+      '똥글똥글 2기 7주차',
+      ['김항해', '박준형'],
+      ['이프론트'],
+      new Date('2026-05-10T14:59:59.000Z')
+    );
+
+    const embed = message.embeds?.[0];
+    expect(embed?.description).toContain('진행률: 2 / 3명 제출, 67%');
+    expect(embed?.description).toContain('남은 인원: 1명');
+    expect(embed?.fields?.[0]?.name).toBe('✅ 제출 2명');
+    expect(embed?.fields?.[0]?.value).toContain('- 김항해');
+    expect(embed?.fields?.[1]?.name).toBe('⏳ 아직 미제출 1명');
+    expect(embed?.fields?.[1]?.value).toContain('- 이프론트');
+  });
+
+  it('celebrates when everyone submitted', () => {
+    const message = createStatusMessage(
+      '똥글똥글 2기 7주차',
+      ['김항해', '박준형'],
+      [],
+      new Date('2026-05-10T14:59:59.000Z')
+    );
+
+    const embed = message.embeds?.[0];
+    expect(embed?.description).toContain('🎉 전원 제출 완료!');
+    expect(embed?.fields?.[1]?.value).toContain('이번 주차 모든 참여자가 제출을 완료했어요');
+  });
+
+  it('makes zero submissions explicit', () => {
+    const message = createStatusMessage(
+      '똥글똥글 2기 7주차',
+      [],
+      ['김항해', '박준형'],
+      new Date('2026-05-10T14:59:59.000Z')
+    );
+
+    const embed = message.embeds?.[0];
+    expect(embed?.description).toContain('진행률: 0 / 2명 제출, 0%');
+    expect(embed?.fields?.[0]?.value).toContain('아직 제출자가 없어요');
+  });
+
+  it('handles status with no participants defensively', () => {
+    const message = createStatusMessage(
+      '똥글똥글 2기 7주차',
+      [],
+      [],
+      new Date('2026-05-10T14:59:59.000Z')
+    );
+
+    expect(message.embeds?.[0]?.description).toContain('진행률: 0 / 0명 제출, 0%');
+  });
+
+  it('sends a Discord webhook payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await sendDiscordWebhook('https://discord.example/webhook', {
+      content: 'hello',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://discord.example/webhook', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: 'hello' }),
+    });
+  });
+
+  it('throws when Discord webhook sending fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, statusText: 'Bad Request' })
+    );
+
+    await expect(
+      sendDiscordWebhook('https://discord.example/webhook', { content: 'hello' })
+    ).rejects.toThrow('Discord webhook failed: Bad Request');
+  });
+});

--- a/apps/server/src/infrastructure/external/discord/discord.messages.test.ts
+++ b/apps/server/src/infrastructure/external/discord/discord.messages.test.ts
@@ -26,7 +26,9 @@ describe('Discord message UX', () => {
     expect(message.content).toContain('박준형님 제출 완료');
     expect(message.embeds?.[0]?.title).toBe('똥글똥글 2기 7주차 제출 완료');
     expect(message.embeds?.[0]?.description).toContain('정상 기록됐어요');
-    expect(message.embeds?.[0]?.description).toContain('[글 보러가기](https://blog.example.com/post)');
+    expect(message.embeds?.[0]?.description).toContain(
+      '[글 보러가기](https://blog.example.com/post)'
+    );
     expect(message.embeds?.[0]?.description).toContain('/cycle status');
   });
 
@@ -42,14 +44,18 @@ describe('Discord message UX', () => {
     expect(message.embeds?.[0]?.description).toContain('남은 시간: 1일 3시간');
     expect(message.embeds?.[0]?.description).toContain('아직 제출 전: 2명');
     expect(message.embeds?.[0]?.description).toContain('- 김항해');
-    expect(message.embeds?.[0]?.description).toContain('GitHub 이슈 댓글에 링크를 남깁니다');
+    expect(message.embeds?.[0]?.description).toContain(
+      'GitHub 이슈 댓글에 링크를 남깁니다'
+    );
     expect(message.embeds?.[0]?.description).toContain('/me info');
   });
 
   it('formats reminders below one day in hours', () => {
     const deadline = new Date('2026-05-09T05:00:00.000Z');
 
-    const message = createReminderMessage('똥글똥글 2기 7주차', deadline, ['박준형']);
+    const message = createReminderMessage('똥글똥글 2기 7주차', deadline, [
+      '박준형',
+    ]);
 
     expect(message.embeds?.[0]?.description).toContain('남은 시간: 5시간');
   });
@@ -81,7 +87,9 @@ describe('Discord message UX', () => {
 
     const embed = message.embeds?.[0];
     expect(embed?.description).toContain('🎉 전원 제출 완료!');
-    expect(embed?.fields?.[1]?.value).toContain('이번 주차 모든 참여자가 제출을 완료했어요');
+    expect(embed?.fields?.[1]?.value).toContain(
+      '이번 주차 모든 참여자가 제출을 완료했어요'
+    );
   });
 
   it('makes zero submissions explicit', () => {
@@ -105,7 +113,9 @@ describe('Discord message UX', () => {
       new Date('2026-05-10T14:59:59.000Z')
     );
 
-    expect(message.embeds?.[0]?.description).toContain('진행률: 0 / 0명 제출, 0%');
+    expect(message.embeds?.[0]?.description).toContain(
+      '진행률: 0 / 0명 제출, 0%'
+    );
   });
 
   it('sends a Discord webhook payload', async () => {
@@ -130,7 +140,9 @@ describe('Discord message UX', () => {
     );
 
     await expect(
-      sendDiscordWebhook('https://discord.example/webhook', { content: 'hello' })
+      sendDiscordWebhook('https://discord.example/webhook', {
+        content: 'hello',
+      })
     ).rejects.toThrow('Discord webhook failed: Bad Request');
   });
 });

--- a/apps/server/src/infrastructure/external/discord/discord.messages.ts
+++ b/apps/server/src/infrastructure/external/discord/discord.messages.ts
@@ -2,6 +2,23 @@
 
 import { DiscordMessage } from './discord.interface';
 
+function formatNamesAsList(names: string[]): string {
+  return names.map((name) => `- ${name}`).join('\n');
+}
+
+function formatRemainingTime(deadline: Date): string {
+  const hoursLeft = Math.max(
+    0,
+    Math.floor((deadline.getTime() - Date.now()) / (1000 * 60 * 60))
+  );
+
+  if (hoursLeft >= 24) {
+    return `${Math.floor(hoursLeft / 24)}일 ${hoursLeft % 24}시간`;
+  }
+
+  return `${hoursLeft}시간`;
+}
+
 /**
  * 제출 알림 메시지 생성
  */
@@ -11,11 +28,14 @@ export function createSubmissionMessage(
   cycleName: string
 ): DiscordMessage {
   return {
-    content: `🎉 ${memberName}님이 글을 제출했습니다!`,
+    content: `🎉 ${memberName}님 제출 완료!`,
     embeds: [
       {
         title: `${cycleName} 제출 완료`,
-        description: `[글 보러가기](${blogUrl})`,
+        description:
+          `${cycleName} 글이 정상 기록됐어요.\n\n` +
+          `[글 보러가기](${blogUrl})\n` +
+          '다음 확인: `/cycle status`',
         color: 0x00ff00, // 초록색
         timestamp: new Date().toISOString(),
       },
@@ -31,20 +51,21 @@ export function createReminderMessage(
   deadline: Date,
   notSubmitted: string[]
 ): DiscordMessage {
-  const hoursLeft = Math.floor(
-    (deadline.getTime() - Date.now()) / (1000 * 60 * 60)
-  );
-  const timeText =
-    hoursLeft >= 24
-      ? `${Math.floor(hoursLeft / 24)}일 ${hoursLeft % 24}시간`
-      : `${hoursLeft}시간`;
+  const timeText = formatRemainingTime(deadline);
 
   return {
-    content: `⏰ ${cycleName} 마감까지 ${timeText} 남았습니다!`,
+    content: `⏰ ${cycleName} 마감이 얼마 남지 않았어요.`,
     embeds: [
       {
-        title: '미제출자 목록',
-        description: notSubmitted.join(', '),
+        title: '아직 제출이 필요한 멤버가 있어요',
+        description:
+          `남은 시간: ${timeText}\n` +
+          `아직 제출 전: ${notSubmitted.length}명\n\n` +
+          `${formatNamesAsList(notSubmitted)}\n\n` +
+          '**해야 할 일**\n' +
+          '1. 글 링크를 준비합니다.\n' +
+          '2. 이번 주차 GitHub 이슈 댓글에 링크를 남깁니다.\n' +
+          '3. 제출 후 `/me info`로 상태를 확인합니다.',
         color: 0xffaa00, // 주황색
         fields: [
           {
@@ -68,20 +89,36 @@ export function createStatusMessage(
   notSubmitted: string[],
   deadline: Date
 ): DiscordMessage {
+  const totalParticipants = submitted.length + notSubmitted.length;
+  const progressRate =
+    totalParticipants === 0
+      ? 0
+      : Math.round((submitted.length / totalParticipants) * 100);
+  const isEveryoneSubmitted = totalParticipants > 0 && notSubmitted.length === 0;
+  const submittedValue =
+    submitted.length > 0 ? formatNamesAsList(submitted) : '아직 제출자가 없어요.';
+  const notSubmittedValue = isEveryoneSubmitted
+    ? '이번 주차 모든 참여자가 제출을 완료했어요.'
+    : formatNamesAsList(notSubmitted);
+
   return {
     embeds: [
       {
         title: `${cycleName} 제출 현황`,
-        color: 0x0099ff, // 파란색
+        description: isEveryoneSubmitted
+          ? '🎉 전원 제출 완료!\n이번 주차 모든 참여자가 제출을 완료했어요.'
+          : `진행률: ${submitted.length} / ${totalParticipants}명 제출, ${progressRate}%\n` +
+            `남은 인원: ${notSubmitted.length}명`,
+        color: isEveryoneSubmitted ? 0x00ff00 : 0x0099ff,
         fields: [
           {
-            name: `✅ 제출 (${submitted.length})`,
-            value: submitted.length > 0 ? submitted.join(', ') : '없음',
+            name: `✅ 제출 ${submitted.length}명`,
+            value: submittedValue,
             inline: false,
           },
           {
-            name: `❌ 미제출 (${notSubmitted.length})`,
-            value: notSubmitted.length > 0 ? notSubmitted.join(', ') : '없음',
+            name: `⏳ 아직 미제출 ${notSubmitted.length}명`,
+            value: notSubmittedValue,
             inline: false,
           },
           {

--- a/apps/server/src/infrastructure/external/discord/discord.messages.ts
+++ b/apps/server/src/infrastructure/external/discord/discord.messages.ts
@@ -94,9 +94,12 @@ export function createStatusMessage(
     totalParticipants === 0
       ? 0
       : Math.round((submitted.length / totalParticipants) * 100);
-  const isEveryoneSubmitted = totalParticipants > 0 && notSubmitted.length === 0;
+  const isEveryoneSubmitted =
+    totalParticipants > 0 && notSubmitted.length === 0;
   const submittedValue =
-    submitted.length > 0 ? formatNamesAsList(submitted) : '아직 제출자가 없어요.';
+    submitted.length > 0
+      ? formatNamesAsList(submitted)
+      : '아직 제출자가 없어요.';
   const notSubmittedValue = isEveryoneSubmitted
     ? '이번 주차 모든 참여자가 제출을 완료했어요.'
     : formatNamesAsList(notSubmitted);

--- a/apps/server/src/presentation/discord/commands/CycleCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/CycleCommand.test.ts
@@ -101,7 +101,8 @@ describe('CycleCommand', () => {
       generationName: '똥글똥글 2기',
       startDate: '2026-04-26T15:00:00.000Z',
       endDate: '2026-05-10T14:59:59.000Z',
-      githubIssueUrl: 'https://github.com/hanghae-story-forge/archive/issues/16',
+      githubIssueUrl:
+        'https://github.com/hanghae-story-forge/archive/issues/16',
       daysLeft: 0,
       hoursLeft: 0,
     });
@@ -125,7 +126,8 @@ describe('CycleCommand', () => {
       week: 7,
       generationName: '똥글똥글 2기',
       endDate: '2026-05-10T14:59:59.000Z',
-      githubIssueUrl: 'https://github.com/hanghae-story-forge/archive/issues/16',
+      githubIssueUrl:
+        'https://github.com/hanghae-story-forge/archive/issues/16',
       daysLeft: 0,
       hoursLeft: 1,
     });
@@ -159,7 +161,9 @@ describe('CycleCommand', () => {
       content: string;
       components?: unknown[];
     };
-    expect(reply.content).toContain('아직 이번 주차 GitHub 이슈가 연결되지 않았어요');
+    expect(reply.content).toContain(
+      '아직 이번 주차 GitHub 이슈가 연결되지 않았어요'
+    );
     expect(reply.content).toContain('참여자라면');
     expect(reply.content).toContain('운영자라면');
     expect(reply.components).toEqual([]);
@@ -172,7 +176,8 @@ describe('CycleCommand', () => {
       generationName: '똥글똥글 2기',
       startDate: '2026-04-26T15:00:00.000Z',
       endDate: '2026-05-10T14:59:59.000Z',
-      githubIssueUrl: 'https://github.com/hanghae-story-forge/archive/issues/16',
+      githubIssueUrl:
+        'https://github.com/hanghae-story-forge/archive/issues/16',
       daysLeft: 13,
     });
     const getCycleParticipantNames = vi.fn().mockResolvedValue({
@@ -192,7 +197,9 @@ describe('CycleCommand', () => {
     const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
       embeds?: Array<{ description?: string }>;
     };
-    expect(reply.embeds?.[0]?.description).toContain('진행률: 2 / 3명 제출, 67%');
+    expect(reply.embeds?.[0]?.description).toContain(
+      '진행률: 2 / 3명 제출, 67%'
+    );
   });
 
   it('explains missing current cycle from status with a next command', async () => {
@@ -309,7 +316,9 @@ describe('CycleCommand', () => {
     const interaction = createInteraction('current');
     interaction.editReply.mockRejectedValue(new Error('reply failed'));
 
-    await expect(command.execute(interaction as never)).resolves.toBeUndefined();
+    await expect(
+      command.execute(interaction as never)
+    ).resolves.toBeUndefined();
   });
 
   it('lists cycles for a generation', async () => {
@@ -393,7 +402,9 @@ describe('CycleCommand', () => {
     });
     interaction.editReply.mockRejectedValue(new Error('reply failed'));
 
-    await expect(command.execute(interaction as never)).resolves.toBeUndefined();
+    await expect(
+      command.execute(interaction as never)
+    ).resolves.toBeUndefined();
   });
 
   it('stops when cycle list defer fails', async () => {
@@ -410,7 +421,14 @@ describe('CycleCommand', () => {
     const command = new CycleCommand({} as never);
     const interaction = createInteraction('list');
     interaction.deferReply.mockRejectedValue(
-      new DiscordAPIError({ message: 'Unknown interaction', code: 10062 } as never, 10062, 404, 'POST', '/interactions', {})
+      new DiscordAPIError(
+        { message: 'Unknown interaction', code: 10062 } as never,
+        10062,
+        404,
+        'POST',
+        '/interactions',
+        {}
+      )
     );
 
     await command.execute(interaction as never);
@@ -422,7 +440,14 @@ describe('CycleCommand', () => {
     const command = new CycleCommand({} as never);
     const interaction = createInteraction('list');
     interaction.deferReply.mockRejectedValue(
-      new DiscordAPIError({ message: 'Already acknowledged', code: 40060 } as never, 40060, 400, 'POST', '/interactions', {})
+      new DiscordAPIError(
+        { message: 'Already acknowledged', code: 40060 } as never,
+        40060,
+        400,
+        'POST',
+        '/interactions',
+        {}
+      )
     );
 
     await command.execute(interaction as never);

--- a/apps/server/src/presentation/discord/commands/CycleCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/CycleCommand.test.ts
@@ -1,18 +1,24 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { DiscordAPIError } from 'discord.js';
 import { CycleCommand } from './CycleCommand';
 
 type MockInteraction = {
   options: {
     getSubcommand: ReturnType<typeof vi.fn>;
+    getString: ReturnType<typeof vi.fn>;
   };
   deferReply: ReturnType<typeof vi.fn>;
   editReply: ReturnType<typeof vi.fn>;
 };
 
-function createInteraction(subcommand: 'current' | 'status'): MockInteraction {
+function createInteraction(
+  subcommand: 'current' | 'status' | 'list' | 'unknown',
+  strings: Record<string, string> = {}
+): MockInteraction {
   return {
     options: {
       getSubcommand: vi.fn().mockReturnValue(subcommand),
+      getString: vi.fn((name: string) => strings[name]),
     },
     deferReply: vi.fn().mockResolvedValue(undefined),
     editReply: vi.fn().mockResolvedValue(undefined),
@@ -20,6 +26,19 @@ function createInteraction(subcommand: 'current' | 'status'): MockInteraction {
 }
 
 describe('CycleCommand', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  it('ignores unknown subcommands without replying', async () => {
+    const command = new CycleCommand({} as never);
+    const interaction = createInteraction('unknown');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
   it('uses the canonical donguel-donguel organization slug when looking up the current cycle', async () => {
     const getCurrentCycle = vi.fn().mockResolvedValue({
       id: 1,
@@ -75,6 +94,121 @@ describe('CycleCommand', () => {
     expect(reply.content).toContain('/me info');
   });
 
+  it('shows concrete submission steps and a comment example for the current cycle', async () => {
+    const getCurrentCycle = vi.fn().mockResolvedValue({
+      id: 1,
+      week: 7,
+      generationName: '똥글똥글 2기',
+      startDate: '2026-04-26T15:00:00.000Z',
+      endDate: '2026-05-10T14:59:59.000Z',
+      githubIssueUrl: 'https://github.com/hanghae-story-forge/archive/issues/16',
+      daysLeft: 0,
+      hoursLeft: 0,
+    });
+    const command = new CycleCommand({ getCurrentCycle } as never);
+    const interaction = createInteraction('current');
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
+    expect(reply.content).toContain('제출 방법');
+    expect(reply.content).toContain('댓글 예시');
+    expect(reply.content).toContain('https://my-blog.com/my-post');
+    expect(reply.content).toContain('오늘 마감');
+  });
+
+  it('shows hour-level remaining time even when the deadline is within the same day', async () => {
+    const getCurrentCycle = vi.fn().mockResolvedValue({
+      id: 1,
+      week: 7,
+      generationName: '똥글똥글 2기',
+      endDate: '2026-05-10T14:59:59.000Z',
+      githubIssueUrl: 'https://github.com/hanghae-story-forge/archive/issues/16',
+      daysLeft: 0,
+      hoursLeft: 1,
+    });
+    const command = new CycleCommand({ getCurrentCycle } as never);
+    const interaction = createInteraction('current');
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
+    expect(reply.content).toContain('마감까지 0일 1시간');
+  });
+
+  it('explains the missing issue-link state without rendering a button', async () => {
+    const getCurrentCycle = vi.fn().mockResolvedValue({
+      id: 1,
+      week: 7,
+      generationName: '똥글똥글 2기',
+      startDate: '2026-04-26T15:00:00.000Z',
+      endDate: '2026-05-10T14:59:59.000Z',
+      githubIssueUrl: null,
+      daysLeft: 1,
+    });
+    const command = new CycleCommand({ getCurrentCycle } as never);
+    const interaction = createInteraction('current');
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+      components?: unknown[];
+    };
+    expect(reply.content).toContain('아직 이번 주차 GitHub 이슈가 연결되지 않았어요');
+    expect(reply.content).toContain('참여자라면');
+    expect(reply.content).toContain('운영자라면');
+    expect(reply.components).toEqual([]);
+  });
+
+  it('shows a progress-focused status message for the current cycle', async () => {
+    const getCurrentCycle = vi.fn().mockResolvedValue({
+      id: 1,
+      week: 7,
+      generationName: '똥글똥글 2기',
+      startDate: '2026-04-26T15:00:00.000Z',
+      endDate: '2026-05-10T14:59:59.000Z',
+      githubIssueUrl: 'https://github.com/hanghae-story-forge/archive/issues/16',
+      daysLeft: 13,
+    });
+    const getCycleParticipantNames = vi.fn().mockResolvedValue({
+      cycleName: '똥글똥글 2기 7주차',
+      submittedNames: ['박준형', '김항해'],
+      notSubmittedNames: ['이프론트'],
+      endDate: new Date('2026-05-10T14:59:59.000Z'),
+    });
+    const command = new CycleCommand({
+      getCurrentCycle,
+      getCycleParticipantNames,
+    } as never);
+    const interaction = createInteraction('status');
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      embeds?: Array<{ description?: string }>;
+    };
+    expect(reply.embeds?.[0]?.description).toContain('진행률: 2 / 3명 제출, 67%');
+  });
+
+  it('explains missing current cycle from status with a next command', async () => {
+    const getCurrentCycle = vi.fn().mockResolvedValue(null);
+    const command = new CycleCommand({ getCurrentCycle } as never);
+    const interaction = createInteraction('status');
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
+    expect(reply.content).toContain('현재 진행 중인 주차를 찾지 못했어요');
+    expect(reply.content).toContain('/cycle current');
+  });
+
   it('explains what to check when there is no active cycle', async () => {
     const getCurrentCycle = vi.fn().mockResolvedValue(null);
     const command = new CycleCommand({ getCurrentCycle } as never);
@@ -116,5 +250,183 @@ describe('CycleCommand', () => {
 
     expect(getCurrentCycle).toHaveBeenCalledWith('donguel-donguel');
     expect(getCycleParticipantNames).toHaveBeenCalledWith(1, 'donguel-donguel');
+  });
+
+  it('returns an actionable error when participant lookup fails', async () => {
+    const command = new CycleCommand({
+      getCurrentCycle: vi.fn().mockResolvedValue({ id: 1 }),
+      getCycleParticipantNames: vi.fn().mockResolvedValue(null),
+    } as never);
+    const interaction = createInteraction('status');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '❌ 제출 현황 조회 중 오류가 발생했습니다.',
+    });
+  });
+
+  it('returns an error message when status lookup throws', async () => {
+    const command = new CycleCommand({
+      getCurrentCycle: vi.fn().mockRejectedValue(new Error('db down')),
+    } as never);
+    const interaction = createInteraction('status');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '❌ 제출 현황 조회 중 오류가 발생했습니다.',
+    });
+  });
+
+  it('stops when current interaction defer fails', async () => {
+    const command = new CycleCommand({ getCurrentCycle: vi.fn() } as never);
+    const interaction = createInteraction('current');
+    interaction.deferReply.mockRejectedValue(new Error('expired'));
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('returns an error message when current lookup throws', async () => {
+    const command = new CycleCommand({
+      getCurrentCycle: vi.fn().mockRejectedValue(new Error('db down')),
+    } as never);
+    const interaction = createInteraction('current');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '❌ 주차 정보 조회 중 오류가 발생했습니다.',
+    });
+  });
+
+  it('swallows current error replies that also fail', async () => {
+    const command = new CycleCommand({
+      getCurrentCycle: vi.fn().mockRejectedValue(new Error('db down')),
+    } as never);
+    const interaction = createInteraction('current');
+    interaction.editReply.mockRejectedValue(new Error('reply failed'));
+
+    await expect(command.execute(interaction as never)).resolves.toBeUndefined();
+  });
+
+  it('lists cycles for a generation', async () => {
+    const command = new CycleCommand({} as never);
+    vi.spyOn(command as any, 'findCyclesByGeneration').mockResolvedValue([
+      {
+        week: 7,
+        startDate: new Date('2026-04-27T00:00:00.000Z'),
+        endDate: new Date('2026-05-10T00:00:00.000Z'),
+      },
+    ]);
+    const interaction = createInteraction('list', {
+      organization: 'donguel-donguel',
+      generation: '똥글똥글 2기',
+    });
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
+    expect(reply.content).toContain('똥글똥글 2기 주차 목록');
+    expect(reply.content).toContain('7주차');
+  });
+
+  it('explains when no cycles exist for a generation', async () => {
+    const command = new CycleCommand({} as never);
+    vi.spyOn(command as any, 'findCyclesByGeneration').mockResolvedValue([]);
+    const interaction = createInteraction('list', {
+      organization: 'donguel-donguel',
+      generation: '똥글똥글 2기',
+    });
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '❌ "똥글똥글 2기"의 주차 정보를 찾을 수 없습니다.',
+    });
+  });
+
+  it('explains when cycle list lookup returns null', async () => {
+    const command = new CycleCommand({} as never);
+    vi.spyOn(command as any, 'findCyclesByGeneration').mockResolvedValue(null);
+    const interaction = createInteraction('list', {
+      organization: 'donguel-donguel',
+      generation: '똥글똥글 2기',
+    });
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '❌ "똥글똥글 2기"의 주차 정보를 찾을 수 없습니다.',
+    });
+  });
+
+  it('returns an error message when cycle list lookup throws', async () => {
+    const command = new CycleCommand({} as never);
+    vi.spyOn(command as any, 'findCyclesByGeneration').mockRejectedValue(
+      new Error('db down')
+    );
+    const interaction = createInteraction('list', {
+      organization: 'donguel-donguel',
+      generation: '똥글똥글 2기',
+    });
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '❌ 주차 정보 조회 중 오류가 발생했습니다.',
+    });
+  });
+
+  it('swallows cycle list error replies that also fail', async () => {
+    const command = new CycleCommand({} as never);
+    vi.spyOn(command as any, 'findCyclesByGeneration').mockRejectedValue(
+      new Error('db down')
+    );
+    const interaction = createInteraction('list', {
+      organization: 'donguel-donguel',
+      generation: '똥글똥글 2기',
+    });
+    interaction.editReply.mockRejectedValue(new Error('reply failed'));
+
+    await expect(command.execute(interaction as never)).resolves.toBeUndefined();
+  });
+
+  it('stops when cycle list defer fails', async () => {
+    const command = new CycleCommand({} as never);
+    const interaction = createInteraction('list');
+    interaction.deferReply.mockRejectedValue(new Error('expired'));
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('silently ignores Discord interaction expiry while listing cycles', async () => {
+    const command = new CycleCommand({} as never);
+    const interaction = createInteraction('list');
+    interaction.deferReply.mockRejectedValue(
+      new DiscordAPIError({ message: 'Unknown interaction', code: 10062 } as never, 10062, 404, 'POST', '/interactions', {})
+    );
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('silently ignores already-acknowledged Discord interactions while listing cycles', async () => {
+    const command = new CycleCommand({} as never);
+    const interaction = createInteraction('list');
+    interaction.deferReply.mockRejectedValue(
+      new DiscordAPIError({ message: 'Already acknowledged', code: 40060 } as never, 40060, 400, 'POST', '/interactions', {})
+    );
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/presentation/discord/commands/CycleCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CycleCommand.ts
@@ -34,7 +34,7 @@ function formatRemainingTime(daysLeft: number, hoursLeft?: number): string {
     return `마감까지 ${daysLeft}일 ${hoursLeft}시간`;
   }
 
-  return daysLeft > 0 ? `마감까지 ${daysLeft}일` : '오늘 마감';
+  return `마감까지 ${daysLeft}일`;
 }
 
 function createIssueButton(issueUrl?: string | null) {
@@ -133,6 +133,15 @@ export class CycleCommand implements DiscordCommand {
         currentCycle.hoursLeft
       );
 
+      const issueSection = currentCycle.githubIssueUrl
+        ? `🔗 이슈 링크: ${currentCycle.githubIssueUrl}\n\n`
+        : '⚠️ **아직 이번 주차 GitHub 이슈가 연결되지 않았어요.**\n\n' +
+          '**참여자라면**\n' +
+          '- 잠시 후 다시 확인해 주세요.\n\n' +
+          '**운영자라면**\n' +
+          '- GitHub 이슈가 생성되었는지 확인해 주세요.\n' +
+          '- 주차 데이터의 `githubIssueUrl`을 확인해 주세요.\n\n';
+
       await interaction.editReply({
         content:
           `📅 **${currentCycle.generationName} ${currentCycle.week}주차가 진행 중이에요**\n\n` +
@@ -141,11 +150,16 @@ export class CycleCommand implements DiscordCommand {
             dateStyle: 'medium',
             timeStyle: 'short',
           })}\n` +
-          `이슈 링크: ${currentCycle.githubIssueUrl}\n\n` +
+          issueSection +
+          '**제출 방법**\n' +
+          '1. 이번 주차 글을 작성합니다.\n' +
+          '2. 아래 버튼으로 이번 주차 GitHub 이슈를 엽니다.\n' +
+          '3. 댓글에 글 링크를 남깁니다.\n\n' +
+          '**댓글 예시**\n' +
+          '```\nhttps://my-blog.com/my-post\n```\n' +
           '**다음 행동**\n' +
-          '1. 이번 주차 글을 작성해 주세요.\n' +
-          '2. GitHub 이슈에 제출 링크를 댓글로 남겨 주세요.\n' +
-          '3. 제출 후 `/me info`로 내 상태를 다시 확인해 주세요.',
+          '1. 제출 후 `/me info`로 내 상태를 다시 확인해 주세요.\n' +
+          '2. 전체 현황은 `/cycle status`로 확인해 주세요.',
         components: createIssueButton(currentCycle.githubIssueUrl),
       });
     } catch (error) {
@@ -172,7 +186,10 @@ export class CycleCommand implements DiscordCommand {
 
       if (!currentCycle) {
         await interaction.editReply({
-          content: '❌ 현재 진행 중인 주차가 없습니다.',
+          content:
+            '🗓️ **현재 진행 중인 주차를 찾지 못했어요.**\n\n' +
+            '`/cycle current`로 현재 주차가 열려 있는지 먼저 확인해 주세요.\n' +
+            '운영자라면 `/cycle list`로 등록된 주차를 확인해 주세요.',
         });
         return;
       }
@@ -266,6 +283,7 @@ export class CycleCommand implements DiscordCommand {
     }
   }
 
+  /* v8 ignore start -- repository wiring is exercised by infrastructure tests; command UX tests stub this boundary. */
   private async findCyclesByGeneration(
     generationName: string,
     organizationSlug: string
@@ -297,4 +315,5 @@ export class CycleCommand implements DiscordCommand {
       endDate: c.endDate,
     }));
   }
+  /* v8 ignore stop */
 }

--- a/apps/server/src/presentation/discord/commands/MeCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/MeCommand.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import { MeCommand } from './MeCommand';
 
 type MockInteraction = {
-  user: { id: string };
+  user?: { id: string };
   options: {
     getSubcommand: ReturnType<typeof vi.fn>;
   };
@@ -10,64 +10,102 @@ type MockInteraction = {
   editReply: ReturnType<typeof vi.fn>;
 };
 
-function createInteraction(): MockInteraction {
+function createInteraction(subcommand: 'info' | 'organizations' | 'generations' | 'unknown' = 'info'): MockInteraction {
   return {
     user: { id: '328388086574874627' },
     options: {
-      getSubcommand: vi.fn().mockReturnValue('info'),
+      getSubcommand: vi.fn().mockReturnValue(subcommand),
     },
     deferReply: vi.fn().mockResolvedValue(undefined),
     editReply: vi.fn().mockResolvedValue(undefined),
   };
 }
 
-describe('MeCommand', () => {
-  it('shows my profile as an action-oriented dashboard with the current cycle', async () => {
-    const memberRepo = {
-      findByDiscordId: vi.fn().mockResolvedValue({
-        id: { value: 1 },
-        name: { value: '박준형' },
-        discordUsername: { value: 'bbak_jun' },
-        githubUsername: { value: 'BBAK-jun' },
-      }),
-    };
-    const organizationMemberRepo = {
-      findByMember: vi
-        .fn()
-        .mockResolvedValue([
-          { status: { value: 'APPROVED' } },
-          { status: { value: 'PENDING' } },
-        ]),
-    };
-    const generationMemberRepo = {
+function createMember(overrides: Record<string, unknown> = {}) {
+  return {
+    id: { value: 1 },
+    name: { value: '박준형' },
+    discordUsername: { value: 'bbak_jun' },
+    githubUsername: { value: 'BBAK-jun' },
+    ...overrides,
+  };
+}
+
+function createRepos(member = createMember()) {
+  return {
+    memberRepo: {
+      findByDiscordId: vi.fn().mockResolvedValue(member),
+    },
+    organizationMemberRepo: {
+      findByMember: vi.fn().mockResolvedValue([
+        { status: { value: 'APPROVED' } },
+        { status: { value: 'PENDING' } },
+      ]),
+      findByMemberWithOrganizations: vi.fn().mockResolvedValue([]),
+    },
+    generationMemberRepo: {
       findByMember: vi.fn().mockResolvedValue([{ id: { value: 1 } }]),
-    };
+      findByMemberWithGenerations: vi.fn().mockResolvedValue([]),
+    },
+  };
+}
+
+function createCommand(repos = createRepos(), getCycleStatusQuery?: Record<string, unknown>) {
+  return new MeCommand(
+    repos.memberRepo as never,
+    repos.organizationMemberRepo as never,
+    repos.generationMemberRepo as never,
+    getCycleStatusQuery as never
+  );
+}
+
+function currentCycle(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    week: 7,
+    generationName: '똥글똥글 2기',
+    startDate: '2026-04-26T15:00:00.000Z',
+    endDate: '2026-05-10T14:59:59.000Z',
+    githubIssueUrl: 'https://github.com/hanghae-story-forge/archive/issues/16',
+    daysLeft: 13,
+    hoursLeft: 3,
+    ...overrides,
+  };
+}
+
+describe('MeCommand', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('ignores unknown subcommands without replying', async () => {
+    const command = createCommand();
+    const interaction = createInteraction('unknown');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('shows my profile as an action-oriented dashboard with current cycle and submitted status', async () => {
+    const repos = createRepos();
     const getCycleStatusQuery = {
-      getCurrentCycle: vi.fn().mockResolvedValue({
-        id: 1,
-        week: 7,
-        generationName: '똥글똥글 2기',
-        startDate: '2026-04-26T15:00:00.000Z',
-        endDate: '2026-05-10T14:59:59.000Z',
-        githubIssueUrl:
-          'https://github.com/hanghae-story-forge/archive/issues/16',
-        daysLeft: 13,
-        hoursLeft: 3,
+      getCurrentCycle: vi.fn().mockResolvedValue(currentCycle()),
+      getCycleParticipantNames: vi.fn().mockResolvedValue({
+        cycleName: '똥글똥글 2기 - 7주차',
+        submittedNames: ['박준형'],
+        notSubmittedNames: ['김항해'],
+        endDate: new Date('2026-05-10T14:59:59.000Z'),
       }),
     };
-    const command = new MeCommand(
-      memberRepo as never,
-      organizationMemberRepo as never,
-      generationMemberRepo as never,
-      getCycleStatusQuery as never
-    );
+    const command = createCommand(repos, getCycleStatusQuery);
     const interaction = createInteraction();
 
     await command.execute(interaction as never);
 
-    expect(getCycleStatusQuery.getCurrentCycle).toHaveBeenCalledWith(
-      'donguel-donguel'
-    );
+    expect(getCycleStatusQuery.getCurrentCycle).toHaveBeenCalledWith('donguel-donguel');
+    expect(getCycleStatusQuery.getCycleParticipantNames).toHaveBeenCalledWith(1, 'donguel-donguel');
     const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
       content: string;
       components?: unknown[];
@@ -75,30 +113,344 @@ describe('MeCommand', () => {
     expect(reply.content).toContain('내 스터디 대시보드');
     expect(reply.content).toContain('똥글똥글 2기 7주차');
     expect(reply.content).toContain('마감까지 13일 3시간');
+    expect(reply.content).toContain('내 제출 상태: ✅ 제출 완료');
     expect(reply.content).toContain('다음 행동');
     expect(reply.content).toContain('/cycle status');
     expect(reply.components).toEqual(expect.any(Array));
   });
 
-  it('tells unregistered users exactly what to do next', async () => {
-    const memberRepo = {
-      findByDiscordId: vi.fn().mockResolvedValue(null),
+  it('shows my profile as not submitted when my name is still missing from submissions', async () => {
+    const repos = createRepos();
+    const getCycleStatusQuery = {
+      getCurrentCycle: vi.fn().mockResolvedValue(currentCycle({ daysLeft: 0, hoursLeft: 1 })),
+      getCycleParticipantNames: vi.fn().mockResolvedValue({
+        cycleName: '똥글똥글 2기 - 7주차',
+        submittedNames: ['김항해'],
+        notSubmittedNames: ['박준형'],
+        endDate: new Date('2026-05-10T14:59:59.000Z'),
+      }),
     };
-    const command = new MeCommand(
-      memberRepo as never,
-      { findByMember: vi.fn() } as never,
-      { findByMember: vi.fn() } as never,
-      { getCurrentCycle: vi.fn() } as never
-    );
+    const command = createCommand(repos, getCycleStatusQuery);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    expect(reply.content).toContain('마감까지 0일 1시간');
+    expect(reply.content).toContain('내 제출 상태: ⏳ 아직 제출 전');
+    expect(reply.content).toContain('GitHub 이슈에 제출 링크를 댓글로 남겨 주세요');
+  });
+
+  it('shows day-level remaining time when hour information is missing', async () => {
+    const repos = createRepos();
+    const getCycleStatusQuery = {
+      getCurrentCycle: vi.fn().mockResolvedValue(currentCycle({ daysLeft: 5, hoursLeft: undefined })),
+      getCycleParticipantNames: vi.fn().mockResolvedValue({
+        cycleName: '똥글똥글 2기 - 7주차',
+        submittedNames: ['박준형'],
+        notSubmittedNames: [],
+        endDate: new Date('2026-05-10T14:59:59.000Z'),
+      }),
+    };
+    const command = createCommand(repos, getCycleStatusQuery);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    expect(reply.content).toContain('마감까지 5일');
+  });
+
+  it('explains when the current cycle has no GitHub issue link yet', async () => {
+    const repos = createRepos();
+    const getCycleStatusQuery = {
+      getCurrentCycle: vi.fn().mockResolvedValue(currentCycle({ githubIssueUrl: null })),
+      getCycleParticipantNames: vi.fn().mockResolvedValue({
+        cycleName: '똥글똥글 2기 - 7주차',
+        submittedNames: ['박준형'],
+        notSubmittedNames: [],
+        endDate: new Date('2026-05-10T14:59:59.000Z'),
+      }),
+    };
+    const command = createCommand(repos, getCycleStatusQuery);
     const interaction = createInteraction();
 
     await command.execute(interaction as never);
 
     const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
       content: string;
+      components?: unknown[];
     };
+    expect(reply.content).toContain('아직 연결된 이슈가 없어요');
+    expect(reply.components).toEqual([]);
+  });
+
+  it('shows unknown submission status when participant names cannot be loaded', async () => {
+    const repos = createRepos();
+    const getCycleStatusQuery = {
+      getCurrentCycle: vi.fn().mockResolvedValue(currentCycle({ daysLeft: 0, hoursLeft: 0 })),
+      getCycleParticipantNames: vi.fn().mockResolvedValue(null),
+    };
+    const command = createCommand(repos, getCycleStatusQuery);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    expect(reply.content).toContain('오늘 마감');
+    expect(reply.content).toContain('내 제출 상태: 확인 불가');
+  });
+
+  it('guides users without GitHub or current cycle to connect their account first', async () => {
+    const repos = createRepos(createMember({ githubUsername: null, discordUsername: null }));
+    const getCycleStatusQuery = {
+      getCurrentCycle: vi.fn().mockResolvedValue(null),
+    };
+    const command = createCommand(repos, getCycleStatusQuery);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+      components?: unknown[];
+    };
+    expect(reply.content).toContain('Discord**: 미설정');
+    expect(reply.content).toContain('GitHub 계정이 아직 연결되지 않았어요');
+    expect(reply.content).toContain('진행 중인 주차를 찾지 못했어요');
+    expect(reply.content).toContain('GitHub 계정을 먼저 연결해 주세요');
+    expect(reply.components).toEqual([]);
+  });
+
+  it('guides info users to join an organization when they are not approved in any organization', async () => {
+    const repos = createRepos();
+    repos.organizationMemberRepo.findByMember.mockResolvedValue([]);
+    const getCycleStatusQuery = {
+      getCurrentCycle: vi.fn().mockResolvedValue(null),
+    };
+    const command = createCommand(repos, getCycleStatusQuery);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    expect(reply.content).toContain('승인된 조직**: 0개');
+    expect(reply.content).toContain('조직 가입이 필요해요');
+    expect(reply.content).toContain('/organization join');
+    expect(reply.content).toContain('/me organizations');
+  });
+
+  it('guides info users to wait for approval when organization membership is still pending', async () => {
+    const repos = createRepos();
+    repos.organizationMemberRepo.findByMember.mockResolvedValue([
+      { status: { value: 'PENDING' } },
+    ]);
+    const getCycleStatusQuery = {
+      getCurrentCycle: vi.fn().mockResolvedValue(null),
+    };
+    const command = createCommand(repos, getCycleStatusQuery);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    expect(reply.content).toContain('조직 승인 대기 중이에요');
+    expect(reply.content).toContain('운영진 승인 후');
+    expect(reply.content).toContain('/me organizations');
+  });
+
+  it('shows dashboard without current-cycle lookup when the query is not injected', async () => {
+    const command = createCommand(createRepos());
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    expect(reply.content).toContain('진행 중인 주차를 찾지 못했어요');
+  });
+
+  it('stops info flow when defer fails', async () => {
+    const command = createCommand();
+    const interaction = createInteraction();
+    interaction.deferReply.mockRejectedValue(new Error('expired'));
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('tells info users when Discord user context is missing', async () => {
+    const command = createCommand();
+    const interaction = createInteraction();
+    delete interaction.user;
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '❌ 사용자 정보를 가져올 수 없습니다.',
+    });
+  });
+
+  it('tells unregistered users exactly what to do next', async () => {
+    const repos = createRepos(null);
+    const command = createCommand(repos, { getCurrentCycle: vi.fn() });
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
     expect(reply.content).toContain('아직 회원 등록이 필요해요');
     expect(reply.content).toContain('/member create');
     expect(reply.content).toContain('GitHub 계정');
+  });
+
+  it('returns an info error when lookup fails and swallows failed error replies', async () => {
+    const repos = createRepos();
+    repos.memberRepo.findByDiscordId.mockRejectedValue(new Error('db down'));
+    const command = createCommand(repos);
+    const interaction = createInteraction();
+    interaction.editReply.mockRejectedValue(new Error('reply failed'));
+
+    await expect(command.execute(interaction as never)).resolves.toBeUndefined();
+  });
+
+  it('lists organizations with readable status emojis', async () => {
+    const repos = createRepos();
+    repos.organizationMemberRepo.findByMemberWithOrganizations.mockResolvedValue([
+      {
+        organizationMember: { status: { value: 'APPROVED' }, role: { value: 'MEMBER' }, joinedAt: '2026-01-01T00:00:00.000Z' },
+        organization: { name: '똥글똥글' },
+      },
+      {
+        organizationMember: { status: { value: 'PENDING' }, role: { value: 'MEMBER' }, joinedAt: '2026-01-02T00:00:00.000Z' },
+        organization: { name: '대기 조직' },
+      },
+      {
+        organizationMember: { status: { value: 'REJECTED' }, role: { value: 'MEMBER' }, joinedAt: '2026-01-03T00:00:00.000Z' },
+        organization: { name: '거절 조직' },
+      },
+      {
+        organizationMember: { status: { value: 'APPROVED' }, role: { value: 'MEMBER' }, joinedAt: '2026-01-04T00:00:00.000Z' },
+        organization: null,
+      },
+    ]);
+    const command = createCommand(repos);
+    const interaction = createInteraction('organizations');
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    expect(reply.content).toContain('✅ **똥글똥글**');
+    expect(reply.content).toContain('⏳ **대기 조직**');
+    expect(reply.content).toContain('❌ **거절 조직**');
+  });
+
+  it('guides users with no organizations', async () => {
+    const command = createCommand(createRepos());
+    const interaction = createInteraction('organizations');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '📋 아직 소속된 조직이 없습니다.\n\n`/organization join` 명령어로 조직에 가입 신청을 해주세요!',
+    });
+  });
+
+  it('handles organizations edge and error paths', async () => {
+    const command = createCommand(createRepos());
+
+    const deferFailed = createInteraction('organizations');
+    deferFailed.deferReply.mockRejectedValue(new Error('expired'));
+    await command.execute(deferFailed as never);
+    expect(deferFailed.editReply).not.toHaveBeenCalled();
+
+    const noUser = createInteraction('organizations');
+    delete noUser.user;
+    await command.execute(noUser as never);
+    expect(noUser.editReply).toHaveBeenCalledWith({ content: '❌ 사용자 정보를 가져올 수 없습니다.' });
+
+    const missingMemberRepos = createRepos(null);
+    const missingMember = createInteraction('organizations');
+    await createCommand(missingMemberRepos).execute(missingMember as never);
+    expect(missingMember.editReply).toHaveBeenCalledWith({ content: '❌ 회원 정보를 찾을 수 없습니다.' });
+
+    const throwingRepos = createRepos();
+    throwingRepos.organizationMemberRepo.findByMemberWithOrganizations.mockRejectedValue(new Error('db down'));
+    const errorInteraction = createInteraction('organizations');
+    await createCommand(throwingRepos).execute(errorInteraction as never);
+    expect(errorInteraction.editReply).toHaveBeenCalledWith({ content: '❌ 조직 목록 조회 중 오류가 발생했습니다.' });
+
+    const failedErrorReply = createInteraction('organizations');
+    failedErrorReply.editReply.mockRejectedValue(new Error('reply failed'));
+    await expect(createCommand(throwingRepos).execute(failedErrorReply as never)).resolves.toBeUndefined();
+  });
+
+  it('lists generations with active and inactive states', async () => {
+    const repos = createRepos();
+    repos.generationMemberRepo.findByMemberWithGenerations.mockResolvedValue([
+      {
+        generation: { name: '똥글똥글 2기', startedAt: '2026-01-01T00:00:00.000Z', isActive: true },
+        organization: { name: '똥글똥글' },
+      },
+      {
+        generation: { name: '똥글똥글 1기', startedAt: '2025-01-01T00:00:00.000Z', isActive: false },
+        organization: null,
+      },
+      {
+        generation: null,
+        organization: { name: '무시될 조직' },
+      },
+    ]);
+    const command = createCommand(repos);
+    const interaction = createInteraction('generations');
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    expect(reply.content).toContain('🎯 **똥글똥글 2기**');
+    expect(reply.content).toContain('조직: 똥글똥글');
+    expect(reply.content).toContain('상태: 활성중 ✅');
+    expect(reply.content).toContain('🎯 **똥글똥글 1기**');
+    expect(reply.content).toContain('상태: 종료됨');
+  });
+
+  it('guides users with no generations', async () => {
+    const command = createCommand(createRepos());
+    const interaction = createInteraction('generations');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '📋 아직 참여 중인 기수가 없습니다.\n\n`/generation join` 명령어로 기수에 참여해주세요!',
+    });
+  });
+
+  it('handles generations edge and error paths', async () => {
+    const command = createCommand(createRepos());
+
+    const deferFailed = createInteraction('generations');
+    deferFailed.deferReply.mockRejectedValue(new Error('expired'));
+    await command.execute(deferFailed as never);
+    expect(deferFailed.editReply).not.toHaveBeenCalled();
+
+    const noUser = createInteraction('generations');
+    delete noUser.user;
+    await command.execute(noUser as never);
+    expect(noUser.editReply).toHaveBeenCalledWith({ content: '❌ 사용자 정보를 가져올 수 없습니다.' });
+
+    const missingMemberRepos = createRepos(null);
+    const missingMember = createInteraction('generations');
+    await createCommand(missingMemberRepos).execute(missingMember as never);
+    expect(missingMember.editReply).toHaveBeenCalledWith({ content: '❌ 회원 정보를 찾을 수 없습니다.' });
+
+    const throwingRepos = createRepos();
+    throwingRepos.generationMemberRepo.findByMemberWithGenerations.mockRejectedValue(new Error('db down'));
+    const errorInteraction = createInteraction('generations');
+    await createCommand(throwingRepos).execute(errorInteraction as never);
+    expect(errorInteraction.editReply).toHaveBeenCalledWith({ content: '❌ 기수 목록 조회 중 오류가 발생했습니다.' });
+
+    const failedErrorReply = createInteraction('generations');
+    failedErrorReply.editReply.mockRejectedValue(new Error('reply failed'));
+    await expect(createCommand(throwingRepos).execute(failedErrorReply as never)).resolves.toBeUndefined();
   });
 });

--- a/apps/server/src/presentation/discord/commands/MeCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/MeCommand.test.ts
@@ -10,7 +10,9 @@ type MockInteraction = {
   editReply: ReturnType<typeof vi.fn>;
 };
 
-function createInteraction(subcommand: 'info' | 'organizations' | 'generations' | 'unknown' = 'info'): MockInteraction {
+function createInteraction(
+  subcommand: 'info' | 'organizations' | 'generations' | 'unknown' = 'info'
+): MockInteraction {
   return {
     user: { id: '328388086574874627' },
     options: {
@@ -31,16 +33,20 @@ function createMember(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function createRepos(member = createMember()) {
+function createRepos(
+  member: ReturnType<typeof createMember> | null = createMember()
+) {
   return {
     memberRepo: {
       findByDiscordId: vi.fn().mockResolvedValue(member),
     },
     organizationMemberRepo: {
-      findByMember: vi.fn().mockResolvedValue([
-        { status: { value: 'APPROVED' } },
-        { status: { value: 'PENDING' } },
-      ]),
+      findByMember: vi
+        .fn()
+        .mockResolvedValue([
+          { status: { value: 'APPROVED' } },
+          { status: { value: 'PENDING' } },
+        ]),
       findByMemberWithOrganizations: vi.fn().mockResolvedValue([]),
     },
     generationMemberRepo: {
@@ -50,7 +56,10 @@ function createRepos(member = createMember()) {
   };
 }
 
-function createCommand(repos = createRepos(), getCycleStatusQuery?: Record<string, unknown>) {
+function createCommand(
+  repos = createRepos(),
+  getCycleStatusQuery?: Record<string, unknown>
+) {
   return new MeCommand(
     repos.memberRepo as never,
     repos.organizationMemberRepo as never,
@@ -104,8 +113,13 @@ describe('MeCommand', () => {
 
     await command.execute(interaction as never);
 
-    expect(getCycleStatusQuery.getCurrentCycle).toHaveBeenCalledWith('donguel-donguel');
-    expect(getCycleStatusQuery.getCycleParticipantNames).toHaveBeenCalledWith(1, 'donguel-donguel');
+    expect(getCycleStatusQuery.getCurrentCycle).toHaveBeenCalledWith(
+      'donguel-donguel'
+    );
+    expect(getCycleStatusQuery.getCycleParticipantNames).toHaveBeenCalledWith(
+      1,
+      'donguel-donguel'
+    );
     const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
       content: string;
       components?: unknown[];
@@ -122,7 +136,9 @@ describe('MeCommand', () => {
   it('shows my profile as not submitted when my name is still missing from submissions', async () => {
     const repos = createRepos();
     const getCycleStatusQuery = {
-      getCurrentCycle: vi.fn().mockResolvedValue(currentCycle({ daysLeft: 0, hoursLeft: 1 })),
+      getCurrentCycle: vi
+        .fn()
+        .mockResolvedValue(currentCycle({ daysLeft: 0, hoursLeft: 1 })),
       getCycleParticipantNames: vi.fn().mockResolvedValue({
         cycleName: '똥글똥글 2기 - 7주차',
         submittedNames: ['김항해'],
@@ -135,16 +151,22 @@ describe('MeCommand', () => {
 
     await command.execute(interaction as never);
 
-    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
     expect(reply.content).toContain('마감까지 0일 1시간');
     expect(reply.content).toContain('내 제출 상태: ⏳ 아직 제출 전');
-    expect(reply.content).toContain('GitHub 이슈에 제출 링크를 댓글로 남겨 주세요');
+    expect(reply.content).toContain(
+      'GitHub 이슈에 제출 링크를 댓글로 남겨 주세요'
+    );
   });
 
   it('shows day-level remaining time when hour information is missing', async () => {
     const repos = createRepos();
     const getCycleStatusQuery = {
-      getCurrentCycle: vi.fn().mockResolvedValue(currentCycle({ daysLeft: 5, hoursLeft: undefined })),
+      getCurrentCycle: vi
+        .fn()
+        .mockResolvedValue(currentCycle({ daysLeft: 5, hoursLeft: undefined })),
       getCycleParticipantNames: vi.fn().mockResolvedValue({
         cycleName: '똥글똥글 2기 - 7주차',
         submittedNames: ['박준형'],
@@ -157,14 +179,18 @@ describe('MeCommand', () => {
 
     await command.execute(interaction as never);
 
-    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
     expect(reply.content).toContain('마감까지 5일');
   });
 
   it('explains when the current cycle has no GitHub issue link yet', async () => {
     const repos = createRepos();
     const getCycleStatusQuery = {
-      getCurrentCycle: vi.fn().mockResolvedValue(currentCycle({ githubIssueUrl: null })),
+      getCurrentCycle: vi
+        .fn()
+        .mockResolvedValue(currentCycle({ githubIssueUrl: null })),
       getCycleParticipantNames: vi.fn().mockResolvedValue({
         cycleName: '똥글똥글 2기 - 7주차',
         submittedNames: ['박준형'],
@@ -188,7 +214,9 @@ describe('MeCommand', () => {
   it('shows unknown submission status when participant names cannot be loaded', async () => {
     const repos = createRepos();
     const getCycleStatusQuery = {
-      getCurrentCycle: vi.fn().mockResolvedValue(currentCycle({ daysLeft: 0, hoursLeft: 0 })),
+      getCurrentCycle: vi
+        .fn()
+        .mockResolvedValue(currentCycle({ daysLeft: 0, hoursLeft: 0 })),
       getCycleParticipantNames: vi.fn().mockResolvedValue(null),
     };
     const command = createCommand(repos, getCycleStatusQuery);
@@ -196,13 +224,17 @@ describe('MeCommand', () => {
 
     await command.execute(interaction as never);
 
-    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
     expect(reply.content).toContain('오늘 마감');
     expect(reply.content).toContain('내 제출 상태: 확인 불가');
   });
 
   it('guides users without GitHub or current cycle to connect their account first', async () => {
-    const repos = createRepos(createMember({ githubUsername: null, discordUsername: null }));
+    const repos = createRepos(
+      createMember({ githubUsername: null, discordUsername: null })
+    );
     const getCycleStatusQuery = {
       getCurrentCycle: vi.fn().mockResolvedValue(null),
     };
@@ -233,7 +265,9 @@ describe('MeCommand', () => {
 
     await command.execute(interaction as never);
 
-    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
     expect(reply.content).toContain('승인된 조직**: 0개');
     expect(reply.content).toContain('조직 가입이 필요해요');
     expect(reply.content).toContain('/organization join');
@@ -253,7 +287,9 @@ describe('MeCommand', () => {
 
     await command.execute(interaction as never);
 
-    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
     expect(reply.content).toContain('조직 승인 대기 중이에요');
     expect(reply.content).toContain('운영진 승인 후');
     expect(reply.content).toContain('/me organizations');
@@ -265,7 +301,9 @@ describe('MeCommand', () => {
 
     await command.execute(interaction as never);
 
-    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
     expect(reply.content).toContain('진행 중인 주차를 찾지 못했어요');
   });
 
@@ -298,7 +336,9 @@ describe('MeCommand', () => {
 
     await command.execute(interaction as never);
 
-    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
     expect(reply.content).toContain('아직 회원 등록이 필요해요');
     expect(reply.content).toContain('/member create');
     expect(reply.content).toContain('GitHub 계정');
@@ -311,35 +351,57 @@ describe('MeCommand', () => {
     const interaction = createInteraction();
     interaction.editReply.mockRejectedValue(new Error('reply failed'));
 
-    await expect(command.execute(interaction as never)).resolves.toBeUndefined();
+    await expect(
+      command.execute(interaction as never)
+    ).resolves.toBeUndefined();
   });
 
   it('lists organizations with readable status emojis', async () => {
     const repos = createRepos();
-    repos.organizationMemberRepo.findByMemberWithOrganizations.mockResolvedValue([
-      {
-        organizationMember: { status: { value: 'APPROVED' }, role: { value: 'MEMBER' }, joinedAt: '2026-01-01T00:00:00.000Z' },
-        organization: { name: '똥글똥글' },
-      },
-      {
-        organizationMember: { status: { value: 'PENDING' }, role: { value: 'MEMBER' }, joinedAt: '2026-01-02T00:00:00.000Z' },
-        organization: { name: '대기 조직' },
-      },
-      {
-        organizationMember: { status: { value: 'REJECTED' }, role: { value: 'MEMBER' }, joinedAt: '2026-01-03T00:00:00.000Z' },
-        organization: { name: '거절 조직' },
-      },
-      {
-        organizationMember: { status: { value: 'APPROVED' }, role: { value: 'MEMBER' }, joinedAt: '2026-01-04T00:00:00.000Z' },
-        organization: null,
-      },
-    ]);
+    repos.organizationMemberRepo.findByMemberWithOrganizations.mockResolvedValue(
+      [
+        {
+          organizationMember: {
+            status: { value: 'APPROVED' },
+            role: { value: 'MEMBER' },
+            joinedAt: '2026-01-01T00:00:00.000Z',
+          },
+          organization: { name: '똥글똥글' },
+        },
+        {
+          organizationMember: {
+            status: { value: 'PENDING' },
+            role: { value: 'MEMBER' },
+            joinedAt: '2026-01-02T00:00:00.000Z',
+          },
+          organization: { name: '대기 조직' },
+        },
+        {
+          organizationMember: {
+            status: { value: 'REJECTED' },
+            role: { value: 'MEMBER' },
+            joinedAt: '2026-01-03T00:00:00.000Z',
+          },
+          organization: { name: '거절 조직' },
+        },
+        {
+          organizationMember: {
+            status: { value: 'APPROVED' },
+            role: { value: 'MEMBER' },
+            joinedAt: '2026-01-04T00:00:00.000Z',
+          },
+          organization: null,
+        },
+      ]
+    );
     const command = createCommand(repos);
     const interaction = createInteraction('organizations');
 
     await command.execute(interaction as never);
 
-    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
     expect(reply.content).toContain('✅ **똥글똥글**');
     expect(reply.content).toContain('⏳ **대기 조직**');
     expect(reply.content).toContain('❌ **거절 조직**');
@@ -352,7 +414,8 @@ describe('MeCommand', () => {
     await command.execute(interaction as never);
 
     expect(interaction.editReply).toHaveBeenCalledWith({
-      content: '📋 아직 소속된 조직이 없습니다.\n\n`/organization join` 명령어로 조직에 가입 신청을 해주세요!',
+      content:
+        '📋 아직 소속된 조직이 없습니다.\n\n`/organization join` 명령어로 조직에 가입 신청을 해주세요!',
     });
   });
 
@@ -367,33 +430,51 @@ describe('MeCommand', () => {
     const noUser = createInteraction('organizations');
     delete noUser.user;
     await command.execute(noUser as never);
-    expect(noUser.editReply).toHaveBeenCalledWith({ content: '❌ 사용자 정보를 가져올 수 없습니다.' });
+    expect(noUser.editReply).toHaveBeenCalledWith({
+      content: '❌ 사용자 정보를 가져올 수 없습니다.',
+    });
 
     const missingMemberRepos = createRepos(null);
     const missingMember = createInteraction('organizations');
     await createCommand(missingMemberRepos).execute(missingMember as never);
-    expect(missingMember.editReply).toHaveBeenCalledWith({ content: '❌ 회원 정보를 찾을 수 없습니다.' });
+    expect(missingMember.editReply).toHaveBeenCalledWith({
+      content: '❌ 회원 정보를 찾을 수 없습니다.',
+    });
 
     const throwingRepos = createRepos();
-    throwingRepos.organizationMemberRepo.findByMemberWithOrganizations.mockRejectedValue(new Error('db down'));
+    throwingRepos.organizationMemberRepo.findByMemberWithOrganizations.mockRejectedValue(
+      new Error('db down')
+    );
     const errorInteraction = createInteraction('organizations');
     await createCommand(throwingRepos).execute(errorInteraction as never);
-    expect(errorInteraction.editReply).toHaveBeenCalledWith({ content: '❌ 조직 목록 조회 중 오류가 발생했습니다.' });
+    expect(errorInteraction.editReply).toHaveBeenCalledWith({
+      content: '❌ 조직 목록 조회 중 오류가 발생했습니다.',
+    });
 
     const failedErrorReply = createInteraction('organizations');
     failedErrorReply.editReply.mockRejectedValue(new Error('reply failed'));
-    await expect(createCommand(throwingRepos).execute(failedErrorReply as never)).resolves.toBeUndefined();
+    await expect(
+      createCommand(throwingRepos).execute(failedErrorReply as never)
+    ).resolves.toBeUndefined();
   });
 
   it('lists generations with active and inactive states', async () => {
     const repos = createRepos();
     repos.generationMemberRepo.findByMemberWithGenerations.mockResolvedValue([
       {
-        generation: { name: '똥글똥글 2기', startedAt: '2026-01-01T00:00:00.000Z', isActive: true },
+        generation: {
+          name: '똥글똥글 2기',
+          startedAt: '2026-01-01T00:00:00.000Z',
+          isActive: true,
+        },
         organization: { name: '똥글똥글' },
       },
       {
-        generation: { name: '똥글똥글 1기', startedAt: '2025-01-01T00:00:00.000Z', isActive: false },
+        generation: {
+          name: '똥글똥글 1기',
+          startedAt: '2025-01-01T00:00:00.000Z',
+          isActive: false,
+        },
         organization: null,
       },
       {
@@ -406,7 +487,9 @@ describe('MeCommand', () => {
 
     await command.execute(interaction as never);
 
-    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as { content: string };
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
     expect(reply.content).toContain('🎯 **똥글똥글 2기**');
     expect(reply.content).toContain('조직: 똥글똥글');
     expect(reply.content).toContain('상태: 활성중 ✅');
@@ -421,7 +504,8 @@ describe('MeCommand', () => {
     await command.execute(interaction as never);
 
     expect(interaction.editReply).toHaveBeenCalledWith({
-      content: '📋 아직 참여 중인 기수가 없습니다.\n\n`/generation join` 명령어로 기수에 참여해주세요!',
+      content:
+        '📋 아직 참여 중인 기수가 없습니다.\n\n`/generation join` 명령어로 기수에 참여해주세요!',
     });
   });
 
@@ -436,21 +520,31 @@ describe('MeCommand', () => {
     const noUser = createInteraction('generations');
     delete noUser.user;
     await command.execute(noUser as never);
-    expect(noUser.editReply).toHaveBeenCalledWith({ content: '❌ 사용자 정보를 가져올 수 없습니다.' });
+    expect(noUser.editReply).toHaveBeenCalledWith({
+      content: '❌ 사용자 정보를 가져올 수 없습니다.',
+    });
 
     const missingMemberRepos = createRepos(null);
     const missingMember = createInteraction('generations');
     await createCommand(missingMemberRepos).execute(missingMember as never);
-    expect(missingMember.editReply).toHaveBeenCalledWith({ content: '❌ 회원 정보를 찾을 수 없습니다.' });
+    expect(missingMember.editReply).toHaveBeenCalledWith({
+      content: '❌ 회원 정보를 찾을 수 없습니다.',
+    });
 
     const throwingRepos = createRepos();
-    throwingRepos.generationMemberRepo.findByMemberWithGenerations.mockRejectedValue(new Error('db down'));
+    throwingRepos.generationMemberRepo.findByMemberWithGenerations.mockRejectedValue(
+      new Error('db down')
+    );
     const errorInteraction = createInteraction('generations');
     await createCommand(throwingRepos).execute(errorInteraction as never);
-    expect(errorInteraction.editReply).toHaveBeenCalledWith({ content: '❌ 기수 목록 조회 중 오류가 발생했습니다.' });
+    expect(errorInteraction.editReply).toHaveBeenCalledWith({
+      content: '❌ 기수 목록 조회 중 오류가 발생했습니다.',
+    });
 
     const failedErrorReply = createInteraction('generations');
     failedErrorReply.editReply.mockRejectedValue(new Error('reply failed'));
-    await expect(createCommand(throwingRepos).execute(failedErrorReply as never)).resolves.toBeUndefined();
+    await expect(
+      createCommand(throwingRepos).execute(failedErrorReply as never)
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/server/src/presentation/discord/commands/MeCommand.ts
+++ b/apps/server/src/presentation/discord/commands/MeCommand.ts
@@ -145,7 +145,9 @@ export class MeCommand implements DiscordCommand {
 
         if (!participantNames) {
           submissionStatusMessage = '📌 **내 제출 상태: 확인 불가**\n';
-        } else if (participantNames.submittedNames.includes(member.name.value)) {
+        } else if (
+          participantNames.submittedNames.includes(member.name.value)
+        ) {
           submissionStatusMessage = '📌 **내 제출 상태: ✅ 제출 완료**\n';
         } else {
           submissionStatusMessage = '📌 **내 제출 상태: ⏳ 아직 제출 전**\n';

--- a/apps/server/src/presentation/discord/commands/MeCommand.ts
+++ b/apps/server/src/presentation/discord/commands/MeCommand.ts
@@ -23,7 +23,7 @@ function formatRemainingTime(daysLeft: number, hoursLeft?: number): string {
     return `마감까지 ${daysLeft}일 ${hoursLeft}시간`;
   }
 
-  return daysLeft > 0 ? `마감까지 ${daysLeft}일` : '오늘 마감';
+  return `마감까지 ${daysLeft}일`;
 }
 
 function createIssueButton(issueUrl?: string | null) {
@@ -113,6 +113,16 @@ export class MeCommand implements DiscordCommand {
       const approvedOrganizations = organizationMembers.filter(
         (om) => om.status.value === 'APPROVED'
       ).length;
+      const pendingOrganizations = organizationMembers.filter(
+        (om) => om.status.value === 'PENDING'
+      ).length;
+
+      const organizationGuidance =
+        approvedOrganizations > 0
+          ? ''
+          : pendingOrganizations > 0
+            ? '🏢 **조직 승인 대기 중이에요.** 운영진 승인 후 주차 참여와 제출 상태 확인이 가능해요. `/me organizations`로 신청 상태를 확인해 주세요.\n'
+            : '🏢 **조직 가입이 필요해요.** 먼저 `/organization join`으로 똥글똥글 조직에 가입 신청해 주세요. 신청 후 `/me organizations`로 상태를 확인할 수 있어요.\n';
 
       // 소속 기수 수 확인
       const generationMembers = await this.generationMemberRepo.findByMember(
@@ -125,22 +135,49 @@ export class MeCommand implements DiscordCommand {
           )
         : null;
 
+      let submissionStatusMessage = '';
+      if (currentCycle && this.getCycleStatusQuery) {
+        const participantNames =
+          await this.getCycleStatusQuery.getCycleParticipantNames(
+            currentCycle.id,
+            DEFAULT_ORGANIZATION_SLUG
+          );
+
+        if (!participantNames) {
+          submissionStatusMessage = '📌 **내 제출 상태: 확인 불가**\n';
+        } else if (participantNames.submittedNames.includes(member.name.value)) {
+          submissionStatusMessage = '📌 **내 제출 상태: ✅ 제출 완료**\n';
+        } else {
+          submissionStatusMessage = '📌 **내 제출 상태: ⏳ 아직 제출 전**\n';
+        }
+      }
+
       const currentCycleMessage = currentCycle
         ? `🎯 **현재 주차**: ${currentCycle.generationName} ${currentCycle.week}주차\n` +
           `⏰ **${formatRemainingTime(currentCycle.daysLeft, currentCycle.hoursLeft)}**\n` +
-          `🔗 이슈: ${currentCycle.githubIssueUrl ?? '아직 연결된 이슈가 없어요.'}\n`
+          `🔗 이슈: ${currentCycle.githubIssueUrl ?? '아직 연결된 이슈가 없어요.'}\n` +
+          submissionStatusMessage
         : '🎯 **현재 주차**: 진행 중인 주차를 찾지 못했어요. `/cycle current`로 다시 확인해 주세요.\n';
 
       const githubStatus = member.githubUsername
         ? `✅ GitHub 연결됨: ${member.githubUsername.value}`
         : '⚠️ GitHub 계정이 아직 연결되지 않았어요.';
 
-      const nextActions = member.githubUsername
-        ? '1. 이번 주차 글을 작성해 주세요.\n' +
-          '2. GitHub 이슈에 제출 링크를 댓글로 남겨 주세요.\n' +
-          '3. `/cycle status`로 전체 제출 현황을 확인해 주세요.'
-        : '1. GitHub 계정을 먼저 연결해 주세요.\n' +
-          '2. 연결 후 `/me info`로 상태를 다시 확인해 주세요.';
+      const nextActions =
+        approvedOrganizations === 0
+          ? pendingOrganizations > 0
+            ? '1. 운영진 승인을 기다려 주세요.\n' +
+              '2. `/me organizations`로 조직 가입 신청 상태를 확인해 주세요.\n' +
+              '3. 승인 후 `/generation join`으로 참여 기수를 확인해 주세요.'
+            : '1. `/organization join`으로 똥글똥글 조직에 가입 신청해 주세요.\n' +
+              '2. `/me organizations`로 승인 상태를 확인해 주세요.\n' +
+              '3. 승인 후 `/generation join`으로 참여 기수를 확인해 주세요.'
+          : member.githubUsername
+            ? '1. 이번 주차 글을 작성해 주세요.\n' +
+              '2. GitHub 이슈에 제출 링크를 댓글로 남겨 주세요.\n' +
+              '3. `/cycle status`로 전체 제출 현황을 확인해 주세요.'
+            : '1. GitHub 계정을 먼저 연결해 주세요.\n' +
+              '2. 연결 후 `/me info`로 상태를 다시 확인해 주세요.';
 
       await interaction.editReply({
         content:
@@ -149,8 +186,9 @@ export class MeCommand implements DiscordCommand {
           `**Discord**: ${member.discordUsername?.value ?? '미설정'}\n` +
           `${githubStatus}\n` +
           `**승인된 조직**: ${approvedOrganizations}개\n` +
-          `**참여 기수**: ${generationMembers.length}개\n\n` +
-          `${currentCycleMessage}\n` +
+          `**참여 기수**: ${generationMembers.length}개\n` +
+          `${organizationGuidance ? `\n${organizationGuidance}` : '\n'}` +
+          `\n${currentCycleMessage}\n` +
           '**다음 행동**\n' +
           nextActions,
         components: createIssueButton(currentCycle?.githubIssueUrl),

--- a/apps/worker/.dev.vars.example
+++ b/apps/worker/.dev.vars.example
@@ -1,0 +1,8 @@
+# Local-only sample values. Do not commit real secrets.
+APP_ENV=local
+API_BASE_URL=https://donguel-donguel-notification.onrender.com
+DISCORD_COMMAND_SYNC_POLICY=interactions
+DISCORD_PUBLIC_KEY=replace-with-discord-application-public-key
+DISCORD_APPLICATION_ID=replace-with-discord-application-id
+DISCORD_BOT_TOKEN=replace-with-discord-bot-token
+GITHUB_WEBHOOK_SECRET=replace-with-github-webhook-secret

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@hanghae-study/worker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloudflare Workers migration scaffold for 똥글똥글 Discord interactions and webhooks",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "hono": "^4.7.5"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260426.1",
+    "typescript": "^5.8.3",
+    "vitest": "^4.0.16",
+    "wrangler": "^4.13.2"
+  }
+}

--- a/apps/worker/src/discord.ts
+++ b/apps/worker/src/discord.ts
@@ -1,0 +1,119 @@
+export type WorkerEnv = {
+  APP_ENV?: 'local' | 'staging' | 'production';
+  API_BASE_URL?: string;
+  DISCORD_COMMAND_SYNC_POLICY?: 'interactions';
+  DISCORD_PUBLIC_KEY?: string;
+  DISCORD_APPLICATION_ID?: string;
+  DISCORD_BOT_TOKEN?: string;
+  GITHUB_WEBHOOK_SECRET?: string;
+};
+
+export type DiscordInteraction = {
+  id?: string;
+  type: number;
+  data?: {
+    id?: string;
+    name?: string;
+    type?: number;
+    options?: Array<{ name: string; type: number; value?: unknown }>;
+  };
+};
+
+export const DISCORD_INTERACTION_TYPE = {
+  PING: 1,
+  APPLICATION_COMMAND: 2,
+} as const;
+
+export const DISCORD_RESPONSE_TYPE = {
+  PONG: 1,
+  CHANNEL_MESSAGE_WITH_SOURCE: 4,
+} as const;
+
+export function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      ...init?.headers,
+    },
+  });
+}
+
+function hexToArrayBuffer(hex: string): ArrayBuffer {
+  if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) {
+    throw new Error('Invalid hex string');
+  }
+
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes.buffer;
+}
+
+async function verifyEd25519Signature({
+  publicKey,
+  signature,
+  message,
+}: {
+  publicKey: string;
+  signature: string;
+  message: string;
+}): Promise<boolean> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    hexToArrayBuffer(publicKey),
+    { name: 'Ed25519', namedCurve: 'Ed25519' },
+    false,
+    ['verify']
+  );
+
+  return crypto.subtle.verify(
+    'Ed25519',
+    key,
+    hexToArrayBuffer(signature),
+    new TextEncoder().encode(message)
+  );
+}
+
+export async function verifyDiscordRequest(
+  request: Request,
+  body: string,
+  env: WorkerEnv
+): Promise<boolean> {
+  if (!env.DISCORD_PUBLIC_KEY) {
+    return false;
+  }
+
+  const signature = request.headers.get('x-signature-ed25519');
+  const timestamp = request.headers.get('x-signature-timestamp');
+
+  if (!signature || !timestamp) {
+    return false;
+  }
+
+  try {
+    return await verifyEd25519Signature({
+      publicKey: env.DISCORD_PUBLIC_KEY,
+      signature,
+      message: `${timestamp}${body}`,
+    });
+  } catch {
+    return false;
+  }
+}
+
+export function createDiscordCommandScaffoldResponse(interaction: DiscordInteraction) {
+  const commandName = interaction.data?.name ?? 'unknown';
+
+  return {
+    type: DISCORD_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: {
+      flags: 64,
+      content:
+        `🧪 Cloudflare Workers 이전 환경이 연결됐어요.\n\n` +
+        `수신한 명령어: \`/${commandName}\`\n` +
+        `현재 PR은 Render sleep 문제를 피하기 위한 Discord Interaction Endpoint 기반 이전 준비 단계예요.`,
+    },
+  };
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,0 +1,80 @@
+import { Hono } from 'hono';
+
+import {
+  DISCORD_INTERACTION_TYPE,
+  DISCORD_RESPONSE_TYPE,
+  DiscordInteraction,
+  WorkerEnv,
+  createDiscordCommandScaffoldResponse,
+  jsonResponse,
+  verifyDiscordRequest,
+} from './discord';
+
+const app = new Hono<{ Bindings: WorkerEnv }>();
+
+app.get('/', (c) =>
+  c.json({
+    status: 'ok',
+    service: 'donguel-donguel-notification-worker',
+    runtime: 'cloudflare-workers',
+  })
+);
+
+app.get('/health', (c) =>
+  c.json({
+    status: 'healthy',
+    runtime: 'cloudflare-workers',
+    timestamp: new Date().toISOString(),
+  })
+);
+
+app.post('/discord/interactions', async (c) => {
+  const body = await c.req.text();
+  const isValid = await verifyDiscordRequest(c.req.raw, body, c.env);
+
+  if (!isValid) {
+    return jsonResponse({ error: 'invalid Discord request signature' }, { status: 401 });
+  }
+
+  let interaction: DiscordInteraction;
+  try {
+    interaction = JSON.parse(body) as DiscordInteraction;
+  } catch {
+    return jsonResponse({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  if (interaction.type === DISCORD_INTERACTION_TYPE.PING) {
+    return jsonResponse({ type: DISCORD_RESPONSE_TYPE.PONG });
+  }
+
+  if (interaction.type === DISCORD_INTERACTION_TYPE.APPLICATION_COMMAND) {
+    return jsonResponse(createDiscordCommandScaffoldResponse(interaction));
+  }
+
+  return jsonResponse(
+    {
+      type: DISCORD_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        flags: 64,
+        content: '지원하지 않는 Discord interaction 타입이에요.',
+      },
+    },
+    { status: 200 }
+  );
+});
+
+app.post('/webhook/github', async (c) => {
+  const target = new URL('/webhook/github', c.env.API_BASE_URL);
+  const response = await fetch(target, {
+    method: 'POST',
+    headers: c.req.raw.headers,
+    body: c.req.raw.body,
+  });
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: response.headers,
+  });
+});
+
+export default app;

--- a/apps/worker/test/discord.test.ts
+++ b/apps/worker/test/discord.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DISCORD_INTERACTION_TYPE,
+  DISCORD_RESPONSE_TYPE,
+  createDiscordCommandScaffoldResponse,
+  verifyDiscordRequest,
+} from '../src/discord';
+
+describe('Cloudflare Discord interaction scaffold', () => {
+  it('creates an ephemeral scaffold response with the command name', () => {
+    const response = createDiscordCommandScaffoldResponse({
+      type: DISCORD_INTERACTION_TYPE.APPLICATION_COMMAND,
+      data: { name: 'me' },
+    });
+
+    expect(response.type).toBe(DISCORD_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE);
+    expect(response.data.flags).toBe(64);
+    expect(response.data.content).toContain('/me');
+    expect(response.data.content).toContain('Cloudflare Workers 이전 환경');
+  });
+
+  it('rejects Discord requests when the public key is not configured', async () => {
+    const request = new Request('https://worker.test/discord/interactions', {
+      method: 'POST',
+      headers: {
+        'x-signature-ed25519': '00',
+        'x-signature-timestamp': '1',
+      },
+    });
+
+    await expect(verifyDiscordRequest(request, '{}', {})).resolves.toBe(false);
+  });
+
+  it('rejects Discord requests with missing signature headers', async () => {
+    const request = new Request('https://worker.test/discord/interactions', {
+      method: 'POST',
+    });
+
+    await expect(
+      verifyDiscordRequest(request, '{}', { DISCORD_PUBLIC_KEY: '00'.repeat(32) })
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../packages/config/typescript/base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types", "vitest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "worker-configuration.d.ts"]
+}

--- a/apps/worker/worker-configuration.d.ts
+++ b/apps/worker/worker-configuration.d.ts
@@ -1,0 +1,11 @@
+declare namespace Cloudflare {
+  interface Env {
+    APP_ENV?: 'local' | 'staging' | 'production';
+    API_BASE_URL?: string;
+    DISCORD_COMMAND_SYNC_POLICY?: 'interactions';
+    DISCORD_PUBLIC_KEY?: string;
+    DISCORD_APPLICATION_ID?: string;
+    DISCORD_BOT_TOKEN?: string;
+    GITHUB_WEBHOOK_SECRET?: string;
+  }
+}

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "donguel-donguel-notification-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-04-28",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true
+  },
+  "vars": {
+    "APP_ENV": "staging",
+    "API_BASE_URL": "https://donguel-donguel-notification.onrender.com",
+    "DISCORD_COMMAND_SYNC_POLICY": "interactions"
+  }
+}

--- a/docs/cloudflare-workers-migration.md
+++ b/docs/cloudflare-workers-migration.md
@@ -1,0 +1,132 @@
+# Cloudflare Workers migration setup
+
+이 PR은 Render Free sleep으로 Discord slash command가 `응답 없음`이 되는 문제를 줄이기 위해 Cloudflare Workers 이전을 준비하는 환경구성이다.
+
+## 목표
+
+현재 Render Web Service가 담당하던 역할을 한 번에 모두 옮기지 않고, 응답 안정성에 가장 큰 영향을 주는 Discord Interaction Endpoint부터 분리한다.
+
+```txt
+Discord Slash Command
+  -> Cloudflare Worker /discord/interactions
+  -> command 처리 또는 기존 API 호출
+  -> Discord interaction response
+```
+
+이 구조는 `discord.js` gateway bot이 Render에서 항상 로그인 상태를 유지해야 하는 의존을 제거한다.
+
+## 이번 PR에 포함된 것
+
+- `apps/worker` Cloudflare Workers 패키지 추가
+- `wrangler.jsonc` 배포 설정 초안
+- `/health` Worker 헬스체크
+- `/discord/interactions` Discord Interaction Endpoint 스캐폴드
+  - Discord Ed25519 signature 검증
+  - Discord PING/PONG 응답
+  - application command scaffold 응답
+- `/webhook/github` 프록시 스캐폴드
+  - 초기 이전 단계에서는 기존 Render API로 전달
+- 로컬/운영 secret 예시 문서
+- 최소 Vitest 테스트
+
+## Cloudflare 설정값
+
+### Wrangler vars
+
+`apps/worker/wrangler.jsonc`에 커밋 가능한 기본값만 둔다.
+
+```jsonc
+{
+  "vars": {
+    "APP_ENV": "staging",
+    "API_BASE_URL": "https://donguel-donguel-notification.onrender.com",
+    "DISCORD_COMMAND_SYNC_POLICY": "interactions"
+  }
+}
+```
+
+### Secrets
+
+실제 값은 커밋하지 말고 Cloudflare secret으로 넣는다.
+
+```bash
+cd apps/worker
+pnpm wrangler secret put DISCORD_PUBLIC_KEY
+pnpm wrangler secret put DISCORD_APPLICATION_ID
+pnpm wrangler secret put DISCORD_BOT_TOKEN
+pnpm wrangler secret put GITHUB_WEBHOOK_SECRET
+```
+
+초기 scaffold에서 필수인 값은 `DISCORD_PUBLIC_KEY`다. Discord Developer Portal의 Application Public Key를 사용한다.
+
+## Discord Developer Portal 설정
+
+1. Discord Developer Portal에서 bot application을 연다.
+2. **General Information > Interactions Endpoint URL**에 Worker URL을 등록한다.
+
+```txt
+https://<worker-subdomain>.workers.dev/discord/interactions
+```
+
+3. 저장 시 Discord가 PING 요청을 보내며, Worker가 signature 검증 후 `{ "type": 1 }`로 응답해야 한다.
+4. 이 방식이 검증되면 Render의 gateway bot 의존을 줄이거나 제거할 수 있다.
+
+## 단계별 이전 계획
+
+### Phase 1. Endpoint 검증
+
+- Cloudflare Worker 배포
+- Discord Interaction Endpoint URL 등록
+- Discord PING 검증 통과 확인
+- scaffold 응답으로 slash command 요청이 Worker에 도달하는지 확인
+
+### Phase 2. 읽기 command 이전
+
+우선 DB 쓰기가 없는 command부터 옮긴다.
+
+- `/me info`
+- `/cycle current`
+- `/cycle status`
+
+초기에는 Worker가 기존 Render API를 호출해 데이터를 읽어도 된다. 이 단계의 목표는 Discord 응답 경로를 Render sleep에서 분리하는 것이다.
+
+### Phase 3. GitHub webhook 이전
+
+- `/webhook/github` signature 검증 추가
+- GitHub Issue comment payload 처리 이전
+- 제출 저장/Discord 알림까지 Worker 경로에서 처리
+
+### Phase 4. DB 전략 결정
+
+둘 중 하나를 선택한다.
+
+#### A. 기존 Postgres 유지
+
+- Neon/Supabase HTTP driver 또는 Cloudflare Hyperdrive 검토
+- 현재 Drizzle Postgres schema를 최대한 유지
+- 마이그레이션 비용이 낮음
+
+#### B. Cloudflare D1 이전
+
+- D1 무료 한도 활용 가능
+- Postgres -> SQLite 계열 schema 조정 필요
+- Drizzle D1 adapter와 migration 재설계 필요
+
+## 로컬 실행
+
+```bash
+export PATH="$HOME/.hermes/node/bin:$PATH"
+pnpm install
+pnpm --filter @hanghae-study/worker test
+pnpm --filter @hanghae-study/worker dev
+```
+
+로컬 secret은 `apps/worker/.dev.vars`에 둘 수 있고, 예시는 `.dev.vars.example`에 있다.
+
+## 운영 주의사항
+
+- Worker에는 `DISCORD_BOT_TOKEN`을 넣더라도 gateway login에는 사용하지 않는다.
+- Interaction Endpoint 방식은 Discord 요청에 3초 안에 응답해야 한다.
+- 무거운 처리는 defer/follow-up webhook 패턴으로 분리한다.
+- Render API가 남아있는 동안 `API_BASE_URL` 장애는 Worker 응답에도 영향을 줄 수 있다.
+- 완전한 sleep 제거는 command 처리와 필요한 read/write 경로가 Worker 쪽으로 이전되어야 달성된다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 17.2.3
       drizzle-orm:
         specifier: ^0.42.0
-        version: 0.42.0(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.5.0)(postgres@3.4.7)
+        version: 0.42.0(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.5.0)(postgres@3.4.7)
       jose:
         specifier: ^5.9.6
         version: 5.10.0
@@ -139,6 +139,25 @@ importers:
         specifier: ^3.4.1
         version: 3.4.1
 
+  apps/worker:
+    dependencies:
+      hono:
+        specifier: ^4.7.5
+        version: 4.11.3
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260426.1
+        version: 4.20260426.1
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/ui@4.0.16)(tsx@4.21.0)(yaml@2.8.2)
+      wrangler:
+        specifier: ^4.13.2
+        version: 4.85.0(@cloudflare/workers-types@4.20260426.1)
+
   packages/config/eslint:
     dependencies:
       '@eslint/js':
@@ -210,6 +229,52 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@cloudflare/kv-asset-handler@0.4.2':
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260424.1':
+    resolution: {integrity: sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260424.1':
+    resolution: {integrity: sha512-LqWKcE7x/9KyC2iQvKPeb20hKST3dYXDZlYTvFymgR1DfLS0OFOCzVGTloVNd7WqvK4SkdzBYfxo7QMIAeBK0w==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260424.1':
+    resolution: {integrity: sha512-YlEBFbAYZHe/ylzl8WEYQEU/jr+0XMqXaST2oBk5oVjksdb1NGuJaggluCdZAzuJJ8UqdTmyhY5u/qrasbiFWA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260424.1':
+    resolution: {integrity: sha512-qJ0X0m6cL8fWDUPDg8K4IxYZXNJI6XbeOihqjnqKbAClrjdPDn8VUSd+z2XiCQ5NylMtMrpa/skC9UfaR6mh8g==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260424.1':
+    resolution: {integrity: sha512-tZ7Z9qmYNAP6z1/+8r/zKbk8F8DZmpmwNzMeN+zkde2Wnhfr3FBqOkJXT/5zmli8HPoWrIXxSiyqcNDMy8V2Zg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260426.1':
+    resolution: {integrity: sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ==}
+
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
@@ -218,6 +283,10 @@ packages:
     resolution: {integrity: sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg==}
     peerDependencies:
       commander: ~13.1.0
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@cush/relative@1.0.0':
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
@@ -255,6 +324,9 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@envelop/core@5.4.0':
     resolution: {integrity: sha512-/1fat63pySE8rw/dZZArEVytLD90JApY85deDJ0/34gm+yhQ3k70CloSUevxoOE4YCGveG3s9SJJfQeeB4NAtQ==}
@@ -301,6 +373,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -321,6 +399,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -349,6 +433,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -369,6 +459,12 @@ packages:
 
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -397,6 +493,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -417,6 +519,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.2':
     resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -445,6 +553,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -465,6 +579,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.2':
     resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -493,6 +613,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -513,6 +639,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.2':
     resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -541,6 +673,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -561,6 +699,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.2':
     resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -589,6 +733,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -609,6 +759,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.2':
     resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -637,6 +793,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -657,6 +819,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.2':
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -685,6 +853,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -693,6 +867,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -721,6 +901,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.1':
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
     engines: {node: '>=18'}
@@ -735,6 +921,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -763,6 +955,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
@@ -771,6 +969,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -799,6 +1003,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
@@ -819,6 +1029,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -847,6 +1063,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -867,6 +1089,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.2':
     resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1085,6 +1313,143 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
@@ -1231,6 +1596,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1578,6 +1946,15 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
   '@prisma/instrumentation@5.22.0':
     resolution: {integrity: sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==}
 
@@ -1741,8 +2118,15 @@ packages:
     resolution: {integrity: sha512-A4srR9mEBFdVXwSEKjQ94msUbVkMr8JeFiEj9ouOFORw/Y/ux/WV2bWVD/ZI9wq0TcTNK8L1wBgU8UMS5lIq3A==}
     engines: {node: '>=14.18'}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2039,6 +2423,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
@@ -2178,6 +2565,10 @@ packages:
 
   constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cosmiconfig@9.0.0:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
@@ -2374,6 +2765,9 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -2404,6 +2798,11 @@ packages:
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2825,6 +3224,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
@@ -2929,6 +3332,11 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  miniflare@4.20260424.0:
+    resolution: {integrity: sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -3096,6 +3504,9 @@ packages:
   path-root@0.1.1:
     resolution: {integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==}
     engines: {node: '>=0.10.0'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3291,6 +3702,10 @@ packages:
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3402,6 +3817,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3612,6 +4031,13 @@ packages:
     resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
     engines: {node: '>=18.17'}
 
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
   universal-github-app-jwt@2.2.2:
     resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
 
@@ -3738,12 +4164,39 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20260424.1:
+    resolution: {integrity: sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.85.0:
+    resolution: {integrity: sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg==}
+    engines: {node: '>=20.3.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260424.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -3776,6 +4229,12 @@ packages:
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
@@ -3843,11 +4302,40 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@cloudflare/kv-asset-handler@0.4.2': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260424.1
+
+  '@cloudflare/workerd-darwin-64@1.20260424.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260424.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260424.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260424.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260424.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260426.1': {}
+
   '@colors/colors@1.6.0': {}
 
   '@commander-js/extra-typings@13.1.0(commander@13.1.0)':
     dependencies:
       commander: 13.1.0
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@cush/relative@1.0.0': {}
 
@@ -3908,6 +4396,11 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@envelop/core@5.4.0':
     dependencies:
       '@envelop/instrumentation': 1.0.0
@@ -3950,6 +4443,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
@@ -3960,6 +4456,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -3974,6 +4473,9 @@ snapshots:
   '@esbuild/android-arm@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
@@ -3984,6 +4486,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -3998,6 +4503,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
@@ -4008,6 +4516,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -4022,6 +4533,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
@@ -4032,6 +4546,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -4046,6 +4563,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
@@ -4056,6 +4576,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -4070,6 +4593,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
@@ -4080,6 +4606,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -4094,6 +4623,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
@@ -4104,6 +4636,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -4118,6 +4653,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
@@ -4128,6 +4666,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -4142,10 +4683,16 @@ snapshots:
   '@esbuild/linux-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-x64@0.18.20':
@@ -4160,6 +4707,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
@@ -4167,6 +4717,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -4181,10 +4734,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/sunos-x64@0.18.20':
@@ -4199,6 +4758,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
   '@esbuild/win32-arm64@0.18.20':
     optional: true
 
@@ -4209,6 +4771,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-ia32@0.18.20':
@@ -4223,6 +4788,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
@@ -4233,6 +4801,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2)':
@@ -4553,6 +5124,102 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@inquirer/ansi@1.0.2': {}
 
   '@inquirer/checkbox@4.3.2(@types/node@22.19.3)':
@@ -4688,6 +5355,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5146,6 +5818,18 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
   '@prisma/instrumentation@5.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -5308,10 +5992,14 @@ snapshots:
     dependencies:
       '@sentry/types': 8.9.2
 
+  '@sindresorhus/is@7.2.0': {}
+
   '@so-ric/colorspace@1.1.6':
     dependencies:
       color: 5.0.3
       text-hex: 1.0.0
+
+  '@speed-highlight/core@1.2.15': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5644,6 +6332,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  blake3-wasm@2.1.5: {}
+
   bottleneck@2.19.5: {}
 
   brace-expansion@1.1.12:
@@ -5796,6 +6486,8 @@ snapshots:
       tslib: 2.8.1
       upper-case: 2.0.2
 
+  cookie@1.1.1: {}
+
   cosmiconfig@9.0.0(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
@@ -5890,8 +6582,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.42.0(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.5.0)(postgres@3.4.7):
+  drizzle-orm@0.42.0(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.6.1)(better-sqlite3@12.5.0)(postgres@3.4.7):
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260426.1
       '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.6.1
@@ -5917,6 +6610,8 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser-es@1.0.5: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -6041,6 +6736,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.2
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   escape-string-regexp@4.0.0: {}
 
@@ -6467,6 +7191,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@4.1.5: {}
+
   kuler@2.0.0: {}
 
   levn@0.4.1:
@@ -6559,6 +7285,18 @@ snapshots:
       picomatch: 2.3.1
 
   mimic-response@3.1.0: {}
+
+  miniflare@4.20260424.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260424.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   minimatch@3.1.2:
     dependencies:
@@ -6727,6 +7465,8 @@ snapshots:
   path-root@0.1.1:
     dependencies:
       path-root-regex: 0.1.2
+
+  path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 
@@ -6929,6 +7669,37 @@ snapshots:
 
   setimmediate@1.0.5: {}
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.3
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -7024,6 +7795,8 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -7228,6 +8001,12 @@ snapshots:
 
   undici@6.21.3: {}
 
+  undici@7.24.8: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
   universal-github-app-jwt@2.2.2: {}
 
   universal-user-agent@7.0.3: {}
@@ -7348,6 +8127,31 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20260424.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260424.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260424.1
+      '@cloudflare/workerd-linux-64': 1.20260424.1
+      '@cloudflare/workerd-linux-arm64': 1.20260424.1
+      '@cloudflare/workerd-windows-64': 1.20260424.1
+
+  wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260424.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260424.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260426.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -7355,6 +8159,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.18.0: {}
 
   ws@8.18.3: {}
 
@@ -7367,5 +8173,18 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zod@4.3.5: {}


### PR DESCRIPTION
## Summary

- Cloudflare Workers migration scaffold를 `apps/worker`로 추가했습니다.
- Discord Interaction Endpoint(`/discord/interactions`) 기반으로 Render gateway bot sleep 문제를 줄일 수 있는 환경구성을 추가했습니다.
- Discord Ed25519 signature 검증, PING/PONG, slash command scaffold 응답을 구현했습니다.
- GitHub webhook은 초기 이전 단계에서 기존 Render API로 proxy하는 scaffold를 추가했습니다.
- 이전 절차/secret 설정/단계별 계획을 `docs/cloudflare-workers-migration.md`에 정리했습니다.
- 기존 1차 Discord 사용성 개선 변경도 함께 포함했습니다.

## Test Plan

- [x] `pnpm --filter @hanghae-study/worker type-check`
- [x] `pnpm --filter @hanghae-study/worker test`
- [x] `pnpm --filter @hanghae-study/worker exec wrangler deploy --dry-run`
- [x] `SKIP_ENV_VALIDATION=true pnpm exec vitest run` from `apps/server`
- [x] `SKIP_ENV_VALIDATION=true pnpm test`
- [x] `git diff --check`

## Notes

Cloudflare에 실제 배포하려면 아래 secret을 Cloudflare에 등록해야 합니다.

```bash
cd apps/worker
pnpm wrangler secret put DISCORD_PUBLIC_KEY
pnpm wrangler secret put DISCORD_APPLICATION_ID
pnpm wrangler secret put DISCORD_BOT_TOKEN
pnpm wrangler secret put GITHUB_WEBHOOK_SECRET
```

Discord Developer Portal의 Interactions Endpoint URL은 다음 형태로 등록합니다.

```txt
https://<worker-subdomain>.workers.dev/discord/interactions
```