### PR TITLE
feat: persist peer review assignments

### DIFF
--- a/apps/server/src/infrastructure/persistence/drizzle-db/schema.peer-review.test.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle-db/schema.peer-review.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cycleReviewSettings,
+  peerReviewAssignments,
+  peerReviewAssignmentStatusEnum,
+} from './schema';
+
+describe('peer review drizzle schema', () => {
+  it('defines peer review assignment statuses', () => {
+    expect(peerReviewAssignmentStatusEnum.enumValues).toEqual([
+      'ASSIGNED',
+      'COMPLETED',
+      'SKIPPED',
+      'CANCELLED',
+    ]);
+  });
+
+  it('defines cycle review settings columns', () => {
+    expect(cycleReviewSettings.cycleId.name).toBe('cycle_id');
+    expect(cycleReviewSettings.enabled.name).toBe('enabled');
+    expect(cycleReviewSettings.assignmentSeed.name).toBe('assignment_seed');
+    expect(cycleReviewSettings.minSubmissionCount.name).toBe(
+      'min_submission_count'
+    );
+  });
+
+  it('defines peer review assignment columns', () => {
+    expect(peerReviewAssignments.cycleId.name).toBe('cycle_id');
+    expect(peerReviewAssignments.reviewerMemberId.name).toBe(
+      'reviewer_member_id'
+    );
+    expect(peerReviewAssignments.revieweeMemberId.name).toBe(
+      'reviewee_member_id'
+    );
+    expect(peerReviewAssignments.submissionId.name).toBe('submission_id');
+    expect(peerReviewAssignments.completedSourceUrl.name).toBe(
+      'completed_source_url'
+    );
+    expect(peerReviewAssignments.completionNote.name).toBe('completion_note');
+  });
+});

--- a/apps/server/src/infrastructure/persistence/drizzle-db/schema.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle-db/schema.ts
@@ -103,6 +103,11 @@ export const obligationStatusEnum = pgEnum('obligation_status', [
   'EXEMPT_NON_PARTICIPANT_ROLE',
 ]);
 
+export const peerReviewAssignmentStatusEnum = pgEnum(
+  'peer_review_assignment_status',
+  ['ASSIGNED', 'COMPLETED', 'SKIPPED', 'CANCELLED']
+);
+
 export const participantCycleResultStatusEnum = pgEnum(
   'participant_cycle_result_status',
   ['SUBMITTED_ON_TIME', 'SUBMITTED_LATE', 'MISSED', 'EXEMPT']
@@ -475,6 +480,70 @@ export const submissions = pgTable(
       table.generationParticipantId
     ),
     statusIdx: index('submissions_status_idx').on(table.status),
+  })
+);
+
+export const cycleReviewSettings = pgTable(
+  'cycle_review_settings',
+  {
+    id: serial('id').primaryKey(),
+    cycleId: integer('cycle_id')
+      .notNull()
+      .references(() => cycles.id),
+    enabled: boolean('enabled').default(true).notNull(),
+    assignmentSeed: text('assignment_seed').notNull(),
+    minSubmissionCount: integer('min_submission_count').default(2).notNull(),
+    createdByMemberId: integer('created_by_member_id').references(
+      () => members.id
+    ),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    cycleIdx: uniqueIndex('cycle_review_settings_cycle_uidx').on(table.cycleId),
+  })
+);
+
+export const peerReviewAssignments = pgTable(
+  'peer_review_assignments',
+  {
+    id: serial('id').primaryKey(),
+    cycleId: integer('cycle_id')
+      .notNull()
+      .references(() => cycles.id),
+    reviewerMemberId: integer('reviewer_member_id')
+      .notNull()
+      .references(() => members.id),
+    revieweeMemberId: integer('reviewee_member_id')
+      .notNull()
+      .references(() => members.id),
+    submissionId: integer('submission_id')
+      .notNull()
+      .references(() => submissions.id),
+    status: peerReviewAssignmentStatusEnum('status')
+      .default('ASSIGNED')
+      .notNull(),
+    assignedAt: timestamp('assigned_at').defaultNow().notNull(),
+    completedAt: timestamp('completed_at'),
+    completedSourceUrl: text('completed_source_url'),
+    completionNote: text('completion_note'),
+    skippedAt: timestamp('skipped_at'),
+    skipReason: text('skip_reason'),
+    cancelledAt: timestamp('cancelled_at'),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    cycleReviewerIdx: uniqueIndex(
+      'peer_review_assignments_cycle_reviewer_uidx'
+    ).on(table.cycleId, table.reviewerMemberId),
+    cycleRevieweeIdx: uniqueIndex(
+      'peer_review_assignments_cycle_reviewee_uidx'
+    ).on(table.cycleId, table.revieweeMemberId),
+    cycleStatusIdx: index('peer_review_assignments_cycle_status_idx').on(
+      table.cycleId,
+      table.status
+    ),
   })
 );
 

--- a/apps/server/src/infrastructure/persistence/drizzle/index.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle/index.ts
@@ -5,4 +5,5 @@ export * from './member.repository.impl';
 export * from './organization.repository.impl';
 export * from './organization-member.repository.impl';
 export * from './submission.repository.impl';
+export * from './peer-review.repository.impl';
 export * from './study-operations.repository.impl';

