### PR TITLE
feat: persist peer review assignments

### DIFF
--- a/apps/server/src/application/peer-review/index.ts
+++ b/apps/server/src/application/peer-review/index.ts
@@ -1,0 +1,1 @@
+export * from './peer-review.commands';

--- a/apps/server/src/application/peer-review/peer-review.commands.test.ts
+++ b/apps/server/src/application/peer-review/peer-review.commands.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import { PeerReviewAssignment } from '@/domain/peer-review';
+import {
+  CompletePeerReviewAssignmentCommand,
+  CreatePeerReviewAssignmentsCommand,
+  GetMyPeerReviewAssignmentQuery,
+  GetPeerReviewStatusQuery,
+  PeerReviewApplicationError,
+  PeerReviewAssignmentRepository,
+  PeerReviewSubmissionLookupPort,
+} from './peer-review.commands';
+
+class FakeSubmissionLookup implements PeerReviewSubmissionLookupPort {
+  constructor(
+    private readonly candidates: Awaited<
+      ReturnType<
+        PeerReviewSubmissionLookupPort['findAcceptedSubmissionCandidates']
+      >
+    >
+  ) {}
+
+  async findAcceptedSubmissionCandidates() {
+    return this.candidates;
+  }
+}
+
+class FakeAssignmentRepository implements PeerReviewAssignmentRepository {
+  assignments: PeerReviewAssignment[];
+
+  constructor(assignments: PeerReviewAssignment[] = []) {
+    this.assignments = assignments;
+  }
+
+  async findByCycleId(cycleId: number) {
+    return this.assignments.filter(
+      (assignment) => assignment.cycleId === cycleId
+    );
+  }
+
+  async findByCycleAndReviewer(cycleId: number, reviewerMemberId: number) {
+    return (
+      this.assignments.find(
+        (assignment) =>
+          assignment.cycleId === cycleId &&
+          assignment.reviewerMemberId === reviewerMemberId
+      ) ?? null
+    );
+  }
+
+  async saveMany(assignments: PeerReviewAssignment[]) {
+    this.assignments.push(...assignments);
+    return assignments;
+  }
+
+  async save(assignment: PeerReviewAssignment) {
+    const index = this.assignments.findIndex(
+      (item) =>
+        item.cycleId === assignment.cycleId &&
+        item.reviewerMemberId === assignment.reviewerMemberId
+    );
+    if (index >= 0) {
+      this.assignments[index] = assignment;
+    } else {
+      this.assignments.push(assignment);
+    }
+    return assignment;
+  }
+}
+
+const candidates = [
+  {
+    memberId: 10,
+    submissionId: 100,
+    submittedAt: new Date('2026-05-26T00:00:00.000Z'),
+  },
+  {
+    memberId: 20,
+    submissionId: 200,
+    submittedAt: new Date('2026-05-26T01:00:00.000Z'),
+  },
+  {
+    memberId: 30,
+    submissionId: 300,
+    submittedAt: new Date('2026-05-26T02:00:00.000Z'),
+  },
+];
+
+describe('CreatePeerReviewAssignmentsCommand', () => {
+  it('creates assignments from accepted submission candidates', async () => {
+    const repository = new FakeAssignmentRepository();
+    const command = new CreatePeerReviewAssignmentsCommand(
+      new FakeSubmissionLookup(candidates),
+      repository
+    );
+
+    const result = await command.execute({ cycleId: 1, seed: 'cycle-1' });
+
+    expect(result).toHaveLength(3);
+    expect(repository.assignments).toHaveLength(3);
+    expect(
+      new Set(result.map((assignment) => assignment.reviewerMemberId))
+    ).toEqual(new Set([10, 20, 30]));
+  });
+
+  it('refuses to create duplicate assignments for a cycle', async () => {
+    const repository = new FakeAssignmentRepository([
+      PeerReviewAssignment.create({
+        cycleId: 1,
+        reviewerMemberId: 10,
+        revieweeMemberId: 20,
+        submissionId: 200,
+      }),
+    ]);
+    const command = new CreatePeerReviewAssignmentsCommand(
+      new FakeSubmissionLookup(candidates),
+      repository
+    );
+
+    await expect(
+      command.execute({ cycleId: 1, seed: 'cycle-1' })
+    ).rejects.toThrow(PeerReviewApplicationError);
+  });
+});
+
+describe('GetMyPeerReviewAssignmentQuery', () => {
+  it('returns the requester assignment for the cycle', async () => {
+    const assignment = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 10,
+      revieweeMemberId: 20,
+      submissionId: 200,
+    });
+    const query = new GetMyPeerReviewAssignmentQuery(
+      new FakeAssignmentRepository([assignment])
+    );
+
+    await expect(
+      query.execute({ cycleId: 1, reviewerMemberId: 10 })
+    ).resolves.toBe(assignment);
+  });
+
+  it('returns null when the requester has no assignment', async () => {
+    const query = new GetMyPeerReviewAssignmentQuery(
+      new FakeAssignmentRepository()
+    );
+
+    await expect(
+      query.execute({ cycleId: 1, reviewerMemberId: 10 })
+    ).resolves.toBeNull();
+  });
+});
+
+describe('GetPeerReviewStatusQuery', () => {
+  it('summarizes assignments by status', async () => {
+    const completed = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 10,
+      revieweeMemberId: 20,
+      submissionId: 200,
+    });
+    completed.complete({ completedAt: new Date('2026-05-27T00:00:00.000Z') });
+    const pending = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 20,
+      revieweeMemberId: 10,
+      submissionId: 100,
+    });
+    const skipped = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 30,
+      revieweeMemberId: 10,
+      submissionId: 100,
+    });
+    skipped.skip({ skippedAt: new Date('2026-05-27T00:00:00.000Z') });
+
+    const query = new GetPeerReviewStatusQuery(
+      new FakeAssignmentRepository([completed, pending, skipped])
+    );
+
+    await expect(query.execute({ cycleId: 1 })).resolves.toEqual({
+      cycleId: 1,
+      total: 3,
+      completed: 1,
+      pending: 1,
+      skipped: 1,
+      cancelled: 0,
+      pendingReviewerMemberIds: [20],
+    });
+  });
+});
+
+describe('CompletePeerReviewAssignmentCommand', () => {
+  it('marks the requester assignment as completed', async () => {
+    const assignment = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 10,
+      revieweeMemberId: 20,
+      submissionId: 200,
+    });
+    const repository = new FakeAssignmentRepository([assignment]);
+    const command = new CompletePeerReviewAssignmentCommand(repository);
+
+    const result = await command.execute({
+      cycleId: 1,
+      reviewerMemberId: 10,
+      completedAt: new Date('2026-05-27T00:00:00.000Z'),
+      completedSourceUrl: 'https://discord.com/channels/1/2/3',
+      completionNote: '남겼음',
+    });
+
+    expect(result.status).toBe('COMPLETED');
+    expect(result.completedSourceUrl).toBe(
+      'https://discord.com/channels/1/2/3'
+    );
+    expect(result.completionNote).toBe('남겼음');
+  });
+
+  it('fails with a helpful error when the requester has no assignment', async () => {
+    const command = new CompletePeerReviewAssignmentCommand(
+      new FakeAssignmentRepository()
+    );
+
+    await expect(
+      command.execute({ cycleId: 1, reviewerMemberId: 10 })
+    ).rejects.toThrow(PeerReviewApplicationError);
+  });
+});

--- a/apps/server/src/application/peer-review/peer-review.commands.ts
+++ b/apps/server/src/application/peer-review/peer-review.commands.ts
@@ -1,0 +1,165 @@
+import {
+  PeerReviewAssignment,
+  PeerReviewCandidate,
+  generatePeerReviewAssignments,
+} from '@/domain/peer-review';
+
+export class PeerReviewApplicationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PeerReviewApplicationError';
+  }
+}
+
+export interface PeerReviewSubmissionLookupPort {
+  findAcceptedSubmissionCandidates(
+    cycleId: number
+  ): Promise<PeerReviewCandidate[]>;
+}
+
+export interface PeerReviewAssignmentRepository {
+  findByCycleId(cycleId: number): Promise<PeerReviewAssignment[]>;
+  findByCycleAndReviewer(
+    cycleId: number,
+    reviewerMemberId: number
+  ): Promise<PeerReviewAssignment | null>;
+  saveMany(
+    assignments: PeerReviewAssignment[]
+  ): Promise<PeerReviewAssignment[]>;
+  save(assignment: PeerReviewAssignment): Promise<PeerReviewAssignment>;
+}
+
+export interface CreatePeerReviewAssignmentsRequest {
+  cycleId: number;
+  seed: string;
+}
+
+export class CreatePeerReviewAssignmentsCommand {
+  constructor(
+    private readonly submissionLookup: PeerReviewSubmissionLookupPort,
+    private readonly assignmentRepository: PeerReviewAssignmentRepository
+  ) {}
+
+  async execute(
+    request: CreatePeerReviewAssignmentsRequest
+  ): Promise<PeerReviewAssignment[]> {
+    const existing = await this.assignmentRepository.findByCycleId(
+      request.cycleId
+    );
+    if (existing.length > 0) {
+      throw new PeerReviewApplicationError(
+        'Peer review assignments already exist for this cycle'
+      );
+    }
+
+    const candidates =
+      await this.submissionLookup.findAcceptedSubmissionCandidates(
+        request.cycleId
+      );
+    const assignments = generatePeerReviewAssignments({
+      cycleId: request.cycleId,
+      seed: request.seed,
+      candidates,
+    });
+
+    return this.assignmentRepository.saveMany(assignments);
+  }
+}
+
+export interface GetMyPeerReviewAssignmentRequest {
+  cycleId: number;
+  reviewerMemberId: number;
+}
+
+export class GetMyPeerReviewAssignmentQuery {
+  constructor(
+    private readonly assignmentRepository: PeerReviewAssignmentRepository
+  ) {}
+
+  async execute(
+    request: GetMyPeerReviewAssignmentRequest
+  ): Promise<PeerReviewAssignment | null> {
+    return this.assignmentRepository.findByCycleAndReviewer(
+      request.cycleId,
+      request.reviewerMemberId
+    );
+  }
+}
+
+export interface PeerReviewStatusResult {
+  cycleId: number;
+  total: number;
+  completed: number;
+  pending: number;
+  skipped: number;
+  cancelled: number;
+  pendingReviewerMemberIds: number[];
+}
+
+export class GetPeerReviewStatusQuery {
+  constructor(
+    private readonly assignmentRepository: PeerReviewAssignmentRepository
+  ) {}
+
+  async execute(request: { cycleId: number }): Promise<PeerReviewStatusResult> {
+    const assignments = await this.assignmentRepository.findByCycleId(
+      request.cycleId
+    );
+
+    return {
+      cycleId: request.cycleId,
+      total: assignments.length,
+      completed: assignments.filter(
+        (assignment) => assignment.status === 'COMPLETED'
+      ).length,
+      pending: assignments.filter(
+        (assignment) => assignment.status === 'ASSIGNED'
+      ).length,
+      skipped: assignments.filter(
+        (assignment) => assignment.status === 'SKIPPED'
+      ).length,
+      cancelled: assignments.filter(
+        (assignment) => assignment.status === 'CANCELLED'
+      ).length,
+      pendingReviewerMemberIds: assignments
+        .filter((assignment) => assignment.status === 'ASSIGNED')
+        .map((assignment) => assignment.reviewerMemberId),
+    };
+  }
+}
+
+export interface CompletePeerReviewAssignmentRequest {
+  cycleId: number;
+  reviewerMemberId: number;
+  completedAt?: Date;
+  completedSourceUrl?: string;
+  completionNote?: string;
+}
+
+export class CompletePeerReviewAssignmentCommand {
+  constructor(
+    private readonly assignmentRepository: PeerReviewAssignmentRepository
+  ) {}
+
+  async execute(
+    request: CompletePeerReviewAssignmentRequest
+  ): Promise<PeerReviewAssignment> {
+    const assignment = await this.assignmentRepository.findByCycleAndReviewer(
+      request.cycleId,
+      request.reviewerMemberId
+    );
+    if (!assignment) {
+      throw new PeerReviewApplicationError(
+        'Peer review assignment not found for this reviewer and cycle'
+      );
+    }
+
+    assignment.complete({
+      completedAt: request.completedAt,
+      completedSourceUrl: request.completedSourceUrl,
+      completionNote: request.completionNote,
+    });
+
+    return this.assignmentRepository.save(assignment);
+  }
+}

--- a/apps/server/src/domain/peer-review/index.ts
+++ b/apps/server/src/domain/peer-review/index.ts
@@ -1,0 +1,1 @@
+export * from './peer-review.domain';

--- a/apps/server/src/domain/peer-review/peer-review.domain.test.ts
+++ b/apps/server/src/domain/peer-review/peer-review.domain.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PeerReviewAssignment,
+  PeerReviewDomainError,
+  generatePeerReviewAssignments,
+} from './peer-review.domain';
+
+describe('PeerReviewAssignment', () => {
+  it('rejects assigning a member to review their own submission', () => {
+    expect(() =>
+      PeerReviewAssignment.create({
+        cycleId: 1,
+        reviewerMemberId: 10,
+        revieweeMemberId: 10,
+        submissionId: 100,
+      })
+    ).toThrow(PeerReviewDomainError);
+  });
+
+  it('marks an assigned review as completed with optional evidence', () => {
+    const assignment = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 10,
+      revieweeMemberId: 20,
+      submissionId: 200,
+      assignedAt: new Date('2026-05-26T00:00:00.000Z'),
+    });
+
+    assignment.complete({
+      completedAt: new Date('2026-05-27T00:00:00.000Z'),
+      completedSourceUrl: 'https://discord.com/channels/1/2/3',
+      completionNote: '댓글 남김',
+    });
+
+    expect(assignment.status).toBe('COMPLETED');
+    expect(assignment.completedAt?.toISOString()).toBe(
+      '2026-05-27T00:00:00.000Z'
+    );
+    expect(assignment.completedSourceUrl).toBe(
+      'https://discord.com/channels/1/2/3'
+    );
+    expect(assignment.completionNote).toBe('댓글 남김');
+  });
+
+  it('does not allow completing a skipped review', () => {
+    const assignment = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 10,
+      revieweeMemberId: 20,
+      submissionId: 200,
+    });
+
+    assignment.skip({
+      skippedAt: new Date('2026-05-27T00:00:00.000Z'),
+      skipReason: '작성자가 제출을 철회함',
+    });
+
+    expect(assignment.skippedAt?.toISOString()).toBe(
+      '2026-05-27T00:00:00.000Z'
+    );
+    expect(assignment.skipReason).toBe('작성자가 제출을 철회함');
+    expect(() => assignment.complete()).toThrow(PeerReviewDomainError);
+  });
+
+  it('rejects invalid identifiers', () => {
+    const valid = {
+      cycleId: 1,
+      reviewerMemberId: 10,
+      revieweeMemberId: 20,
+      submissionId: 200,
+    };
+
+    expect(() => PeerReviewAssignment.create({ ...valid, cycleId: 0 })).toThrow(
+      PeerReviewDomainError
+    );
+    expect(() =>
+      PeerReviewAssignment.create({ ...valid, reviewerMemberId: 0 })
+    ).toThrow(PeerReviewDomainError);
+    expect(() =>
+      PeerReviewAssignment.create({ ...valid, revieweeMemberId: 0 })
+    ).toThrow(PeerReviewDomainError);
+    expect(() =>
+      PeerReviewAssignment.create({ ...valid, submissionId: 0 })
+    ).toThrow(PeerReviewDomainError);
+  });
+
+  it('cancels an assigned review and rejects cancelling a completed review', () => {
+    const assigned = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 10,
+      revieweeMemberId: 20,
+      submissionId: 200,
+    });
+
+    assigned.cancel(new Date('2026-05-28T00:00:00.000Z'));
+
+    expect(assigned.status).toBe('CANCELLED');
+    expect(assigned.cancelledAt?.toISOString()).toBe(
+      '2026-05-28T00:00:00.000Z'
+    );
+
+    const completed = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 20,
+      revieweeMemberId: 10,
+      submissionId: 100,
+    });
+    completed.complete();
+
+    expect(() => completed.cancel()).toThrow(PeerReviewDomainError);
+  });
+
+  it('does not allow skipping a completed review', () => {
+    const assignment = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 10,
+      revieweeMemberId: 20,
+      submissionId: 200,
+    });
+    assignment.complete();
+
+    expect(() => assignment.skip()).toThrow(PeerReviewDomainError);
+  });
+
+  it('can skip an assigned review without explicit timestamp', () => {
+    const assignment = PeerReviewAssignment.create({
+      cycleId: 1,
+      reviewerMemberId: 10,
+      revieweeMemberId: 20,
+      submissionId: 200,
+    });
+
+    assignment.skip();
+
+    expect(assignment.status).toBe('SKIPPED');
+    expect(assignment.skippedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('generatePeerReviewAssignments', () => {
+  it('requires at least two distinct submitters', () => {
+    expect(() =>
+      generatePeerReviewAssignments({
+        cycleId: 1,
+        seed: 'cycle-1',
+        candidates: [
+          {
+            memberId: 10,
+            submissionId: 100,
+            submittedAt: new Date('2026-05-26T00:00:00.000Z'),
+          },
+        ],
+      })
+    ).toThrow(PeerReviewDomainError);
+  });
+
+  it('creates one outgoing and one incoming assignment per submitter without self-review', () => {
+    const assignments = generatePeerReviewAssignments({
+      cycleId: 1,
+      seed: 'cycle-1',
+      candidates: [
+        {
+          memberId: 10,
+          submissionId: 100,
+          submittedAt: new Date('2026-05-26T00:00:00.000Z'),
+        },
+        {
+          memberId: 20,
+          submissionId: 200,
+          submittedAt: new Date('2026-05-26T01:00:00.000Z'),
+        },
+        {
+          memberId: 30,
+          submissionId: 300,
+          submittedAt: new Date('2026-05-26T02:00:00.000Z'),
+        },
+        {
+          memberId: 40,
+          submissionId: 400,
+          submittedAt: new Date('2026-05-26T03:00:00.000Z'),
+        },
+      ],
+    });
+
+    expect(assignments).toHaveLength(4);
+    expect(new Set(assignments.map((a) => a.reviewerMemberId))).toEqual(
+      new Set([10, 20, 30, 40])
+    );
+    expect(new Set(assignments.map((a) => a.revieweeMemberId))).toEqual(
+      new Set([10, 20, 30, 40])
+    );
+    expect(
+      assignments.every((a) => a.reviewerMemberId !== a.revieweeMemberId)
+    ).toBe(true);
+  });
+
+  it('is stable for the same seed and candidates regardless of input order', () => {
+    const candidates = [
+      {
+        memberId: 10,
+        submissionId: 100,
+        submittedAt: new Date('2026-05-26T00:00:00.000Z'),
+      },
+      {
+        memberId: 20,
+        submissionId: 200,
+        submittedAt: new Date('2026-05-26T01:00:00.000Z'),
+      },
+      {
+        memberId: 30,
+        submissionId: 300,
+        submittedAt: new Date('2026-05-26T02:00:00.000Z'),
+      },
+    ];
+
+    const first = generatePeerReviewAssignments({
+      cycleId: 1,
+      seed: 'cycle-1',
+      candidates,
+    }).map((a) => [a.reviewerMemberId, a.revieweeMemberId, a.submissionId]);
+
+    const second = generatePeerReviewAssignments({
+      cycleId: 1,
+      seed: 'cycle-1',
+      candidates: [...candidates].reverse(),
+    }).map((a) => [a.reviewerMemberId, a.revieweeMemberId, a.submissionId]);
+
+    expect(second).toEqual(first);
+  });
+
+  it('uses the earliest submission when a member submitted multiple posts', () => {
+    const assignments = generatePeerReviewAssignments({
+      cycleId: 1,
+      seed: 'cycle-1',
+      candidates: [
+        {
+          memberId: 10,
+          submissionId: 101,
+          submittedAt: new Date('2026-05-26T02:00:00.000Z'),
+        },
+        {
+          memberId: 10,
+          submissionId: 100,
+          submittedAt: new Date('2026-05-26T00:00:00.000Z'),
+        },
+        {
+          memberId: 20,
+          submissionId: 200,
+          submittedAt: new Date('2026-05-26T01:00:00.000Z'),
+        },
+      ],
+    });
+
+    expect(assignments.map((a) => a.submissionId).sort()).toEqual([100, 200]);
+  });
+
+  it('keeps the existing earliest submission when a later duplicate appears', () => {
+    const assignments = generatePeerReviewAssignments({
+      cycleId: 1,
+      seed: 'cycle-1',
+      candidates: [
+        {
+          memberId: 10,
+          submissionId: 100,
+          submittedAt: new Date('2026-05-26T00:00:00.000Z'),
+        },
+        {
+          memberId: 10,
+          submissionId: 101,
+          submittedAt: new Date('2026-05-26T02:00:00.000Z'),
+        },
+        {
+          memberId: 20,
+          submissionId: 200,
+          submittedAt: new Date('2026-05-26T01:00:00.000Z'),
+        },
+      ],
+    });
+
+    expect(assignments.map((a) => a.submissionId).sort()).toEqual([100, 200]);
+  });
+});

--- a/apps/server/src/domain/peer-review/peer-review.domain.ts
+++ b/apps/server/src/domain/peer-review/peer-review.domain.ts
@@ -1,0 +1,255 @@
+export type PeerReviewAssignmentStatus =
+  | 'ASSIGNED'
+  | 'COMPLETED'
+  | 'SKIPPED'
+  | 'CANCELLED';
+
+export class PeerReviewDomainError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PeerReviewDomainError';
+  }
+}
+
+export interface PeerReviewCandidate {
+  memberId: number;
+  submissionId: number;
+  submittedAt: Date;
+}
+
+export interface PeerReviewAssignmentProps {
+  id?: number;
+  cycleId: number;
+  reviewerMemberId: number;
+  revieweeMemberId: number;
+  submissionId: number;
+  status?: PeerReviewAssignmentStatus;
+  assignedAt?: Date;
+  completedAt?: Date;
+  completedSourceUrl?: string;
+  completionNote?: string;
+  skippedAt?: Date;
+  skipReason?: string;
+  cancelledAt?: Date;
+}
+
+export interface CompletePeerReviewAssignmentProps {
+  completedAt?: Date;
+  completedSourceUrl?: string;
+  completionNote?: string;
+}
+
+export interface SkipPeerReviewAssignmentProps {
+  skippedAt?: Date;
+  skipReason?: string;
+}
+
+export class PeerReviewAssignment {
+  readonly id?: number;
+  readonly cycleId: number;
+  readonly reviewerMemberId: number;
+  readonly revieweeMemberId: number;
+  readonly submissionId: number;
+  readonly assignedAt: Date;
+  private _status: PeerReviewAssignmentStatus;
+  private _completedAt?: Date;
+  private _completedSourceUrl?: string;
+  private _completionNote?: string;
+  private _skippedAt?: Date;
+  private _skipReason?: string;
+  private _cancelledAt?: Date;
+
+  private constructor(props: RequiredPeerReviewAssignmentProps) {
+    this.id = props.id;
+    this.cycleId = props.cycleId;
+    this.reviewerMemberId = props.reviewerMemberId;
+    this.revieweeMemberId = props.revieweeMemberId;
+    this.submissionId = props.submissionId;
+    this.assignedAt = props.assignedAt;
+    this._status = props.status;
+    this._completedAt = props.completedAt;
+    this._completedSourceUrl = props.completedSourceUrl;
+    this._completionNote = props.completionNote;
+    this._skippedAt = props.skippedAt;
+    this._skipReason = props.skipReason;
+    this._cancelledAt = props.cancelledAt;
+  }
+
+  static create(props: PeerReviewAssignmentProps): PeerReviewAssignment {
+    if (props.cycleId < 1) {
+      throw new PeerReviewDomainError('cycleId must be positive');
+    }
+    if (props.reviewerMemberId < 1) {
+      throw new PeerReviewDomainError('reviewerMemberId must be positive');
+    }
+    if (props.revieweeMemberId < 1) {
+      throw new PeerReviewDomainError('revieweeMemberId must be positive');
+    }
+    if (props.submissionId < 1) {
+      throw new PeerReviewDomainError('submissionId must be positive');
+    }
+    if (props.reviewerMemberId === props.revieweeMemberId) {
+      throw new PeerReviewDomainError('Reviewer cannot review their own post');
+    }
+
+    return new PeerReviewAssignment({
+      id: props.id,
+      cycleId: props.cycleId,
+      reviewerMemberId: props.reviewerMemberId,
+      revieweeMemberId: props.revieweeMemberId,
+      submissionId: props.submissionId,
+      status: props.status ?? 'ASSIGNED',
+      assignedAt: props.assignedAt ?? new Date(),
+      completedAt: props.completedAt,
+      completedSourceUrl: props.completedSourceUrl,
+      completionNote: props.completionNote,
+      skippedAt: props.skippedAt,
+      skipReason: props.skipReason,
+      cancelledAt: props.cancelledAt,
+    });
+  }
+
+  get status(): PeerReviewAssignmentStatus {
+    return this._status;
+  }
+
+  get completedAt(): Date | undefined {
+    return this._completedAt;
+  }
+
+  get completedSourceUrl(): string | undefined {
+    return this._completedSourceUrl;
+  }
+
+  get completionNote(): string | undefined {
+    return this._completionNote;
+  }
+
+  get skippedAt(): Date | undefined {
+    return this._skippedAt;
+  }
+
+  get skipReason(): string | undefined {
+    return this._skipReason;
+  }
+
+  get cancelledAt(): Date | undefined {
+    return this._cancelledAt;
+  }
+
+  complete(props: CompletePeerReviewAssignmentProps = {}): void {
+    if (this._status !== 'ASSIGNED') {
+      throw new PeerReviewDomainError('Only assigned reviews can be completed');
+    }
+    this._status = 'COMPLETED';
+    this._completedAt = props.completedAt ?? new Date();
+    this._completedSourceUrl = props.completedSourceUrl;
+    this._completionNote = props.completionNote;
+  }
+
+  skip(props: SkipPeerReviewAssignmentProps = {}): void {
+    if (this._status !== 'ASSIGNED') {
+      throw new PeerReviewDomainError('Only assigned reviews can be skipped');
+    }
+    this._status = 'SKIPPED';
+    this._skippedAt = props.skippedAt ?? new Date();
+    this._skipReason = props.skipReason;
+  }
+
+  cancel(cancelledAt = new Date()): void {
+    if (this._status === 'COMPLETED') {
+      throw new PeerReviewDomainError('Completed reviews cannot be cancelled');
+    }
+    this._status = 'CANCELLED';
+    this._cancelledAt = cancelledAt;
+  }
+}
+
+type RequiredPeerReviewAssignmentProps = Required<
+  Pick<
+    PeerReviewAssignmentProps,
+    | 'cycleId'
+    | 'reviewerMemberId'
+    | 'revieweeMemberId'
+    | 'submissionId'
+    | 'status'
+    | 'assignedAt'
+  >
+> &
+  Pick<
+    PeerReviewAssignmentProps,
+    | 'id'
+    | 'completedAt'
+    | 'completedSourceUrl'
+    | 'completionNote'
+    | 'skippedAt'
+    | 'skipReason'
+    | 'cancelledAt'
+  >;
+
+export function generatePeerReviewAssignments(input: {
+  cycleId: number;
+  seed: string;
+  candidates: PeerReviewCandidate[];
+}): PeerReviewAssignment[] {
+  const candidates = selectEarliestSubmissionPerMember(input.candidates);
+  if (candidates.length < 2) {
+    throw new PeerReviewDomainError(
+      'At least two distinct submitters are required for peer review assignment'
+    );
+  }
+
+  const shuffled = seededShuffle(candidates, input.seed);
+  return shuffled.map((reviewer, index) => {
+    const reviewee = shuffled[(index + 1) % shuffled.length];
+    return PeerReviewAssignment.create({
+      cycleId: input.cycleId,
+      reviewerMemberId: reviewer.memberId,
+      revieweeMemberId: reviewee.memberId,
+      submissionId: reviewee.submissionId,
+    });
+  });
+}
+
+function selectEarliestSubmissionPerMember(
+  candidates: PeerReviewCandidate[]
+): PeerReviewCandidate[] {
+  const byMember = new Map<number, PeerReviewCandidate>();
+  for (const candidate of candidates) {
+    const current = byMember.get(candidate.memberId);
+    if (
+      !current ||
+      candidate.submittedAt.getTime() < current.submittedAt.getTime()
+    ) {
+      byMember.set(candidate.memberId, candidate);
+    }
+  }
+
+  return [...byMember.values()].sort((a, b) => a.memberId - b.memberId);
+}
+
+function seededShuffle<T>(items: T[], seed: string): T[] {
+  const result = [...items];
+  let state = hashSeed(seed);
+
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    state = nextRandomState(state);
+    const swapIndex = state % (index + 1);
+    [result[index], result[swapIndex]] = [result[swapIndex], result[index]];
+  }
+
+  return result;
+}
+
+function hashSeed(seed: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function nextRandomState(state: number): number {
+  return (Math.imul(state, 1664525) + 1013904223) >>> 0;
+}

--- a/apps/server/src/infrastructure/external/discord/discord.messages.test.ts
+++ b/apps/server/src/infrastructure/external/discord/discord.messages.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createReminderMessage,
+  createStatusMessage,
+  createSubmissionMessage,
+  sendDiscordWebhook,
+} from './discord.messages';
+
+describe('Discord message UX', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('turns a submission notification into a clear confirmation with next action', () => {
+    const message = createSubmissionMessage(
+      '박준형',
+      'https://blog.example.com/post',
+      '똥글똥글 2기 7주차'
+    );
+
+    expect(message.content).toContain('박준형님 제출 완료');
+    expect(message.embeds?.[0]?.title).toBe('똥글똥글 2기 7주차 제출 완료');
+    expect(message.embeds?.[0]?.description).toContain('정상 기록됐어요');
+    expect(message.embeds?.[0]?.description).toContain(
+      '[글 보러가기](https://blog.example.com/post)'
+    );
+    expect(message.embeds?.[0]?.description).toContain('/cycle status');
+  });
+
+  it('makes reminder messages action-oriented for missing submitters', () => {
+    vi.setSystemTime(new Date('2026-05-08T00:00:00.000Z'));
+    const deadline = new Date('2026-05-09T03:00:00.000Z');
+
+    const message = createReminderMessage('똥글똥글 2기 7주차', deadline, [
+      '김항해',
+      '박준형',
+    ]);
+
+    expect(message.content).toContain('미제출 2명');
+    expect(message.embeds?.[0]?.title).toBe('똥글똥글 2기 7주차 제출 리마인더');
+    expect(message.embeds?.[0]?.description).toContain('남은 시간: 1일 3시간');
+    expect(message.embeds?.[0]?.description).toContain('아직 제출 전: 2명');
+    expect(message.embeds?.[0]?.description).toContain('- 김항해');
+    expect(message.embeds?.[0]?.description).toContain(
+      'GitHub 이슈 댓글에 링크를 남깁니다'
+    );
+    expect(message.embeds?.[0]?.description).toContain('/me info');
+  });
+
+  it('formats reminders below one day in hours', () => {
+    vi.setSystemTime(new Date('2026-05-09T00:00:00.000Z'));
+    const deadline = new Date('2026-05-09T05:00:00.000Z');
+
+    const message = createReminderMessage('똥글똥글 2기 7주차', deadline, [
+      '박준형',
+    ]);
+
+    expect(message.embeds?.[0]?.description).toContain('남은 시간: 5시간');
+  });
+
+  it('shows reminders as due now when the deadline has passed', () => {
+    vi.setSystemTime(new Date('2026-05-09T06:00:00.000Z'));
+    const deadline = new Date('2026-05-09T05:00:00.000Z');
+
+    const message = createReminderMessage('똥글똥글 2기 7주차', deadline, [
+      '박준형',
+    ]);
+
+    expect(message.embeds?.[0]?.description).toContain('남은 시간: 지금 마감');
+  });
+
+  it('does not ask for submissions when everyone has submitted', () => {
+    vi.setSystemTime(new Date('2026-05-08T00:00:00.000Z'));
+    const deadline = new Date('2026-05-09T03:00:00.000Z');
+
+    const message = createReminderMessage('똥글똥글 2기 7주차', deadline, []);
+
+    expect(message.content).toContain('전원 제출 완료');
+    expect(message.embeds?.[0]?.description).toContain('🎉 전원 제출 완료!');
+  });
+
+  it('summarizes cycle status with progress and exact next actions', () => {
+    const message = createStatusMessage(
+      '똥글똥글 2기 7주차',
+      ['박준형', '김항해'],
+      ['이항해'],
+      new Date('2026-05-10T14:59:59.000Z')
+    );
+
+    const embed = message.embeds?.[0];
+    expect(embed?.title).toBe('똥글똥글 2기 7주차 제출 현황');
+    expect(embed?.description).toContain('진행률: 2 / 3명 제출, 67%');
+    expect(embed?.fields?.[0]?.value).toContain('- 박준형');
+    expect(embed?.fields?.[1]?.value).toContain('- 이항해');
+    expect(embed?.fields?.[2]?.value).toContain('/me info');
+  });
+
+  it('makes all-submitted status celebratory instead of showing an empty missing list', () => {
+    const message = createStatusMessage(
+      '똥글똥글 2기 7주차',
+      ['박준형'],
+      [],
+      new Date('2026-05-10T14:59:59.000Z')
+    );
+
+    const embed = message.embeds?.[0];
+    expect(embed?.description).toContain('🎉 전원 제출 완료!');
+    expect(embed?.fields?.[1]?.value).toContain(
+      '이번 주차 모든 참여자가 제출을 완료했어요'
+    );
+  });
+
+  it('makes zero submissions explicit', () => {
+    const message = createStatusMessage(
+      '똥글똥글 2기 7주차',
+      [],
+      ['박준형'],
+      new Date('2026-05-10T14:59:59.000Z')
+    );
+
+    expect(message.embeds?.[0]?.fields?.[0]?.value).toContain(
+      '아직 제출자가 없어요'
+    );
+  });
+
+  it('handles empty participant lists without dividing by zero', () => {
+    const message = createStatusMessage(
+      '똥글똥글 2기 7주차',
+      [],
+      [],
+      new Date('2026-05-10T14:59:59.000Z')
+    );
+
+    expect(message.embeds?.[0]?.description).toContain(
+      '진행률: 0 / 0명 제출, 0%'
+    );
+  });
+
+  it('sends a Discord webhook payload', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: true } as Response);
+
+    await sendDiscordWebhook('https://discord.example/webhook', {
+      content: 'hello',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://discord.example/webhook',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'hello' }),
+      })
+    );
+  });
+
+  it('surfaces Discord webhook failures with the response status text', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Request',
+    } as Response);
+
+    await expect(
+      sendDiscordWebhook('https://discord.example/webhook', {
+        content: 'hello',
+      })
+    ).rejects.toThrow('Discord webhook failed: Bad Request');
+  });
+});