--- a/apps/server/src/infrastructure/persistence/drizzle/peer-review.repository.impl.test.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle/peer-review.repository.impl.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mapPeerReviewAssignmentDetailsRow,
+  mapPeerReviewAssignmentRowToDomain,
+  mapPeerReviewAssignmentToInsert,
+  mapPeerReviewAssignmentToUpdate,
+} from './peer-review.repository.impl';
+
+describe('peer review persistence mappers', () => {
+  it('maps a database row into a domain assignment', () => {
+    const assignedAt = new Date('2026-05-26T00:00:00.000Z');
+    const completedAt = new Date('2026-05-27T00:00:00.000Z');
+
+    const assignment = mapPeerReviewAssignmentRowToDomain({
+      id: 1,
+      cycleId: 10,
+      reviewerMemberId: 20,
+      revieweeMemberId: 30,
+      submissionId: 300,
+      status: 'COMPLETED',
+      assignedAt,
+      completedAt,
+      completedSourceUrl: 'https://github.com/org/repo/issues/1#comment-1',
+      completionNote: '좋았던 점 남김',
+      skippedAt: null,
+      skipReason: null,
+      cancelledAt: null,
+      createdAt: assignedAt,
+      updatedAt: completedAt,
+    });
+
+    expect(assignment.id).toBe(1);
+    expect(assignment.cycleId).toBe(10);
+    expect(assignment.reviewerMemberId).toBe(20);
+    expect(assignment.revieweeMemberId).toBe(30);
+    expect(assignment.submissionId).toBe(300);
+    expect(assignment.status).toBe('COMPLETED');
+    expect(assignment.assignedAt).toBe(assignedAt);
+    expect(assignment.completedAt).toBe(completedAt);
+    expect(assignment.completedSourceUrl).toBe(
+      'https://github.com/org/repo/issues/1#comment-1'
+    );
+    expect(assignment.completionNote).toBe('좋았던 점 남김');
+  });
+
+  it('maps a new domain assignment into insert values', () => {
+    const assignedAt = new Date('2026-05-26T00:00:00.000Z');
+    const assignment = mapPeerReviewAssignmentRowToDomain({
+      id: 1,
+      cycleId: 10,
+      reviewerMemberId: 20,
+      revieweeMemberId: 30,
+      submissionId: 300,
+      status: 'ASSIGNED',
+      assignedAt,
+      completedAt: null,
+      completedSourceUrl: null,
+      completionNote: null,
+      skippedAt: null,
+      skipReason: null,
+      cancelledAt: null,
+      createdAt: assignedAt,
+      updatedAt: assignedAt,
+    });
+
+    expect(mapPeerReviewAssignmentToInsert(assignment)).toEqual({
+      cycleId: 10,
+      reviewerMemberId: 20,
+      revieweeMemberId: 30,
+      submissionId: 300,
+      status: 'ASSIGNED',
+      assignedAt,
+      completedAt: undefined,
+      completedSourceUrl: undefined,
+      completionNote: undefined,
+      skippedAt: undefined,
+      skipReason: undefined,
+      cancelledAt: undefined,
+    });
+  });
+
+  it('maps a completed assignment into update values', () => {
+    const assignedAt = new Date('2026-05-26T00:00:00.000Z');
+    const completedAt = new Date('2026-05-27T00:00:00.000Z');
+    const assignment = mapPeerReviewAssignmentRowToDomain({
+      id: 1,
+      cycleId: 10,
+      reviewerMemberId: 20,
+      revieweeMemberId: 30,
+      submissionId: 300,
+      status: 'ASSIGNED',
+      assignedAt,
+      completedAt: null,
+      completedSourceUrl: null,
+      completionNote: null,
+      skippedAt: null,
+      skipReason: null,
+      cancelledAt: null,
+      createdAt: assignedAt,
+      updatedAt: assignedAt,
+    });
+
+    assignment.complete({
+      completedAt,
+      completedSourceUrl: 'https://example.com/comment',
+      completionNote: '완료',
+    });
+
+    expect(mapPeerReviewAssignmentToUpdate(assignment)).toMatchObject({
+      status: 'COMPLETED',
+      completedAt,
+      completedSourceUrl: 'https://example.com/comment',
+      completionNote: '완료',
+      skippedAt: undefined,
+      skipReason: undefined,
+      cancelledAt: undefined,
+    });
+    expect(
+      mapPeerReviewAssignmentToUpdate(assignment).updatedAt
+    ).toBeInstanceOf(Date);
+  });
+
+  it('maps assignment detail rows into reviewee display data', () => {
+    expect(
+      mapPeerReviewAssignmentDetailsRow({
+        revieweeName: '김리뷰',
+        submissionUrl: 'https://example.com/post',
+      })
+    ).toEqual({
+      revieweeName: '김리뷰',
+      submissionUrl: 'https://example.com/post',
+    });
+  });
+});

--- a/apps/server/src/infrastructure/persistence/drizzle/peer-review.repository.impl.ts
+++ b/apps/server/src/infrastructure/persistence/drizzle/peer-review.repository.impl.ts
@@ -1,0 +1,216 @@
+import { and, asc, eq } from 'drizzle-orm';
+import {
+  PeerReviewAssignment,
+  PeerReviewCandidate,
+} from '@/domain/peer-review';
+import {
+  PeerReviewAssignmentRepository,
+  PeerReviewSubmissionLookupPort,
+} from '@/application/peer-review';
+import { db } from '../../lib/db';
+import {
+  members,
+  peerReviewAssignments,
+  submissions,
+} from '../drizzle-db/schema';
+
+type PeerReviewAssignmentRow = typeof peerReviewAssignments.$inferSelect;
+type PeerReviewAssignmentInsert = typeof peerReviewAssignments.$inferInsert;
+
+type PeerReviewAssignmentUpdate = Partial<
+  Pick<
+    PeerReviewAssignmentInsert,
+    | 'status'
+    | 'completedAt'
+    | 'completedSourceUrl'
+    | 'completionNote'
+    | 'skippedAt'
+    | 'skipReason'
+    | 'cancelledAt'
+    | 'updatedAt'
+  >
+>;
+
+export function mapPeerReviewAssignmentRowToDomain(
+  row: PeerReviewAssignmentRow
+): PeerReviewAssignment {
+  return PeerReviewAssignment.create({
+    id: row.id,
+    cycleId: row.cycleId,
+    reviewerMemberId: row.reviewerMemberId,
+    revieweeMemberId: row.revieweeMemberId,
+    submissionId: row.submissionId,
+    status: row.status,
+    assignedAt: row.assignedAt,
+    completedAt: row.completedAt ?? undefined,
+    completedSourceUrl: row.completedSourceUrl ?? undefined,
+    completionNote: row.completionNote ?? undefined,
+    skippedAt: row.skippedAt ?? undefined,
+    skipReason: row.skipReason ?? undefined,
+    cancelledAt: row.cancelledAt ?? undefined,
+  });
+}
+
+export function mapPeerReviewAssignmentToInsert(
+  assignment: PeerReviewAssignment
+): PeerReviewAssignmentInsert {
+  return {
+    cycleId: assignment.cycleId,
+    reviewerMemberId: assignment.reviewerMemberId,
+    revieweeMemberId: assignment.revieweeMemberId,
+    submissionId: assignment.submissionId,
+    status: assignment.status,
+    assignedAt: assignment.assignedAt,
+    completedAt: assignment.completedAt,
+    completedSourceUrl: assignment.completedSourceUrl,
+    completionNote: assignment.completionNote,
+    skippedAt: assignment.skippedAt,
+    skipReason: assignment.skipReason,
+    cancelledAt: assignment.cancelledAt,
+  };
+}
+
+export function mapPeerReviewAssignmentToUpdate(
+  assignment: PeerReviewAssignment
+): PeerReviewAssignmentUpdate {
+  return {
+    status: assignment.status,
+    completedAt: assignment.completedAt,
+    completedSourceUrl: assignment.completedSourceUrl,
+    completionNote: assignment.completionNote,
+    skippedAt: assignment.skippedAt,
+    skipReason: assignment.skipReason,
+    cancelledAt: assignment.cancelledAt,
+    updatedAt: new Date(),
+  };
+}
+
+export class DrizzlePeerReviewAssignmentRepository implements PeerReviewAssignmentRepository {
+  async findByCycleId(cycleId: number): Promise<PeerReviewAssignment[]> {
+    const rows = await db
+      .select()
+      .from(peerReviewAssignments)
+      .where(eq(peerReviewAssignments.cycleId, cycleId))
+      .orderBy(asc(peerReviewAssignments.reviewerMemberId));
+
+    return rows.map(mapPeerReviewAssignmentRowToDomain);
+  }
+
+  async findByCycleAndReviewer(
+    cycleId: number,
+    reviewerMemberId: number
+  ): Promise<PeerReviewAssignment | null> {
+    const [row] = await db
+      .select()
+      .from(peerReviewAssignments)
+      .where(
+        and(
+          eq(peerReviewAssignments.cycleId, cycleId),
+          eq(peerReviewAssignments.reviewerMemberId, reviewerMemberId)
+        )
+      )
+      .limit(1);
+
+    return row ? mapPeerReviewAssignmentRowToDomain(row) : null;
+  }
+
+  async saveMany(
+    assignments: PeerReviewAssignment[]
+  ): Promise<PeerReviewAssignment[]> {
+    if (assignments.length === 0) return [];
+
+    const rows = await db
+      .insert(peerReviewAssignments)
+      .values(assignments.map(mapPeerReviewAssignmentToInsert))
+      .returning();
+
+    return rows.map(mapPeerReviewAssignmentRowToDomain);
+  }
+
+  async save(assignment: PeerReviewAssignment): Promise<PeerReviewAssignment> {
+    if (!assignment.id) {
+      const [row] = await db
+        .insert(peerReviewAssignments)
+        .values(mapPeerReviewAssignmentToInsert(assignment))
+        .returning();
+      return mapPeerReviewAssignmentRowToDomain(row);
+    }
+
+    const [row] = await db
+      .update(peerReviewAssignments)
+      .set(mapPeerReviewAssignmentToUpdate(assignment))
+      .where(eq(peerReviewAssignments.id, assignment.id))
+      .returning();
+
+    return mapPeerReviewAssignmentRowToDomain(row);
+  }
+}
+
+export interface PeerReviewAssignmentDetailsRow {
+  revieweeName: string;
+  submissionUrl: string;
+}
+
+export function mapPeerReviewAssignmentDetailsRow(
+  row: PeerReviewAssignmentDetailsRow
+): PeerReviewAssignmentDetailsRow {
+  return {
+    revieweeName: row.revieweeName,
+    submissionUrl: row.submissionUrl,
+  };
+}
+
+export class DrizzlePeerReviewSubmissionLookup implements PeerReviewSubmissionLookupPort {
+  async findAcceptedSubmissionCandidates(
+    cycleId: number
+  ): Promise<PeerReviewCandidate[]> {
+    const rows = await db
+      .select({
+        memberId: submissions.memberId,
+        submissionId: submissions.id,
+        submittedAt: submissions.submittedAt,
+      })
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.cycleId, cycleId),
+          eq(submissions.status, 'ACCEPTED')
+        )
+      )
+      .orderBy(asc(submissions.memberId), asc(submissions.submittedAt));
+
+    return rows;
+  }
+}
+
+export class DrizzlePeerReviewAssignmentDetailsLookup {
+  async findAssignmentDetails(
+    assignment: PeerReviewAssignment
+  ): Promise<PeerReviewAssignmentDetailsRow> {
+    const [row] = await db
+      .select({
+        revieweeName: members.name,
+        submissionUrl: submissions.url,
+      })
+      .from(peerReviewAssignments)
+      .innerJoin(
+        submissions,
+        eq(peerReviewAssignments.submissionId, submissions.id)
+      )
+      .innerJoin(
+        members,
+        eq(peerReviewAssignments.revieweeMemberId, members.id)
+      )
+      .where(eq(peerReviewAssignments.id, assignment.id ?? 0))
+      .limit(1);
+
+    if (!row) {
+      return {
+        revieweeName: `member#${assignment.revieweeMemberId}`,
+        submissionUrl: '',
+      };
+    }
+
+    return mapPeerReviewAssignmentDetailsRow(row);
+  }
+}