--- a/apps/server/src/infrastructure/external/discord/discord.messages.ts
+++ b/apps/server/src/infrastructure/external/discord/discord.messages.ts
@@ -2,6 +2,26 @@
 
 import { DiscordMessage } from './discord.interface';
 
+function formatNamesAsList(names: string[]): string {
+  return names.map((name) => `- ${name}`).join('\n');
+}
+
+function formatRemainingTime(deadline: Date): string {
+  const hoursLeft = Math.floor(
+    (deadline.getTime() - Date.now()) / (1000 * 60 * 60)
+  );
+
+  if (hoursLeft <= 0) {
+    return '지금 마감';
+  }
+
+  if (hoursLeft >= 24) {
+    return `${Math.floor(hoursLeft / 24)}일 ${hoursLeft % 24}시간`;
+  }
+
+  return `${hoursLeft}시간`;
+}
+
 /**
  * 제출 알림 메시지 생성
  */
@@ -11,11 +31,14 @@ export function createSubmissionMessage(
   cycleName: string
 ): DiscordMessage {
   return {
-    content: `🎉 ${memberName}님이 글을 제출했습니다!`,
+    content: `🎉 ${memberName}님 제출 완료!`,
     embeds: [
       {
         title: `${cycleName} 제출 완료`,
-        description: `[글 보러가기](${blogUrl})`,
+        description:
+          '정상 기록됐어요. 제출 현황에서 바로 확인할 수 있습니다.\n\n' +
+          `🔗 [글 보러가기](${blogUrl})\n` +
+          '📊 전체 제출 현황은 `/cycle status`로 확인해 주세요.',
         color: 0x00ff00, // 초록색
         timestamp: new Date().toISOString(),
       },
@@ -31,21 +54,26 @@ export function createReminderMessage(
   deadline: Date,
   notSubmitted: string[]
 ): DiscordMessage {
-  const hoursLeft = Math.floor(
-    (deadline.getTime() - Date.now()) / (1000 * 60 * 60)
-  );
-  const timeText =
-    hoursLeft >= 24
-      ? `${Math.floor(hoursLeft / 24)}일 ${hoursLeft % 24}시간`
-      : `${hoursLeft}시간`;
+  const timeText = formatRemainingTime(deadline);
+  const isEveryoneSubmitted = notSubmitted.length === 0;
 
   return {
-    content: `⏰ ${cycleName} 마감까지 ${timeText} 남았습니다!`,
+    content: isEveryoneSubmitted
+      ? `🎉 ${cycleName} 전원 제출 완료!`
+      : `⏰ ${cycleName} 마감 리마인더 · 미제출 ${notSubmitted.length}명`,
     embeds: [
       {
-        title: '미제출자 목록',
-        description: notSubmitted.join(', '),
-        color: 0xffaa00, // 주황색
+        title: `${cycleName} 제출 리마인더`,
+        description: isEveryoneSubmitted
+          ? '🎉 전원 제출 완료! 지금은 추가로 제출을 요청할 대상이 없어요.'
+          : `⏰ 남은 시간: ${timeText}\n` +
+            `📌 아직 제출 전: ${notSubmitted.length}명\n` +
+            `${formatNamesAsList(notSubmitted)}\n\n` +
+            '**제출 방법**\n' +
+            '1. 이번 주차 글을 작성합니다.\n' +
+            '2. GitHub 이슈 댓글에 링크를 남깁니다.\n' +
+            '3. `/me info`로 내 제출 상태를 확인합니다.',
+        color: isEveryoneSubmitted ? 0x00ff00 : 0xffaa00, // 초록색 / 주황색
         fields: [
           {
             name: '마감 시간',
@@ -68,20 +96,45 @@ export function createStatusMessage(
   notSubmitted: string[],
   deadline: Date
 ): DiscordMessage {
+  const totalParticipants = submitted.length + notSubmitted.length;
+  const progressPercent =
+    totalParticipants === 0
+      ? 0
+      : Math.round((submitted.length / totalParticipants) * 100);
+  const isEveryoneSubmitted =
+    totalParticipants > 0 && notSubmitted.length === 0;
+  const submittedValue =
+    submitted.length > 0
+      ? formatNamesAsList(submitted)
+      : '아직 제출자가 없어요.';
+  const notSubmittedValue = isEveryoneSubmitted
+    ? '이번 주차 모든 참여자가 제출을 완료했어요.'
+    : formatNamesAsList(notSubmitted);
+
   return {
     embeds: [
       {
         title: `${cycleName} 제출 현황`,
-        color: 0x0099ff, // 파란색
+        description:
+          `진행률: ${submitted.length} / ${totalParticipants}명 제출, ${progressPercent}%` +
+          (isEveryoneSubmitted ? '\n🎉 전원 제출 완료!' : ''),
+        color: isEveryoneSubmitted ? 0x00ff00 : 0x0099ff, // 초록색 / 파란색
         fields: [
           {
             name: `✅ 제출 (${submitted.length})`,
-            value: submitted.length > 0 ? submitted.join(', ') : '없음',
+            value: submittedValue,
             inline: false,
           },
           {
             name: `❌ 미제출 (${notSubmitted.length})`,
-            value: notSubmitted.length > 0 ? notSubmitted.join(', ') : '없음',
+            value: notSubmittedValue,
+            inline: false,
+          },
+          {
+            name: '다음 행동',
+            value: isEveryoneSubmitted
+              ? '모두 제출 완료됐어요. 다음 주차가 열리면 다시 안내할게요.'
+              : '미제출자는 GitHub 이슈 댓글에 글 링크를 남기고 `/me info`로 내 상태를 확인해 주세요.',
             inline: false,
           },
           {

--- a/apps/server/src/infrastructure/external/discord/index.ts
+++ b/apps/server/src/infrastructure/external/discord/index.ts
@@ -3,3 +3,4 @@
 export * from './discord.interface';
 export * from './discord.webhook';
 export * from './discord.messages';
+export * from './peer-review.messages';

--- a/apps/server/src/infrastructure/external/discord/peer-review.messages.test.ts
+++ b/apps/server/src/infrastructure/external/discord/peer-review.messages.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPeerReviewDoneMessage,
+  createPeerReviewMyAssignmentMessage,
+  createPeerReviewNoAssignmentMessage,
+  createPeerReviewStatusMessage,
+  createPeerReviewTemplateMessage,
+} from './peer-review.messages';
+
+describe('peer review Discord messages', () => {
+  it('creates a 3rd generation submission and review template that lowers review pressure', () => {
+    const message = createPeerReviewTemplateMessage();
+
+    expect(message.content).toContain('3기 제출 템플릿');
+    expect(message.content).toContain('제목');
+    expect(message.content).toContain('소개 / 소감');
+    expect(message.content).toContain('스스로의 만족도');
+    expect(message.content).toContain('평가나 채점이 아니라');
+    expect(message.content).toContain('2~5문장');
+  });
+
+  it('creates a private assignment guide with the assigned article and next action', () => {
+    const message = createPeerReviewMyAssignmentMessage({
+      cycleName: '똥글똥글 3기 1회차',
+      revieweeName: '윤영서',
+      submissionUrl: 'https://example.com/post',
+    });
+
+    expect(message.content).toContain('똥글똥글 3기 1회차');
+    expect(message.content).toContain('윤영서');
+    expect(message.content).toContain('https://example.com/post');
+    expect(message.content).toContain('/review done');
+    expect(message.ephemeral).toBe(true);
+  });
+
+  it('creates an actionable no-assignment message', () => {
+    const message = createPeerReviewNoAssignmentMessage({
+      cycleName: '똥글똥글 3기 1회차',
+    });
+
+    expect(message.content).toContain('아직 배정된 글이 없어요');
+    expect(message.content).toContain('/review assign');
+    expect(message.ephemeral).toBe(true);
+  });
+
+  it('summarizes peer review status without shaming pending reviewers', () => {
+    const message = createPeerReviewStatusMessage({
+      cycleName: '똥글똥글 3기 1회차',
+      total: 5,
+      completed: 3,
+      pending: 2,
+      skipped: 0,
+      cancelled: 0,
+    });
+
+    expect(message.content).toContain('감상평 현황');
+    expect(message.content).toContain('3 / 5');
+    expect(message.content).toContain('남은 감상평: 2개');
+    expect(message.content).not.toContain('미완료자');
+  });
+
+  it('confirms completion and frames the review as human communication', () => {
+    const message = createPeerReviewDoneMessage({
+      cycleName: '똥글똥글 3기 1회차',
+    });
+
+    expect(message.content).toContain('완료로 기록했어요');
+    expect(message.content).toContain('서로 읽어주는 흐름');
+    expect(message.ephemeral).toBe(true);
+  });
+});

--- a/apps/server/src/infrastructure/external/discord/peer-review.messages.ts
+++ b/apps/server/src/infrastructure/external/discord/peer-review.messages.ts
@@ -1,0 +1,86 @@
+interface DiscordMessagePayload {
+  content: string;
+  ephemeral?: boolean;
+}
+
+export function createPeerReviewTemplateMessage(): DiscordMessagePayload {
+  return {
+    content:
+      '## 📝 똥글똥글 3기 제출 템플릿\n\n' +
+      '글을 제출할 때 아래 내용을 함께 남겨주세요.\n\n' +
+      '### 제목\n' +
+      '글 제목을 적어주세요.\n\n' +
+      '### 링크\n' +
+      'https://...\n\n' +
+      '### 소개 / 소감\n' +
+      '1. 이 글은 무엇에 대한 글인지\n' +
+      '2. 왜 이 글을 쓰게 되었는지\n' +
+      '3. 쓰고 나서 만족스럽거나 아쉬운 점\n\n' +
+      '### 스스로의 만족도\n' +
+      '7 / 10\n\n' +
+      '## 💬 감상평은 이렇게 남겨도 충분해요\n\n' +
+      '감상평은 평가나 채점이 아니라, 읽은 사람이 남기는 짧은 반응이에요.\n' +
+      '아래 중 하나만 골라서 2~5문장 정도로 남겨도 충분합니다.\n\n' +
+      '- 인상 깊었던 부분\n' +
+      '- 새로 알게 된 점\n' +
+      '- 비슷한 경험\n' +
+      '- 더 궁금해진 점',
+  };
+}
+
+export function createPeerReviewMyAssignmentMessage(input: {
+  cycleName: string;
+  revieweeName: string;
+  submissionUrl: string;
+}): DiscordMessagePayload {
+  return {
+    ephemeral: true,
+    content:
+      `💎 **${input.cycleName} 감상평 배정**\n\n` +
+      `이번 회차에는 **${input.revieweeName}**님의 글을 읽어주세요.\n` +
+      `글 링크: ${input.submissionUrl}\n\n` +
+      '감상평은 길지 않아도 괜찮아요. 좋았던 점, 기억에 남은 부분, 궁금한 점 중 하나만 2~5문장으로 남겨주세요.\n\n' +
+      '남긴 뒤에는 `/review done`으로 완료 처리해 주세요.',
+  };
+}
+
+export function createPeerReviewNoAssignmentMessage(input: {
+  cycleName: string;
+}): DiscordMessagePayload {
+  return {
+    ephemeral: true,
+    content:
+      `💎 **${input.cycleName}**에는 아직 배정된 글이 없어요.\n\n` +
+      '운영자가 `/review assign`으로 이번 회차 감상평 매칭을 만든 뒤 다시 확인해 주세요.',
+  };
+}
+
+export function createPeerReviewStatusMessage(input: {
+  cycleName: string;
+  total: number;
+  completed: number;
+  pending: number;
+  skipped: number;
+  cancelled: number;
+}): DiscordMessagePayload {
+  return {
+    content:
+      `📚 **${input.cycleName} 감상평 현황**\n\n` +
+      `완료: **${input.completed} / ${input.total}**\n` +
+      `남은 감상평: ${input.pending}개\n` +
+      `스킵: ${input.skipped}개\n` +
+      `취소: ${input.cancelled}개\n\n` +
+      '감상평은 평가가 아니라 서로의 글을 읽었다는 짧은 반응이면 충분해요.',
+  };
+}
+
+export function createPeerReviewDoneMessage(input: {
+  cycleName: string;
+}): DiscordMessagePayload {
+  return {
+    ephemeral: true,
+    content:
+      `✅ **${input.cycleName} 감상평을 완료로 기록했어요.**\n\n` +
+      '서로 읽어주는 흐름을 만들어줘서 고마워요.',
+  };
+}

--- a/apps/server/src/infrastructure/persistence/drizzle-db/schema.peer-review.test.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle-db/schema.peer-review.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cycleReviewSettings,
+  peerReviewAssignments,
+  peerReviewAssignmentStatusEnum,
+} from './schema';
+
+describe('peer review drizzle schema', () => {
+  it('defines peer review assignment statuses', () => {
+    expect(peerReviewAssignmentStatusEnum.enumValues).toEqual([
+      'ASSIGNED',
+      'COMPLETED',
+      'SKIPPED',
+      'CANCELLED',
+    ]);
+  });
+
+  it('defines cycle review settings columns', () => {
+    expect(cycleReviewSettings.cycleId.name).toBe('cycle_id');
+    expect(cycleReviewSettings.enabled.name).toBe('enabled');
+    expect(cycleReviewSettings.assignmentSeed.name).toBe('assignment_seed');
+    expect(cycleReviewSettings.minSubmissionCount.name).toBe(
+      'min_submission_count'
+    );
+  });
+
+  it('defines peer review assignment columns', () => {
+    expect(peerReviewAssignments.cycleId.name).toBe('cycle_id');
+    expect(peerReviewAssignments.reviewerMemberId.name).toBe(
+      'reviewer_member_id'
+    );
+    expect(peerReviewAssignments.revieweeMemberId.name).toBe(
+      'reviewee_member_id'
+    );
+    expect(peerReviewAssignments.submissionId.name).toBe('submission_id');
+    expect(peerReviewAssignments.completedSourceUrl.name).toBe(
+      'completed_source_url'
+    );
+    expect(peerReviewAssignments.completionNote.name).toBe('completion_note');
+  });
+});

--- a/apps/server/src/infrastructure/persistence/drizzle-db/schema.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle-db/schema.ts
@@ -103,6 +103,11 @@ export const obligationStatusEnum = pgEnum('obligation_status', [
   'EXEMPT_NON_PARTICIPANT_ROLE',
 ]);
 
+export const peerReviewAssignmentStatusEnum = pgEnum(
+  'peer_review_assignment_status',
+  ['ASSIGNED', 'COMPLETED', 'SKIPPED', 'CANCELLED']
+);
+
 export const participantCycleResultStatusEnum = pgEnum(
   'participant_cycle_result_status',
   ['SUBMITTED_ON_TIME', 'SUBMITTED_LATE', 'MISSED', 'EXEMPT']
@@ -475,6 +480,70 @@ export const submissions = pgTable(
       table.generationParticipantId
     ),
     statusIdx: index('submissions_status_idx').on(table.status),
+  })
+);
+
+export const cycleReviewSettings = pgTable(
+  'cycle_review_settings',
+  {
+    id: serial('id').primaryKey(),
+    cycleId: integer('cycle_id')
+      .notNull()
+      .references(() => cycles.id),
+    enabled: boolean('enabled').default(true).notNull(),
+    assignmentSeed: text('assignment_seed').notNull(),
+    minSubmissionCount: integer('min_submission_count').default(2).notNull(),
+    createdByMemberId: integer('created_by_member_id').references(
+      () => members.id
+    ),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    cycleIdx: uniqueIndex('cycle_review_settings_cycle_uidx').on(table.cycleId),
+  })
+);
+
+export const peerReviewAssignments = pgTable(
+  'peer_review_assignments',
+  {
+    id: serial('id').primaryKey(),
+    cycleId: integer('cycle_id')
+      .notNull()
+      .references(() => cycles.id),
+    reviewerMemberId: integer('reviewer_member_id')
+      .notNull()
+      .references(() => members.id),
+    revieweeMemberId: integer('reviewee_member_id')
+      .notNull()
+      .references(() => members.id),
+    submissionId: integer('submission_id')
+      .notNull()
+      .references(() => submissions.id),
+    status: peerReviewAssignmentStatusEnum('status')
+      .default('ASSIGNED')
+      .notNull(),
+    assignedAt: timestamp('assigned_at').defaultNow().notNull(),
+    completedAt: timestamp('completed_at'),
+    completedSourceUrl: text('completed_source_url'),
+    completionNote: text('completion_note'),
+    skippedAt: timestamp('skipped_at'),
+    skipReason: text('skip_reason'),
+    cancelledAt: timestamp('cancelled_at'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    cycleReviewerIdx: uniqueIndex(
+      'peer_review_assignments_cycle_reviewer_uidx'
+    ).on(table.cycleId, table.reviewerMemberId),
+    cycleRevieweeIdx: uniqueIndex(
+      'peer_review_assignments_cycle_reviewee_uidx'
+    ).on(table.cycleId, table.revieweeMemberId),
+    cycleStatusIdx: index('peer_review_assignments_cycle_status_idx').on(
+      table.cycleId,
+      table.status
+    ),
   })
 );
 

--- a/apps/server/src/infrastructure/persistence/drizzle/index.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle/index.ts
@@ -5,4 +5,5 @@ export * from './member.repository.impl';
 export * from './organization.repository.impl';
 export * from './organization-member.repository.impl';
 export * from './submission.repository.impl';
+export * from './peer-review.repository.impl';
 export * from './study-operations.repository.impl';

--- a/apps/server/src/infrastructure/persistence/drizzle/peer-review.repository.impl.test.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle/peer-review.repository.impl.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mapPeerReviewAssignmentDetailsRow,
+  mapPeerReviewAssignmentRowToDomain,
+  mapPeerReviewAssignmentToInsert,
+  mapPeerReviewAssignmentToUpdate,
+} from './peer-review.repository.impl';
+
+describe('peer review persistence mappers', () => {
+  it('maps a database row into a domain assignment', () => {
+    const assignedAt = new Date('2026-05-26T00:00:00.000Z');
+    const completedAt = new Date('2026-05-27T00:00:00.000Z');
+
+    const assignment = mapPeerReviewAssignmentRowToDomain({
+      id: 1,
+      cycleId: 10,
+      reviewerMemberId: 20,
+      revieweeMemberId: 30,
+      submissionId: 300,
+      status: 'COMPLETED',
+      assignedAt,
+      completedAt,
+      completedSourceUrl: 'https://github.com/org/repo/issues/1#comment-1',
+      completionNote: '좋았던 점 남김',
+      skippedAt: null,
+      skipReason: null,
+      cancelledAt: null,
+      createdAt: assignedAt,
+      updatedAt: completedAt,
+    });
+
+    expect(assignment.id).toBe(1);
+    expect(assignment.cycleId).toBe(10);
+    expect(assignment.reviewerMemberId).toBe(20);
+    expect(assignment.revieweeMemberId).toBe(30);
+    expect(assignment.submissionId).toBe(300);
+    expect(assignment.status).toBe('COMPLETED');
+    expect(assignment.assignedAt).toBe(assignedAt);
+    expect(assignment.completedAt).toBe(completedAt);
+    expect(assignment.completedSourceUrl).toBe(
+      'https://github.com/org/repo/issues/1#comment-1'
+    );
+    expect(assignment.completionNote).toBe('좋았던 점 남김');
+  });
+
+  it('maps a new domain assignment into insert values', () => {
+    const assignedAt = new Date('2026-05-26T00:00:00.000Z');
+    const assignment = mapPeerReviewAssignmentRowToDomain({
+      id: 1,
+      cycleId: 10,
+      reviewerMemberId: 20,
+      revieweeMemberId: 30,
+      submissionId: 300,
+      status: 'ASSIGNED',
+      assignedAt,
+      completedAt: null,
+      completedSourceUrl: null,
+      completionNote: null,
+      skippedAt: null,
+      skipReason: null,
+      cancelledAt: null,
+      createdAt: assignedAt,
+      updatedAt: assignedAt,
+    });
+
+    expect(mapPeerReviewAssignmentToInsert(assignment)).toEqual({
+      cycleId: 10,
+      reviewerMemberId: 20,
+      revieweeMemberId: 30,
+      submissionId: 300,
+      status: 'ASSIGNED',
+      assignedAt,
+      completedAt: undefined,
+      completedSourceUrl: undefined,
+      completionNote: undefined,
+      skippedAt: undefined,
+      skipReason: undefined,
+      cancelledAt: undefined,
+    });
+  });
+
+  it('maps a completed assignment into update values', () => {
+    const assignedAt = new Date('2026-05-26T00:00:00.000Z');
+    const completedAt = new Date('2026-05-27T00:00:00.000Z');
+    const assignment = mapPeerReviewAssignmentRowToDomain({
+      id: 1,
+      cycleId: 10,
+      reviewerMemberId: 20,
+      revieweeMemberId: 30,
+      submissionId: 300,
+      status: 'ASSIGNED',
+      assignedAt,
+      completedAt: null,
+      completedSourceUrl: null,
+      completionNote: null,
+      skippedAt: null,
+      skipReason: null,
+      cancelledAt: null,
+      createdAt: assignedAt,
+      updatedAt: assignedAt,
+    });
+
+    assignment.complete({
+      completedAt,
+      completedSourceUrl: 'https://example.com/comment',
+      completionNote: '완료',
+    });
+
+    expect(mapPeerReviewAssignmentToUpdate(assignment)).toMatchObject({
+      status: 'COMPLETED',
+      completedAt,
+      completedSourceUrl: 'https://example.com/comment',
+      completionNote: '완료',
+      skippedAt: undefined,
+      skipReason: undefined,
+      cancelledAt: undefined,
+    });
+    expect(
+      mapPeerReviewAssignmentToUpdate(assignment).updatedAt
+    ).toBeInstanceOf(Date);
+  });
+
+  it('maps assignment detail rows into reviewee display data', () => {
+    expect(
+      mapPeerReviewAssignmentDetailsRow({
+        revieweeName: '김리뷰',
+        submissionUrl: 'https://example.com/post',
+      })
+    ).toEqual({
+      revieweeName: '김리뷰',
+      submissionUrl: 'https://example.com/post',
+    });
+  });
+});

--- a/apps/server/src/infrastructure/persistence/drizzle/peer-review.repository.impl.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle/peer-review.repository.impl.ts
@@ -1,0 +1,216 @@
+import { and, asc, eq } from 'drizzle-orm';
+import {
+  PeerReviewAssignment,
+  PeerReviewCandidate,
+} from '@/domain/peer-review';
+import {
+  PeerReviewAssignmentRepository,
+  PeerReviewSubmissionLookupPort,
+} from '@/application/peer-review';
+import { db } from '../../lib/db';
+import {
+  members,
+  peerReviewAssignments,
+  submissions,
+} from '../drizzle-db/schema';
+
+type PeerReviewAssignmentRow = typeof peerReviewAssignments.$inferSelect;
+type PeerReviewAssignmentInsert = typeof peerReviewAssignments.$inferInsert;
+
+type PeerReviewAssignmentUpdate = Partial<
+  Pick<
+    PeerReviewAssignmentInsert,
+    | 'status'
+    | 'completedAt'
+    | 'completedSourceUrl'
+    | 'completionNote'
+    | 'skippedAt'
+    | 'skipReason'
+    | 'cancelledAt'
+    | 'updatedAt'
+  >
+>;
+
+export function mapPeerReviewAssignmentRowToDomain(
+  row: PeerReviewAssignmentRow
+): PeerReviewAssignment {
+  return PeerReviewAssignment.create({
+    id: row.id,
+    cycleId: row.cycleId,
+    reviewerMemberId: row.reviewerMemberId,
+    revieweeMemberId: row.revieweeMemberId,
+    submissionId: row.submissionId,
+    status: row.status,
+    assignedAt: row.assignedAt,
+    completedAt: row.completedAt ?? undefined,
+    completedSourceUrl: row.completedSourceUrl ?? undefined,
+    completionNote: row.completionNote ?? undefined,
+    skippedAt: row.skippedAt ?? undefined,
+    skipReason: row.skipReason ?? undefined,
+    cancelledAt: row.cancelledAt ?? undefined,
+  });
+}
+
+export function mapPeerReviewAssignmentToInsert(
+  assignment: PeerReviewAssignment
+): PeerReviewAssignmentInsert {
+  return {
+    cycleId: assignment.cycleId,
+    reviewerMemberId: assignment.reviewerMemberId,
+    revieweeMemberId: assignment.revieweeMemberId,
+    submissionId: assignment.submissionId,
+    status: assignment.status,
+    assignedAt: assignment.assignedAt,
+    completedAt: assignment.completedAt,
+    completedSourceUrl: assignment.completedSourceUrl,
+    completionNote: assignment.completionNote,
+    skippedAt: assignment.skippedAt,
+    skipReason: assignment.skipReason,
+    cancelledAt: assignment.cancelledAt,
+  };
+}
+
+export function mapPeerReviewAssignmentToUpdate(
+  assignment: PeerReviewAssignment
+): PeerReviewAssignmentUpdate {
+  return {
+    status: assignment.status,
+    completedAt: assignment.completedAt,
+    completedSourceUrl: assignment.completedSourceUrl,
+    completionNote: assignment.completionNote,
+    skippedAt: assignment.skippedAt,
+    skipReason: assignment.skipReason,
+    cancelledAt: assignment.cancelledAt,
+    updatedAt: new Date(),
+  };
+}
+
+export class DrizzlePeerReviewAssignmentRepository implements PeerReviewAssignmentRepository {
+  async findByCycleId(cycleId: number): Promise<PeerReviewAssignment[]> {
+    const rows = await db
+      .select()
+      .from(peerReviewAssignments)
+      .where(eq(peerReviewAssignments.cycleId, cycleId))
+      .orderBy(asc(peerReviewAssignments.reviewerMemberId));
+
+    return rows.map(mapPeerReviewAssignmentRowToDomain);
+  }
+
+  async findByCycleAndReviewer(
+    cycleId: number,
+    reviewerMemberId: number
+  ): Promise<PeerReviewAssignment | null> {
+    const [row] = await db
+      .select()
+      .from(peerReviewAssignments)
+      .where(
+        and(
+          eq(peerReviewAssignments.cycleId, cycleId),
+          eq(peerReviewAssignments.reviewerMemberId, reviewerMemberId)
+        )
+      )
+      .limit(1);
+
+    return row ? mapPeerReviewAssignmentRowToDomain(row) : null;
+  }
+
+  async saveMany(
+    assignments: PeerReviewAssignment[]
+  ): Promise<PeerReviewAssignment[]> {
+    if (assignments.length === 0) return [];
+
+    const rows = await db
+      .insert(peerReviewAssignments)
+      .values(assignments.map(mapPeerReviewAssignmentToInsert))
+      .returning();
+
+    return rows.map(mapPeerReviewAssignmentRowToDomain);
+  }
+
+  async save(assignment: PeerReviewAssignment): Promise<PeerReviewAssignment> {
+    if (!assignment.id) {
+      const [row] = await db
+        .insert(peerReviewAssignments)
+        .values(mapPeerReviewAssignmentToInsert(assignment))
+        .returning();
+      return mapPeerReviewAssignmentRowToDomain(row);
+    }
+
+    const [row] = await db
+      .update(peerReviewAssignments)
+      .set(mapPeerReviewAssignmentToUpdate(assignment))
+      .where(eq(peerReviewAssignments.id, assignment.id))
+      .returning();
+
+    return mapPeerReviewAssignmentRowToDomain(row);
+  }
+}
+
+export interface PeerReviewAssignmentDetailsRow {
+  revieweeName: string;
+  submissionUrl: string;
+}
+
+export function mapPeerReviewAssignmentDetailsRow(
+  row: PeerReviewAssignmentDetailsRow
+): PeerReviewAssignmentDetailsRow {
+  return {
+    revieweeName: row.revieweeName,
+    submissionUrl: row.submissionUrl,
+  };
+}
+
+export class DrizzlePeerReviewSubmissionLookup implements PeerReviewSubmissionLookupPort {
+  async findAcceptedSubmissionCandidates(
+    cycleId: number
+  ): Promise<PeerReviewCandidate[]> {
+    const rows = await db
+      .select({
+        memberId: submissions.memberId,
+        submissionId: submissions.id,
+        submittedAt: submissions.submittedAt,
+      })
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.cycleId, cycleId),
+          eq(submissions.status, 'ACCEPTED')
+        )
+      )
+      .orderBy(asc(submissions.memberId), asc(submissions.submittedAt));
+
+    return rows;
+  }
+}
+
+export class DrizzlePeerReviewAssignmentDetailsLookup {
+  async findAssignmentDetails(
+    assignment: PeerReviewAssignment
+  ): Promise<PeerReviewAssignmentDetailsRow> {
+    const [row] = await db
+      .select({
+        revieweeName: members.name,
+        submissionUrl: submissions.url,
+      })
+      .from(peerReviewAssignments)
+      .innerJoin(
+        submissions,
+        eq(peerReviewAssignments.submissionId, submissions.id)
+      )
+      .innerJoin(
+        members,
+        eq(peerReviewAssignments.revieweeMemberId, members.id)
+      )
+      .where(eq(peerReviewAssignments.id, assignment.id ?? 0))
+      .limit(1);
+
+    if (!row) {
+      return {
+        revieweeName: `member#${assignment.revieweeMemberId}`,
+        submissionUrl: '',
+      };
+    }
+
+    return mapPeerReviewAssignmentDetailsRow(row);
+  }
+}

--- a/apps/server/src/migrations/004_add_peer_review_assignments.sql
+++ b/apps/server/src/migrations/004_add_peer_review_assignments.sql
@@ -1,0 +1,54 @@
+-- Peer review assignments for Donguel-Donguel random short reactions
+-- Adds cycle-level review settings and per-reviewer assignment state.
+
+DO $$ BEGIN
+  CREATE TYPE peer_review_assignment_status AS ENUM (
+    'ASSIGNED',
+    'COMPLETED',
+    'SKIPPED',
+    'CANCELLED'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS cycle_review_settings (
+  id SERIAL PRIMARY KEY,
+  cycle_id INTEGER NOT NULL REFERENCES cycles(id),
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  assignment_seed TEXT NOT NULL,
+  min_submission_count INTEGER NOT NULL DEFAULT 2,
+  created_by_member_id INTEGER REFERENCES members(id),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS cycle_review_settings_cycle_uidx
+  ON cycle_review_settings(cycle_id);
+
+CREATE TABLE IF NOT EXISTS peer_review_assignments (
+  id SERIAL PRIMARY KEY,
+  cycle_id INTEGER NOT NULL REFERENCES cycles(id),
+  reviewer_member_id INTEGER NOT NULL REFERENCES members(id),
+  reviewee_member_id INTEGER NOT NULL REFERENCES members(id),
+  submission_id INTEGER NOT NULL REFERENCES submissions(id),
+  status peer_review_assignment_status NOT NULL DEFAULT 'ASSIGNED',
+  assigned_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMP,
+  completed_source_url TEXT,
+  completion_note TEXT,
+  skipped_at TIMESTAMP,
+  skip_reason TEXT,
+  cancelled_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS peer_review_assignments_cycle_reviewer_uidx
+  ON peer_review_assignments(cycle_id, reviewer_member_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS peer_review_assignments_cycle_reviewee_uidx
+  ON peer_review_assignments(cycle_id, reviewee_member_id);
+
+CREATE INDEX IF NOT EXISTS peer_review_assignments_cycle_status_idx
+  ON peer_review_assignments(cycle_id, status);

--- a/apps/server/src/presentation/discord/commands/ReviewCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/ReviewCommand.test.ts
@@ -1,31 +1,118 @@
+import { MessageFlags } from 'discord.js';
 import { describe, expect, it, vi } from 'vitest';
-import { ReviewCommand } from './ReviewCommand';
+import { PeerReviewAssignment } from '@/domain/peer-review';
+import { Member } from '@/domain/member/member.domain';
+import { ReviewCommand, ReviewCommandDependencies } from './ReviewCommand';
 
 type MockInteraction = {
+  user: { id: string };
   options: {
     getSubcommand: ReturnType<typeof vi.fn>;
+    getString: ReturnType<typeof vi.fn>;
   };
   reply: ReturnType<typeof vi.fn>;
+  deferReply: ReturnType<typeof vi.fn>;
+  editReply: ReturnType<typeof vi.fn>;
 };
 
-function createInteraction(subcommand: 'template'): MockInteraction {
+function createInteraction(
+  subcommand: 'template' | 'assign' | 'my' | 'done' | 'status' | 'unknown',
+  stringOptions: Record<string, string | null> = {}
+): MockInteraction {
   return {
+    user: { id: 'discord-1' },
     options: {
       getSubcommand: vi.fn().mockReturnValue(subcommand),
+      getString: vi.fn((name: string) => stringOptions[name] ?? null),
     },
     reply: vi.fn().mockResolvedValue(undefined),
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMember(id = 20): Member {
+  return Member.reconstitute({
+    id,
+    discordId: 'discord-1',
+    discordUsername: 'jun',
+    githubUsername: 'BBAK-jun',
+    name: '박준형',
+    createdAt: new Date('2026-05-26T00:00:00.000Z'),
+  });
+}
+
+function createAssignment(status: 'ASSIGNED' | 'COMPLETED' = 'ASSIGNED') {
+  return PeerReviewAssignment.create({
+    id: 1,
+    cycleId: 10,
+    reviewerMemberId: 20,
+    revieweeMemberId: 30,
+    submissionId: 300,
+    status,
+    assignedAt: new Date('2026-05-26T00:00:00.000Z'),
+    completedAt:
+      status === 'COMPLETED' ? new Date('2026-05-27T00:00:00.000Z') : undefined,
+  });
+}
+
+function createDependencies(
+  overrides: Partial<ReviewCommandDependencies> = {}
+): ReviewCommandDependencies {
+  return {
+    memberRepository: {
+      findByDiscordId: vi.fn().mockResolvedValue(createMember()),
+    },
+    cycleQuery: {
+      getCurrentCycle: vi.fn().mockResolvedValue({
+        id: 10,
+        week: 3,
+        generationName: '똥글똥글 3기',
+      }),
+    },
+    createAssignmentsCommand: {
+      execute: vi.fn().mockResolvedValue([createAssignment()]),
+    },
+    getMyAssignmentQuery: {
+      execute: vi.fn().mockResolvedValue(createAssignment()),
+    },
+    completeAssignmentCommand: {
+      execute: vi.fn().mockResolvedValue(createAssignment('COMPLETED')),
+    },
+    getStatusQuery: {
+      execute: vi.fn().mockResolvedValue({
+        cycleId: 10,
+        total: 1,
+        completed: 0,
+        pending: 1,
+        skipped: 0,
+        cancelled: 0,
+        pendingReviewerMemberIds: [20],
+      }),
+    },
+    assignmentDetailsLookup: {
+      findAssignmentDetails: vi.fn().mockResolvedValue({
+        revieweeName: '김리뷰',
+        submissionUrl: 'https://example.com/post',
+      }),
+    },
+    ...overrides,
   };
 }
 
 describe('ReviewCommand', () => {
-  it('defines the review command with a template subcommand', () => {
+  it('defines the review command with peer-review subcommands', () => {
     const commandJson = new ReviewCommand().definition.toJSON();
 
     expect(commandJson.name).toBe('review');
     expect(commandJson.description).toContain('감상평');
-    expect(
-      commandJson.options?.some((option) => option.name === 'template')
-    ).toBe(true);
+    expect(commandJson.options?.map((option) => option.name)).toEqual([
+      'template',
+      'assign',
+      'my',
+      'done',
+      'status',
+    ]);
   });
 
   it('replies with the 3rd generation submission and peer review template', async () => {
@@ -44,17 +131,104 @@ describe('ReviewCommand', () => {
     expect(reply.content).toContain('2~5문장');
   });
 
+  it('assigns current cycle peer reviews for operators', async () => {
+    const dependencies = createDependencies();
+    const command = new ReviewCommand(dependencies);
+    const interaction = createInteraction('assign', { seed: 'week-3' });
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith();
+    expect(dependencies.cycleQuery.getCurrentCycle).toHaveBeenCalledWith(
+      'dongueldonguel'
+    );
+    expect(dependencies.createAssignmentsCommand.execute).toHaveBeenCalledWith({
+      cycleId: 10,
+      seed: 'week-3',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('1개의 감상평 매칭을 만들었어요'),
+      })
+    );
+  });
+
+  it('shows my current cycle peer review assignment', async () => {
+    const dependencies = createDependencies();
+    const command = new ReviewCommand(dependencies);
+    const interaction = createInteraction('my');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({
+      flags: MessageFlags.Ephemeral,
+    });
+    expect(dependencies.memberRepository.findByDiscordId).toHaveBeenCalledWith(
+      'discord-1'
+    );
+    expect(dependencies.getMyAssignmentQuery.execute).toHaveBeenCalledWith({
+      cycleId: 10,
+      reviewerMemberId: 20,
+    });
+    expect(
+      dependencies.assignmentDetailsLookup.findAssignmentDetails
+    ).toHaveBeenCalledWith(createAssignment());
+    const reply = interaction.editReply.mock.calls[0][0] as { content: string };
+    expect(reply.content).toContain('김리뷰');
+    expect(reply.content).toContain('https://example.com/post');
+  });
+
+  it('marks my current cycle peer review as done', async () => {
+    const dependencies = createDependencies();
+    const command = new ReviewCommand(dependencies);
+    const interaction = createInteraction('done', {
+      source_url: 'https://github.com/org/repo/issues/1#comment-1',
+      note: '좋았던 점을 남겼어요',
+    });
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({
+      flags: MessageFlags.Ephemeral,
+    });
+    expect(dependencies.completeAssignmentCommand.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cycleId: 10,
+        reviewerMemberId: 20,
+        completedSourceUrl: 'https://github.com/org/repo/issues/1#comment-1',
+        completionNote: '좋았던 점을 남겼어요',
+      })
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('감상평을 완료로 기록했어요'),
+      })
+    );
+  });
+
+  it('shows current cycle peer review status', async () => {
+    const dependencies = createDependencies();
+    const command = new ReviewCommand(dependencies);
+    const interaction = createInteraction('status');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith();
+    expect(dependencies.getStatusQuery.execute).toHaveBeenCalledWith({
+      cycleId: 10,
+    });
+    const reply = interaction.editReply.mock.calls[0][0] as { content: string };
+    expect(reply.content).toContain('감상평 현황');
+    expect(reply.content).toContain('남은 감상평: 1개');
+  });
+
   it('ignores unknown subcommands without replying', async () => {
     const command = new ReviewCommand();
-    const interaction = {
-      options: {
-        getSubcommand: vi.fn().mockReturnValue('unknown'),
-      },
-      reply: vi.fn().mockResolvedValue(undefined),
-    };
+    const interaction = createInteraction('unknown');
 
     await command.execute(interaction as never);
 
     expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.deferReply).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/presentation/discord/commands/ReviewCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/ReviewCommand.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ReviewCommand } from './ReviewCommand';
+
+type MockInteraction = {
+  options: {
+    getSubcommand: ReturnType<typeof vi.fn>;
+  };
+  reply: ReturnType<typeof vi.fn>;
+};
+
+function createInteraction(subcommand: 'template'): MockInteraction {
+  return {
+    options: {
+      getSubcommand: vi.fn().mockReturnValue(subcommand),
+    },
+    reply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('ReviewCommand', () => {
+  it('defines the review command with a template subcommand', () => {
+    const commandJson = new ReviewCommand().definition.toJSON();
+
+    expect(commandJson.name).toBe('review');
+    expect(commandJson.description).toContain('감상평');
+    expect(
+      commandJson.options?.some((option) => option.name === 'template')
+    ).toBe(true);
+  });
+
+  it('replies with the 3rd generation submission and peer review template', async () => {
+    const command = new ReviewCommand();
+    const interaction = createInteraction('template');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('3기 제출 템플릿'),
+      })
+    );
+    const reply = interaction.reply.mock.calls[0][0] as { content: string };
+    expect(reply.content).toContain('평가나 채점이 아니라');
+    expect(reply.content).toContain('2~5문장');
+  });
+
+  it('ignores unknown subcommands without replying', async () => {
+    const command = new ReviewCommand();
+    const interaction = {
+      options: {
+        getSubcommand: vi.fn().mockReturnValue('unknown'),
+      },
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await command.execute(interaction as never);
+
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/presentation/discord/commands/ReviewCommand.ts
+++ b/apps/server/src/presentation/discord/commands/ReviewCommand.ts
@@ -1,6 +1,58 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { createPeerReviewTemplateMessage } from '@/infrastructure/external/discord';
+import {
+  ChatInputCommandInteraction,
+  MessageFlags,
+  SlashCommandBuilder,
+} from 'discord.js';
+import {
+  CompletePeerReviewAssignmentCommand,
+  CreatePeerReviewAssignmentsCommand,
+  GetMyPeerReviewAssignmentQuery,
+  GetPeerReviewStatusQuery,
+} from '@/application/peer-review';
+import { PeerReviewAssignment } from '@/domain/peer-review';
+import { MemberRepository } from '@/domain/member/member.repository';
+import {
+  createPeerReviewDoneMessage,
+  createPeerReviewMyAssignmentMessage,
+  createPeerReviewNoAssignmentMessage,
+  createPeerReviewStatusMessage,
+  createPeerReviewTemplateMessage,
+} from '@/infrastructure/external/discord';
 import { DiscordCommand } from './types';
+
+const DEFAULT_ORGANIZATION_SLUG = 'dongueldonguel';
+
+interface CurrentCycleLookup {
+  getCurrentCycle(organizationSlug: string): Promise<{
+    id: number;
+    week: number;
+    generationName: string;
+  } | null>;
+}
+
+export interface PeerReviewAssignmentDetails {
+  revieweeName: string;
+  submissionUrl: string;
+}
+
+export interface PeerReviewAssignmentDetailsLookup {
+  findAssignmentDetails(
+    assignment: PeerReviewAssignment
+  ): Promise<PeerReviewAssignmentDetails>;
+}
+
+export interface ReviewCommandDependencies {
+  memberRepository: Pick<MemberRepository, 'findByDiscordId'>;
+  cycleQuery: CurrentCycleLookup;
+  createAssignmentsCommand: Pick<CreatePeerReviewAssignmentsCommand, 'execute'>;
+  getMyAssignmentQuery: Pick<GetMyPeerReviewAssignmentQuery, 'execute'>;
+  completeAssignmentCommand: Pick<
+    CompletePeerReviewAssignmentCommand,
+    'execute'
+  >;
+  getStatusQuery: Pick<GetPeerReviewStatusQuery, 'execute'>;
+  assignmentDetailsLookup: PeerReviewAssignmentDetailsLookup;
+}
 
 export class ReviewCommand implements DiscordCommand {
   readonly definition = new SlashCommandBuilder()
@@ -10,13 +62,227 @@ export class ReviewCommand implements DiscordCommand {
       subcommand
         .setName('template')
         .setDescription('3기 제출 템플릿과 감상평 가이드를 확인합니다')
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('assign')
+        .setDescription('현재 회차 제출자끼리 감상평 매칭을 생성합니다')
+        .addStringOption((option) =>
+          option
+            .setName('seed')
+            .setDescription('재현 가능한 랜덤 매칭 seed (선택)')
+            .setRequired(false)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('my')
+        .setDescription('내가 읽고 감상평을 남길 글을 확인합니다')
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('done')
+        .setDescription('내 감상평 작성을 완료로 기록합니다')
+        .addStringOption((option) =>
+          option
+            .setName('source_url')
+            .setDescription('감상평을 남긴 댓글/메시지 링크 (선택)')
+            .setRequired(false)
+        )
+        .addStringOption((option) =>
+          option
+            .setName('note')
+            .setDescription('운영 참고용 짧은 메모 (선택)')
+            .setRequired(false)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('status')
+        .setDescription('현재 회차 감상평 진행 현황을 확인합니다')
     );
+
+  constructor(private readonly dependencies?: ReviewCommandDependencies) {}
 
   async execute(interaction: ChatInputCommandInteraction): Promise<void> {
     const subcommand = interaction.options.getSubcommand(true);
 
     if (subcommand === 'template') {
       await interaction.reply(createPeerReviewTemplateMessage());
+      return;
     }
+
+    if (subcommand === 'assign') {
+      await this.handleAssign(interaction);
+    } else if (subcommand === 'my') {
+      await this.handleMy(interaction);
+    } else if (subcommand === 'done') {
+      await this.handleDone(interaction);
+    } else if (subcommand === 'status') {
+      await this.handleStatus(interaction);
+    }
+  }
+
+  private async handleAssign(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    await interaction.deferReply();
+    const dependencies = await this.requireDependencies(interaction);
+    if (!dependencies) return;
+
+    const currentCycle = await this.getCurrentCycleOrReply(interaction);
+    if (!currentCycle) return;
+
+    const seed =
+      interaction.options.getString('seed') ??
+      `${DEFAULT_ORGANIZATION_SLUG}:${currentCycle.id}`;
+    const assignments = await dependencies.createAssignmentsCommand.execute({
+      cycleId: currentCycle.id,
+      seed,
+    });
+
+    await interaction.editReply({
+      content:
+        `✅ **${currentCycle.generationName} ${currentCycle.week}주차**에 ` +
+        `**${assignments.length}개의 감상평 매칭을 만들었어요.**\n\n` +
+        '참가자는 `/review my`로 본인이 읽을 글을 확인할 수 있어요.',
+    });
+  }
+
+  private async handleMy(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    const dependencies = await this.requireDependencies(interaction);
+    if (!dependencies) return;
+
+    const currentCycle = await this.getCurrentCycleOrReply(interaction);
+    if (!currentCycle) return;
+
+    const member = await this.getMemberOrReply(interaction);
+    if (!member) return;
+
+    const assignment = await dependencies.getMyAssignmentQuery.execute({
+      cycleId: currentCycle.id,
+      reviewerMemberId: member.id.value,
+    });
+
+    if (!assignment) {
+      await interaction.editReply(
+        createPeerReviewNoAssignmentMessage({
+          cycleName: `${currentCycle.generationName} ${currentCycle.week}주차`,
+        })
+      );
+      return;
+    }
+
+    const details =
+      await dependencies.assignmentDetailsLookup.findAssignmentDetails(
+        assignment
+      );
+
+    await interaction.editReply(
+      createPeerReviewMyAssignmentMessage({
+        cycleName: `${currentCycle.generationName} ${currentCycle.week}주차`,
+        revieweeName: details.revieweeName,
+        submissionUrl: details.submissionUrl,
+      })
+    );
+  }
+
+  private async handleDone(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    const dependencies = await this.requireDependencies(interaction);
+    if (!dependencies) return;
+
+    const currentCycle = await this.getCurrentCycleOrReply(interaction);
+    if (!currentCycle) return;
+
+    const member = await this.getMemberOrReply(interaction);
+    if (!member) return;
+
+    await dependencies.completeAssignmentCommand.execute({
+      cycleId: currentCycle.id,
+      reviewerMemberId: member.id.value,
+      completedSourceUrl:
+        interaction.options.getString('source_url') ?? undefined,
+      completionNote: interaction.options.getString('note') ?? undefined,
+    });
+
+    await interaction.editReply(
+      createPeerReviewDoneMessage({
+        cycleName: `${currentCycle.generationName} ${currentCycle.week}주차`,
+      })
+    );
+  }
+
+  private async handleStatus(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    await interaction.deferReply();
+    const dependencies = await this.requireDependencies(interaction);
+    if (!dependencies) return;
+
+    const currentCycle = await this.getCurrentCycleOrReply(interaction);
+    if (!currentCycle) return;
+
+    const status = await dependencies.getStatusQuery.execute({
+      cycleId: currentCycle.id,
+    });
+
+    await interaction.editReply(
+      createPeerReviewStatusMessage({
+        cycleName: `${currentCycle.generationName} ${currentCycle.week}주차`,
+        total: status.total,
+        completed: status.completed,
+        pending: status.pending,
+        skipped: status.skipped,
+        cancelled: status.cancelled,
+      })
+    );
+  }
+
+  private async requireDependencies(
+    interaction: ChatInputCommandInteraction
+  ): Promise<ReviewCommandDependencies | null> {
+    if (this.dependencies) return this.dependencies;
+
+    await interaction.editReply({
+      content:
+        '❌ 감상평 명령어 설정이 아직 연결되지 않았어요. 운영자에게 알려주세요.',
+    });
+    return null;
+  }
+
+  private async getCurrentCycleOrReply(
+    interaction: ChatInputCommandInteraction
+  ): Promise<{ id: number; week: number; generationName: string } | null> {
+    const currentCycle = await this.dependencies?.cycleQuery.getCurrentCycle(
+      DEFAULT_ORGANIZATION_SLUG
+    );
+    if (currentCycle) return currentCycle;
+
+    await interaction.editReply({
+      content:
+        '❌ 현재 진행 중인 회차를 찾지 못했어요. `/cycle current`로 먼저 회차 상태를 확인해 주세요.',
+    });
+    return null;
+  }
+
+  private async getMemberOrReply(
+    interaction: ChatInputCommandInteraction
+  ): Promise<{ id: { value: number } } | null> {
+    const member = await this.dependencies?.memberRepository.findByDiscordId(
+      interaction.user.id
+    );
+    if (member) return member;
+
+    await interaction.editReply({
+      content:
+        '👋 아직 회원 등록이 필요해요. `/member create`로 등록한 뒤 다시 실행해 주세요.',
+    });
+    return null;
   }
 }

--- a/apps/server/src/presentation/discord/commands/ReviewCommand.ts
+++ b/apps/server/src/presentation/discord/commands/ReviewCommand.ts
@@ -1,0 +1,22 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { createPeerReviewTemplateMessage } from '@/infrastructure/external/discord';
+import { DiscordCommand } from './types';
+
+export class ReviewCommand implements DiscordCommand {
+  readonly definition = new SlashCommandBuilder()
+    .setName('review')
+    .setDescription('똥글똥글 감상평 매칭과 템플릿을 관리합니다')
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('template')
+        .setDescription('3기 제출 템플릿과 감상평 가이드를 확인합니다')
+    );
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    const subcommand = interaction.options.getSubcommand(true);
+
+    if (subcommand === 'template') {
+      await interaction.reply(createPeerReviewTemplateMessage());
+    }
+  }
+}

--- a/apps/server/src/presentation/discord/commands/index.ts
+++ b/apps/server/src/presentation/discord/commands/index.ts
@@ -7,6 +7,7 @@ import { MemberCommand } from './MemberCommand';
 import { OrganizationCommand } from './OrganizationCommand';
 import { GenerationCommand } from './GenerationCommand';
 import { MeCommand } from './MeCommand';
+import { ReviewCommand } from './ReviewCommand';
 import { GetCycleStatusQuery } from '@/application/queries';
 import {
   CreateMemberCommand as AppCreateMemberCommand,
@@ -123,6 +124,7 @@ export const createCommands = (): DiscordCommand[] => {
       cycleRepo
     ),
     new CycleCommand(getCycleStatusQuery),
+    new ReviewCommand(),
   ];
 };
 

--- a/apps/server/src/presentation/discord/commands/index.ts
+++ b/apps/server/src/presentation/discord/commands/index.ts
@@ -33,6 +33,17 @@ import {
   ListGenerationApplicationsQuery,
 } from '@/application/study-operations';
 import { MemberService } from '@/domain/member/member.service';
+import {
+  CompletePeerReviewAssignmentCommand,
+  CreatePeerReviewAssignmentsCommand,
+  GetMyPeerReviewAssignmentQuery,
+  GetPeerReviewStatusQuery,
+} from '@/application/peer-review';
+import {
+  DrizzlePeerReviewAssignmentDetailsLookup,
+  DrizzlePeerReviewAssignmentRepository,
+  DrizzlePeerReviewSubmissionLookup,
+} from '@/infrastructure/persistence/drizzle/peer-review.repository.impl';
 
 // Repository instances
 const cycleRepo = new DrizzleCycleRepository();
@@ -44,6 +55,10 @@ const organizationRepo = new DrizzleOrganizationRepository();
 const organizationMemberRepo = new DrizzleOrganizationMemberRepository();
 const generationParticipantRepo = new DrizzleGenerationParticipantRepository();
 const studyOperationsOutbox = new DrizzleOutboxPort();
+const peerReviewAssignmentRepo = new DrizzlePeerReviewAssignmentRepository();
+const peerReviewSubmissionLookup = new DrizzlePeerReviewSubmissionLookup();
+const peerReviewAssignmentDetailsLookup =
+  new DrizzlePeerReviewAssignmentDetailsLookup();
 
 // Application layer instances
 const memberService = new MemberService(memberRepo);
@@ -91,6 +106,42 @@ const getCycleStatusQuery = new GetCycleStatusQuery(
   organizationMemberRepo,
   memberRepo
 );
+const createPeerReviewAssignmentsCommand =
+  new CreatePeerReviewAssignmentsCommand(
+    peerReviewSubmissionLookup,
+    peerReviewAssignmentRepo
+  );
+const getMyPeerReviewAssignmentQuery = new GetMyPeerReviewAssignmentQuery(
+  peerReviewAssignmentRepo
+);
+const completePeerReviewAssignmentCommand =
+  new CompletePeerReviewAssignmentCommand(peerReviewAssignmentRepo);
+const getPeerReviewStatusQuery = new GetPeerReviewStatusQuery(
+  peerReviewAssignmentRepo
+);
+
+const currentPeerReviewCycleQuery = {
+  async getCurrentCycle(organizationSlug: string) {
+    const organization = await organizationRepo.findBySlug(organizationSlug);
+    if (!organization) return null;
+
+    const activeCycles = await cycleRepo.findActiveCyclesByOrganization(
+      organization.id.value
+    );
+    const currentCycle = activeCycles[0];
+    if (!currentCycle) return null;
+
+    const generation = await generationRepo.findActiveByOrganization(
+      organization.id.value
+    );
+
+    return {
+      id: currentCycle.id.value,
+      week: currentCycle.week.toNumber(),
+      generationName: generation?.name ?? '똥글똥글',
+    };
+  },
+};
 
 // Command instances
 export const createCommands = (): DiscordCommand[] => {
@@ -124,7 +175,15 @@ export const createCommands = (): DiscordCommand[] => {
       cycleRepo
     ),
     new CycleCommand(getCycleStatusQuery),
-    new ReviewCommand(),
+    new ReviewCommand({
+      memberRepository: memberRepo,
+      cycleQuery: currentPeerReviewCycleQuery,
+      createAssignmentsCommand: createPeerReviewAssignmentsCommand,
+      getMyAssignmentQuery: getMyPeerReviewAssignmentQuery,
+      completeAssignmentCommand: completePeerReviewAssignmentCommand,
+      getStatusQuery: getPeerReviewStatusQuery,
+      assignmentDetailsLookup: peerReviewAssignmentDetailsLookup,
+    }),
   ];
 };
 


### PR DESCRIPTION
## Summary
- Add peer-review persistence schema/repository and idempotent SQL migration
- Wire `/review assign`, `/review my`, `/review done`, `/review status` to Drizzle-backed use cases
- Use canonical `dongueldonguel` organization slug for runtime current-cycle lookup

## Test Plan
- `SKIP_ENV_VALIDATION=true pnpm exec vitest run src/presentation/discord/commands/ReviewCommand.test.ts src/infrastructure/persistence/drizzle-db/schema.peer-review.test.ts src/infrastructure/persistence/drizzle/peer-review.repository.impl.test.ts`
- `pnpm --filter @hanghae-study/server test -- --runInBand`
- `pnpm --filter @hanghae-study/server type-check`
- `pnpm --filter @hanghae-study/server lint`
- `pnpm --filter @hanghae-study/server format:check`
- `git diff --check`

## Notes
- Render production service auto-deploys from `main`.
- `DISCORD_COMMAND_SYNC_POLICY=off` means slash command schema changes may require a controlled command-sync restart after deploy.