--- a/apps/server/src/migrations/004_add_peer_review_assignments.sql
+++ b/apps/server/src/migrations/004_add_peer_review_assignments.sql
@@ -1,0 +1,54 @@
+-- Peer review assignments for Donguel-Donguel random short reactions
+-- Adds cycle-level review settings and per-reviewer assignment state.
+
+DO $$ BEGIN
+  CREATE TYPE peer_review_assignment_status AS ENUM (
+    'ASSIGNED',
+    'COMPLETED',
+    'SKIPPED',
+    'CANCELLED'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS cycle_review_settings (
+  id SERIAL PRIMARY KEY,
+  cycle_id INTEGER NOT NULL REFERENCES cycles(id),
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  assignment_seed TEXT NOT NULL,
+  min_submission_count INTEGER NOT NULL DEFAULT 2,
+  created_by_member_id INTEGER REFERENCES members(id),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS cycle_review_settings_cycle_uidx
+  ON cycle_review_settings(cycle_id);
+
+CREATE TABLE IF NOT EXISTS peer_review_assignments (
+  id SERIAL PRIMARY KEY,
+  cycle_id INTEGER NOT NULL REFERENCES cycles(id),
+  reviewer_member_id INTEGER NOT NULL REFERENCES members(id),
+  reviewee_member_id INTEGER NOT NULL REFERENCES members(id),
+  submission_id INTEGER NOT NULL REFERENCES submissions(id),
+  status peer_review_assignment_status NOT NULL DEFAULT 'ASSIGNED',
+  assigned_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMP,
+  completed_source_url TEXT,
+  completion_note TEXT,
+  skipped_at TIMESTAMP,
+  skip_reason TEXT,
+  cancelled_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS peer_review_assignments_cycle_reviewer_uidx
+  ON peer_review_assignments(cycle_id, reviewer_member_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS peer_review_assignments_cycle_reviewee_uidx
+  ON peer_review_assignments(cycle_id, reviewee_member_id);
+
+CREATE INDEX IF NOT EXISTS peer_review_assignments_cycle_status_idx
+  ON peer_review_assignments(cycle_id, status);

--- a/apps/server/src/presentation/discord/commands/ReviewCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/ReviewCommand.test.ts
@@ -1,31 +1,118 @@
+import { MessageFlags } from 'discord.js';
 import { describe, expect, it, vi } from 'vitest';
-import { ReviewCommand } from './ReviewCommand';
+import { PeerReviewAssignment } from '@/domain/peer-review';
+import { Member } from '@/domain/member/member.domain';
+import { ReviewCommand, ReviewCommandDependencies } from './ReviewCommand';
 
 type MockInteraction = {
+  user: { id: string };
   options: {
     getSubcommand: ReturnType<typeof vi.fn>;
+    getString: ReturnType<typeof vi.fn>;
   };
   reply: ReturnType<typeof vi.fn>;
+  deferReply: ReturnType<typeof vi.fn>;
+  editReply: ReturnType<typeof vi.fn>;
 };
 
-function createInteraction(subcommand: 'template'): MockInteraction {
+function createInteraction(
+  subcommand: 'template' | 'assign' | 'my' | 'done' | 'status' | 'unknown',
+  stringOptions: Record<string, string | null> = {}
+): MockInteraction {
   return {
+    user: { id: 'discord-1' },
     options: {
       getSubcommand: vi.fn().mockReturnValue(subcommand),
+      getString: vi.fn((name: string) => stringOptions[name] ?? null),
     },
     reply: vi.fn().mockResolvedValue(undefined),
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMember(id = 20): Member {
+  return Member.reconstitute({
+    id,
+    discordId: 'discord-1',
+    discordUsername: 'jun',
+    githubUsername: 'BBAK-jun',
+    name: '박준형',
+    createdAt: new Date('2026-05-26T00:00:00.000Z'),
+  });
+}
+
+function createAssignment(status: 'ASSIGNED' | 'COMPLETED' = 'ASSIGNED') {
+  return PeerReviewAssignment.create({
+    id: 1,
+    cycleId: 10,
+    reviewerMemberId: 20,
+    revieweeMemberId: 30,
+    submissionId: 300,
+    status,
+    assignedAt: new Date('2026-05-26T00:00:00.000Z'),
+    completedAt:
+      status === 'COMPLETED' ? new Date('2026-05-27T00:00:00.000Z') : undefined,
+  });
+}
+
+function createDependencies(
+  overrides: Partial<ReviewCommandDependencies> = {}
+): ReviewCommandDependencies {
+  return {
+    memberRepository: {
+      findByDiscordId: vi.fn().mockResolvedValue(createMember()),
+    },
+    cycleQuery: {
+      getCurrentCycle: vi.fn().mockResolvedValue({
+        id: 10,
+        week: 3,
+        generationName: '똥글똥글 3기',
+      }),
+    },
+    createAssignmentsCommand: {
+      execute: vi.fn().mockResolvedValue([createAssignment()]),
+    },
+    getMyAssignmentQuery: {
+      execute: vi.fn().mockResolvedValue(createAssignment()),
+    },
+    completeAssignmentCommand: {
+      execute: vi.fn().mockResolvedValue(createAssignment('COMPLETED')),
+    },
+    getStatusQuery: {
+      execute: vi.fn().mockResolvedValue({
+        cycleId: 10,
+        total: 1,
+        completed: 0,
+        pending: 1,
+        skipped: 0,
+        cancelled: 0,
+        pendingReviewerMemberIds: [20],
+      }),
+    },
+    assignmentDetailsLookup: {
+      findAssignmentDetails: vi.fn().mockResolvedValue({
+        revieweeName: '김리뷰',
+        submissionUrl: 'https://example.com/post',
+      }),
+    },
+    ...overrides,
   };
 }
 
 describe('ReviewCommand', () => {
-  it('defines the review command with a template subcommand', () => {
+  it('defines the review command with peer-review subcommands', () => {
     const commandJson = new ReviewCommand().definition.toJSON();
 
     expect(commandJson.name).toBe('review');
     expect(commandJson.description).toContain('감상평');
-    expect(
-      commandJson.options?.some((option) => option.name === 'template')
-    ).toBe(true);
+    expect(commandJson.options?.map((option) => option.name)).toEqual([
+      'template',
+      'assign',
+      'my',
+      'done',
+      'status',
+    ]);
   });
 
   it('replies with the 3rd generation submission and peer review template', async () => {
@@ -44,17 +131,104 @@ describe('ReviewCommand', () => {
     expect(reply.content).toContain('2~5문장');
   });
 
+  it('assigns current cycle peer reviews for operators', async () => {
+    const dependencies = createDependencies();
+    const command = new ReviewCommand(dependencies);
+    const interaction = createInteraction('assign', { seed: 'week-3' });
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith();
+    expect(dependencies.cycleQuery.getCurrentCycle).toHaveBeenCalledWith(
+      'dongueldonguel'
+    );
+    expect(dependencies.createAssignmentsCommand.execute).toHaveBeenCalledWith({
+      cycleId: 10,
+      seed: 'week-3',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('1개의 감상평 매칭을 만들었어요'),
+      })
+    );
+  });
+
+  it('shows my current cycle peer review assignment', async () => {
+    const dependencies = createDependencies();
+    const command = new ReviewCommand(dependencies);
+    const interaction = createInteraction('my');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({
+      flags: MessageFlags.Ephemeral,
+    });
+    expect(dependencies.memberRepository.findByDiscordId).toHaveBeenCalledWith(
+      'discord-1'
+    );
+    expect(dependencies.getMyAssignmentQuery.execute).toHaveBeenCalledWith({
+      cycleId: 10,
+      reviewerMemberId: 20,
+    });
+    expect(
+      dependencies.assignmentDetailsLookup.findAssignmentDetails
+    ).toHaveBeenCalledWith(createAssignment());
+    const reply = interaction.editReply.mock.calls[0][0] as { content: string };
+    expect(reply.content).toContain('김리뷰');
+    expect(reply.content).toContain('https://example.com/post');
+  });
+
+  it('marks my current cycle peer review as done', async () => {
+    const dependencies = createDependencies();
+    const command = new ReviewCommand(dependencies);
+    const interaction = createInteraction('done', {
+      source_url: 'https://github.com/org/repo/issues/1#comment-1',
+      note: '좋았던 점을 남겼어요',
+    });
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({
+      flags: MessageFlags.Ephemeral,
+    });
+    expect(dependencies.completeAssignmentCommand.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cycleId: 10,
+        reviewerMemberId: 20,
+        completedSourceUrl: 'https://github.com/org/repo/issues/1#comment-1',
+        completionNote: '좋았던 점을 남겼어요',
+      })
+    );
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('감상평을 완료로 기록했어요'),
+      })
+    );
+  });
+
+  it('shows current cycle peer review status', async () => {
+    const dependencies = createDependencies();
+    const command = new ReviewCommand(dependencies);
+    const interaction = createInteraction('status');
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith();
+    expect(dependencies.getStatusQuery.execute).toHaveBeenCalledWith({
+      cycleId: 10,
+    });
+    const reply = interaction.editReply.mock.calls[0][0] as { content: string };
+    expect(reply.content).toContain('감상평 현황');
+    expect(reply.content).toContain('남은 감상평: 1개');
+  });
+
   it('ignores unknown subcommands without replying', async () => {
     const command = new ReviewCommand();
-    const interaction = {
-      options: {
-        getSubcommand: vi.fn().mockReturnValue('unknown'),
-      },
-      reply: vi.fn().mockResolvedValue(undefined),
-    };
+    const interaction = createInteraction('unknown');
 
     await command.execute(interaction as never);
 
     expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.deferReply).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/presentation/discord/commands/ReviewCommand.ts
+++ b/apps/server/src/presentation/discord/commands/ReviewCommand.ts
@@ -1,6 +1,58 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-import { createPeerReviewTemplateMessage } from '@/infrastructure/external/discord';
+import {
+  ChatInputCommandInteraction,
+  MessageFlags,
+  SlashCommandBuilder,
+} from 'discord.js';
+import {
+  CompletePeerReviewAssignmentCommand,
+  CreatePeerReviewAssignmentsCommand,
+  GetMyPeerReviewAssignmentQuery,
+  GetPeerReviewStatusQuery,
+} from '@/application/peer-review';
+import { PeerReviewAssignment } from '@/domain/peer-review';
+import { MemberRepository } from '@/domain/member/member.repository';
+import {
+  createPeerReviewDoneMessage,
+  createPeerReviewMyAssignmentMessage,
+  createPeerReviewNoAssignmentMessage,
+  createPeerReviewStatusMessage,
+  createPeerReviewTemplateMessage,
+} from '@/infrastructure/external/discord';
 import { DiscordCommand } from './types';
+
+const DEFAULT_ORGANIZATION_SLUG = 'dongueldonguel';
+
+interface CurrentCycleLookup {
+  getCurrentCycle(organizationSlug: string): Promise<{
+    id: number;
+    week: number;
+    generationName: string;
+  } | null>;
+}
+
+export interface PeerReviewAssignmentDetails {
+  revieweeName: string;
+  submissionUrl: string;
+}
+
+export interface PeerReviewAssignmentDetailsLookup {
+  findAssignmentDetails(
+    assignment: PeerReviewAssignment
+  ): Promise<PeerReviewAssignmentDetails>;
+}
+
+export interface ReviewCommandDependencies {
+  memberRepository: Pick<MemberRepository, 'findByDiscordId'>;
+  cycleQuery: CurrentCycleLookup;
+  createAssignmentsCommand: Pick<CreatePeerReviewAssignmentsCommand, 'execute'>;
+  getMyAssignmentQuery: Pick<GetMyPeerReviewAssignmentQuery, 'execute'>;
+  completeAssignmentCommand: Pick<
+    CompletePeerReviewAssignmentCommand,
+    'execute'
+  >;
+  getStatusQuery: Pick<GetPeerReviewStatusQuery, 'execute'>;
+  assignmentDetailsLookup: PeerReviewAssignmentDetailsLookup;
+}
 
 export class ReviewCommand implements DiscordCommand {
   readonly definition = new SlashCommandBuilder()
@@ -10,13 +62,227 @@ export class ReviewCommand implements DiscordCommand {
       subcommand
         .setName('template')
         .setDescription('3기 제출 템플릿과 감상평 가이드를 확인합니다')
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('assign')
+        .setDescription('현재 회차 제출자끼리 감상평 매칭을 생성합니다')
+        .addStringOption((option) =>
+          option
+            .setName('seed')
+            .setDescription('재현 가능한 랜덤 매칭 seed (선택)')
+            .setRequired(false)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('my')
+        .setDescription('내가 읽고 감상평을 남길 글을 확인합니다')
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('done')
+        .setDescription('내 감상평 작성을 완료로 기록합니다')
+        .addStringOption((option) =>
+          option
+            .setName('source_url')
+            .setDescription('감상평을 남긴 댓글/메시지 링크 (선택)')
+            .setRequired(false)
+        )
+        .addStringOption((option) =>
+          option
+            .setName('note')
+            .setDescription('운영 참고용 짧은 메모 (선택)')
+            .setRequired(false)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('status')
+        .setDescription('현재 회차 감상평 진행 현황을 확인합니다')
     );
+
+  constructor(private readonly dependencies?: ReviewCommandDependencies) {}
 
   async execute(interaction: ChatInputCommandInteraction): Promise<void> {
     const subcommand = interaction.options.getSubcommand(true);
 
     if (subcommand === 'template') {
       await interaction.reply(createPeerReviewTemplateMessage());
+      return;
     }
+
+    if (subcommand === 'assign') {
+      await this.handleAssign(interaction);
+    } else if (subcommand === 'my') {
+      await this.handleMy(interaction);
+    } else if (subcommand === 'done') {
+      await this.handleDone(interaction);
+    } else if (subcommand === 'status') {
+      await this.handleStatus(interaction);
+    }
+  }
+
+  private async handleAssign(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    await interaction.deferReply();
+    const dependencies = await this.requireDependencies(interaction);
+    if (!dependencies) return;
+
+    const currentCycle = await this.getCurrentCycleOrReply(interaction);
+    if (!currentCycle) return;
+
+    const seed =
+      interaction.options.getString('seed') ??
+      `${DEFAULT_ORGANIZATION_SLUG}:${currentCycle.id}`;
+    const assignments = await dependencies.createAssignmentsCommand.execute({
+      cycleId: currentCycle.id,
+      seed,
+    });
+
+    await interaction.editReply({
+      content:
+        `✅ **${currentCycle.generationName} ${currentCycle.week}주차**에 ` +
+        `**${assignments.length}개의 감상평 매칭을 만들었어요.**\n\n` +
+        '참가자는 `/review my`로 본인이 읽을 글을 확인할 수 있어요.',
+    });
+  }
+
+  private async handleMy(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    const dependencies = await this.requireDependencies(interaction);
+    if (!dependencies) return;
+
+    const currentCycle = await this.getCurrentCycleOrReply(interaction);
+    if (!currentCycle) return;
+
+    const member = await this.getMemberOrReply(interaction);
+    if (!member) return;
+
+    const assignment = await dependencies.getMyAssignmentQuery.execute({
+      cycleId: currentCycle.id,
+      reviewerMemberId: member.id.value,
+    });
+
+    if (!assignment) {
+      await interaction.editReply(
+        createPeerReviewNoAssignmentMessage({
+          cycleName: `${currentCycle.generationName} ${currentCycle.week}주차`,
+        })
+      );
+      return;
+    }
+
+    const details =
+      await dependencies.assignmentDetailsLookup.findAssignmentDetails(
+        assignment
+      );
+
+    await interaction.editReply(
+      createPeerReviewMyAssignmentMessage({
+        cycleName: `${currentCycle.generationName} ${currentCycle.week}주차`,
+        revieweeName: details.revieweeName,
+        submissionUrl: details.submissionUrl,
+      })
+    );
+  }
+
+  private async handleDone(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    const dependencies = await this.requireDependencies(interaction);
+    if (!dependencies) return;
+
+    const currentCycle = await this.getCurrentCycleOrReply(interaction);
+    if (!currentCycle) return;
+
+    const member = await this.getMemberOrReply(interaction);
+    if (!member) return;
+
+    await dependencies.completeAssignmentCommand.execute({
+      cycleId: currentCycle.id,
+      reviewerMemberId: member.id.value,
+      completedSourceUrl:
+        interaction.options.getString('source_url') ?? undefined,
+      completionNote: interaction.options.getString('note') ?? undefined,
+    });
+
+    await interaction.editReply(
+      createPeerReviewDoneMessage({
+        cycleName: `${currentCycle.generationName} ${currentCycle.week}주차`,
+      })
+    );
+  }
+
+  private async handleStatus(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    await interaction.deferReply();
+    const dependencies = await this.requireDependencies(interaction);
+    if (!dependencies) return;
+
+    const currentCycle = await this.getCurrentCycleOrReply(interaction);
+    if (!currentCycle) return;
+
+    const status = await dependencies.getStatusQuery.execute({
+      cycleId: currentCycle.id,
+    });
+
+    await interaction.editReply(
+      createPeerReviewStatusMessage({
+        cycleName: `${currentCycle.generationName} ${currentCycle.week}주차`,
+        total: status.total,
+        completed: status.completed,
+        pending: status.pending,
+        skipped: status.skipped,
+        cancelled: status.cancelled,
+      })
+    );
+  }
+
+  private async requireDependencies(
+    interaction: ChatInputCommandInteraction
+  ): Promise<ReviewCommandDependencies | null> {
+    if (this.dependencies) return this.dependencies;
+
+    await interaction.editReply({
+      content:
+        '❌ 감상평 명령어 설정이 아직 연결되지 않았어요. 운영자에게 알려주세요.',
+    });
+    return null;
+  }
+
+  private async getCurrentCycleOrReply(
+    interaction: ChatInputCommandInteraction
+  ): Promise<{ id: number; week: number; generationName: string } | null> {
+    const currentCycle = await this.dependencies?.cycleQuery.getCurrentCycle(
+      DEFAULT_ORGANIZATION_SLUG
+    );
+    if (currentCycle) return currentCycle;
+
+    await interaction.editReply({
+      content:
+        '❌ 현재 진행 중인 회차를 찾지 못했어요. `/cycle current`로 먼저 회차 상태를 확인해 주세요.',
+    });
+    return null;
+  }
+
+  private async getMemberOrReply(
+    interaction: ChatInputCommandInteraction
+  ): Promise<{ id: { value: number } } | null> {
+    const member = await this.dependencies?.memberRepository.findByDiscordId(
+      interaction.user.id
+    );
+    if (member) return member;
+
+    await interaction.editReply({
+      content:
+        '👋 아직 회원 등록이 필요해요. `/member create`로 등록한 뒤 다시 실행해 주세요.',
+    });
+    return null;
   }
 }

--- a/apps/server/src/presentation/discord/commands/index.ts
+++ b/apps/server/src/presentation/discord/commands/index.ts
@@ -33,6 +33,17 @@ import {
   ListGenerationApplicationsQuery,
 } from '@/application/study-operations';
 import { MemberService } from '@/domain/member/member.service';
+import {
+  CompletePeerReviewAssignmentCommand,
+  CreatePeerReviewAssignmentsCommand,
+  GetMyPeerReviewAssignmentQuery,
+  GetPeerReviewStatusQuery,
+} from '@/application/peer-review';
+import {
+  DrizzlePeerReviewAssignmentDetailsLookup,
+  DrizzlePeerReviewAssignmentRepository,
+  DrizzlePeerReviewSubmissionLookup,
+} from '@/infrastructure/persistence/drizzle/peer-review.repository.impl';
 
 // Repository instances
 const cycleRepo = new DrizzleCycleRepository();
@@ -44,6 +55,10 @@ const organizationRepo = new DrizzleOrganizationRepository();
 const organizationMemberRepo = new DrizzleOrganizationMemberRepository();
 const generationParticipantRepo = new DrizzleGenerationParticipantRepository();
 const studyOperationsOutbox = new DrizzleOutboxPort();
+const peerReviewAssignmentRepo = new DrizzlePeerReviewAssignmentRepository();
+const peerReviewSubmissionLookup = new DrizzlePeerReviewSubmissionLookup();
+const peerReviewAssignmentDetailsLookup =
+  new DrizzlePeerReviewAssignmentDetailsLookup();
 
 // Application layer instances
 const memberService = new MemberService(memberRepo);
@@ -91,6 +106,42 @@ const getCycleStatusQuery = new GetCycleStatusQuery(
   organizationMemberRepo,
   memberRepo
 );
+const createPeerReviewAssignmentsCommand =
+  new CreatePeerReviewAssignmentsCommand(
+    peerReviewSubmissionLookup,
+    peerReviewAssignmentRepo
+  );
+const getMyPeerReviewAssignmentQuery = new GetMyPeerReviewAssignmentQuery(
+  peerReviewAssignmentRepo
+);
+const completePeerReviewAssignmentCommand =
+  new CompletePeerReviewAssignmentCommand(peerReviewAssignmentRepo);
+const getPeerReviewStatusQuery = new GetPeerReviewStatusQuery(
+  peerReviewAssignmentRepo
+);
+
+const currentPeerReviewCycleQuery = {
+  async getCurrentCycle(organizationSlug: string) {
+    const organization = await organizationRepo.findBySlug(organizationSlug);
+    if (!organization) return null;
+
+    const activeCycles = await cycleRepo.findActiveCyclesByOrganization(
+      organization.id.value
+    );
+    const currentCycle = activeCycles[0];
+    if (!currentCycle) return null;
+
+    const generation = await generationRepo.findActiveByOrganization(
+      organization.id.value
+    );
+
+    return {
+      id: currentCycle.id.value,
+      week: currentCycle.week.toNumber(),
+      generationName: generation?.name ?? '똥글똥글',
+    };
+  },
+};
 
 // Command instances
 export const createCommands = (): DiscordCommand[] => {
@@ -124,7 +175,15 @@ export const createCommands = (): DiscordCommand[] => {
       cycleRepo
     ),
     new CycleCommand(getCycleStatusQuery),
-    new ReviewCommand(),
+    new ReviewCommand({
+      memberRepository: memberRepo,
+      cycleQuery: currentPeerReviewCycleQuery,
+      createAssignmentsCommand: createPeerReviewAssignmentsCommand,
+      getMyAssignmentQuery: getMyPeerReviewAssignmentQuery,
+      completeAssignmentCommand: completePeerReviewAssignmentCommand,
+      getStatusQuery: getPeerReviewStatusQuery,
+      assignmentDetailsLookup: peerReviewAssignmentDetailsLookup,
+    }),
   ];
 };
 


### PR DESCRIPTION
## Summary
- Add peer-review persistence schema/repository and idempotent SQL migration
- Wire `/review assign`, `/review my`, `/review done`, `/review status` to Drizzle-backed use cases
- Use canonical `dongueldonguel` organization slug for runtime current-cycle lookup

## Test Plan
- `SKIP_ENV_VALIDATION=true pnpm exec vitest run src/presentation/discord/commands/ReviewCommand.test.ts src/infrastructure/persistence/drizzle-db/schema.peer-review.test.ts src/infrastructure/persistence/drizzle/peer-review.repository.impl.test.ts`
- `pnpm --filter @hanghae-study/server test -- --runInBand`
- `pnpm --filter @hanghae-study/server type-check`
- `pnpm --filter @hanghae-study/server lint`
- `pnpm --filter @hanghae-study/server format:check`
- `git diff --check`

## Notes
- Replaces conflict-only stacked PR #67 after #66 was squash-merged.
- Render production service auto-deploys from `main`.
- `DISCORD_COMMAND_SYNC_POLICY=off` means slash command schema changes may require a controlled command-sync restart after deploy.