### PR TITLE
feat: handle cycle current in Worker interactions

### DIFF
--- a/apps/worker/src/discord.ts
+++ b/apps/worker/src/discord.ts
@@ -5,26 +5,67 @@ export interface DiscordVerificationInput {
   body: string;
 }
 
+export interface DiscordCommandOption {
+  name: string;
+  type: number;
+  value?: string | number | boolean;
+  options?: DiscordCommandOption[];
+}
+
 export interface DiscordInteraction {
   type: number;
+  application_id?: string;
+  token?: string;
   data?: {
     name?: string;
+    options?: DiscordCommandOption[];
   };
 }
 
 export interface DiscordInteractionResponse {
   type: number;
-  data?: {
-    content: string;
-    flags?: number;
-  };
+  data?: DiscordMessagePayload;
+}
+
+export interface DiscordMessagePayload {
+  content?: string;
+  flags?: number;
+  components?: DiscordActionRow[];
+}
+
+interface DiscordActionRow {
+  type: 1;
+  components: DiscordLinkButton[];
+}
+
+interface DiscordLinkButton {
+  type: 2;
+  style: 5;
+  label: string;
+  url: string;
+}
+
+interface CurrentCycleResponse {
+  id: number;
+  week: number;
+  generationName: string;
+  startDate: string;
+  endDate: string;
+  githubIssueUrl: string | null;
+  daysLeft: number;
+  hoursLeft?: number;
+  organizationSlug: string;
 }
 
 const DISCORD_PING = 1;
 const DISCORD_APPLICATION_COMMAND = 2;
 const DISCORD_RESPONSE_PONG = 1;
 const DISCORD_RESPONSE_CHANNEL_MESSAGE_WITH_SOURCE = 4;
+const DISCORD_RESPONSE_DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5;
 const DISCORD_EPHEMERAL_FLAG = 64;
+const DISCORD_SUBCOMMAND_OPTION = 1;
+const DEFAULT_ORGANIZATION_SLUG = "donguel-donguel";
+const DISCORD_API_BASE_URL = "https://discord.com/api/v10";
 
 function hexToArrayBuffer(hex: string): ArrayBuffer {
   if (hex.length % 2 !== 0) {
@@ -77,11 +118,33 @@ export async function verifyDiscordRequest({
   }
 }
 
+export function isCycleCurrentCommand(
+  interaction: DiscordInteraction,
+): boolean {
+  if (
+    interaction.type !== DISCORD_APPLICATION_COMMAND ||
+    interaction.data?.name !== "cycle"
+  ) {
+    return false;
+  }
+
+  return (
+    interaction.data.options?.some(
+      (option) =>
+        option.type === DISCORD_SUBCOMMAND_OPTION && option.name === "current",
+    ) === true
+  );
+}
+
 export function createDiscordInteractionResponse(
   interaction: DiscordInteraction,
 ): DiscordInteractionResponse | null {
   if (interaction.type === DISCORD_PING) {
     return { type: DISCORD_RESPONSE_PONG };
+  }
+
+  if (isCycleCurrentCommand(interaction)) {
+    return { type: DISCORD_RESPONSE_DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE };
   }
 
   if (interaction.type === DISCORD_APPLICATION_COMMAND) {
@@ -96,4 +159,117 @@ export function createDiscordInteractionResponse(
   }
 
   return null;
+}
+
+export async function updateCycleCurrentInteractionResponse(
+  interaction: DiscordInteraction,
+  env: Env,
+): Promise<void> {
+  if (!interaction.token) {
+    return;
+  }
+
+  const applicationId =
+    interaction.application_id ?? env.DISCORD_APPLICATION_ID;
+  const payload = await createCycleCurrentMessage(env);
+
+  await fetch(
+    `${DISCORD_API_BASE_URL}/webhooks/${applicationId}/${interaction.token}/messages/@original`,
+    {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+async function createCycleCurrentMessage(
+  env: Env,
+): Promise<DiscordMessagePayload> {
+  const apiBaseUrl = env.API_BASE_URL.replace(/\/$/, "");
+  const response = await fetch(
+    `${apiBaseUrl}/api/status/current?organizationSlug=${encodeURIComponent(
+      DEFAULT_ORGANIZATION_SLUG,
+    )}`,
+  );
+
+  if (response.status === 404) {
+    return {
+      content:
+        "🗓️ **현재 진행 중인 주차를 찾지 못했어요.**\n\n" +
+        "가능한 원인\n" +
+        "1. 아직 이번 주차가 생성되지 않았어요.\n" +
+        "2. 스터디 운영 설정이 아직 반영되지 않았을 수 있어요.\n" +
+        "3. 잠시 후 다시 시도해 주세요.\n\n" +
+        "운영자라면 `/cycle list`로 등록된 주차를 확인해 주세요.",
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      content:
+        "❌ 주차 정보 조회 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+    };
+  }
+
+  const currentCycle = (await response.json()) as CurrentCycleResponse;
+  return formatCycleCurrentMessage(currentCycle);
+}
+
+function formatCycleCurrentMessage(
+  currentCycle: CurrentCycleResponse,
+): DiscordMessagePayload {
+  const remainingTime = formatRemainingTime(
+    currentCycle.daysLeft,
+    currentCycle.hoursLeft,
+  );
+  const issueLinkText = currentCycle.githubIssueUrl
+    ? `이슈 링크: ${currentCycle.githubIssueUrl}\n\n`
+    : "이슈 링크: 아직 등록되지 않았어요.\n\n";
+
+  return {
+    content:
+      `📅 **${currentCycle.generationName} ${currentCycle.week}주차가 진행 중이에요**\n\n` +
+      `⏰ **${remainingTime}**\n` +
+      `마감일: ${new Date(currentCycle.endDate).toLocaleString("ko-KR", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      })}\n` +
+      issueLinkText +
+      "**다음 행동**\n" +
+      "1. 이번 주차 글을 작성해 주세요.\n" +
+      "2. GitHub 이슈에 제출 링크를 댓글로 남겨 주세요.\n" +
+      "3. 제출 후 `/me info`로 내 상태를 다시 확인해 주세요.",
+    components: createIssueButton(currentCycle.githubIssueUrl),
+  };
+}
+
+function formatRemainingTime(daysLeft: number, hoursLeft?: number): string {
+  if (daysLeft <= 0 && (!hoursLeft || hoursLeft <= 0)) {
+    return "오늘 마감";
+  }
+
+  if (typeof hoursLeft === "number") {
+    return `마감까지 ${daysLeft}일 ${hoursLeft}시간`;
+  }
+
+  return daysLeft > 0 ? `마감까지 ${daysLeft}일` : "오늘 마감";
+}
+
+function createIssueButton(issueUrl?: string | null): DiscordActionRow[] {
+  if (!issueUrl) return [];
+
+  return [
+    {
+      type: 1,
+      components: [
+        {
+          type: 2,
+          style: 5,
+          label: "이번 주차 이슈 열기",
+          url: issueUrl,
+        },
+      ],
+    },
+  ];
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import {
   createDiscordInteractionResponse,
+  isCycleCurrentCommand,
+  updateCycleCurrentInteractionResponse,
   verifyDiscordRequest,
   type DiscordInteraction,
 } from "./discord";
@@ -40,6 +42,12 @@ app.post("/discord/interactions", async (context) => {
   const response = createDiscordInteractionResponse(interaction);
   if (!response) {
     return context.text("unsupported interaction type", 400);
+  }
+
+  if (isCycleCurrentCommand(interaction)) {
+    context.executionCtx.waitUntil(
+      updateCycleCurrentInteractionResponse(interaction, context.env),
+    );
   }
 
   return context.json(response);

--- a/apps/worker/test/discord.test.ts
+++ b/apps/worker/test/discord.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createDiscordInteractionResponse,
   verifyDiscordRequest,
@@ -13,6 +13,10 @@ const env: Env = {
   GITHUB_WEBHOOK_SECRET: "test-secret",
   API_BASE_URL: "https://api.example.test",
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("notification Cloudflare Worker", () => {
   it("returns health information without waking Render", async () => {
@@ -65,10 +69,10 @@ describe("notification Cloudflare Worker", () => {
     expect(verifySpy).toHaveBeenCalledOnce();
   });
 
-  it("returns a scaffold response for application commands", async () => {
+  it("returns a scaffold response for unsupported application commands", async () => {
     const response = createDiscordInteractionResponse({
       type: 2,
-      data: { name: "cycle" },
+      data: { name: "unsupported" },
     });
 
     expect(response).toEqual({
@@ -78,6 +82,93 @@ describe("notification Cloudflare Worker", () => {
           "Cloudflare Worker 전환 준비가 완료되었어요. `/cycle current` 이식은 다음 단계에서 연결합니다.",
         flags: 64,
       },
+    });
+  });
+
+  it("defers /cycle current and schedules an original interaction response update", async () => {
+    vi.spyOn(crypto.subtle, "verify").mockResolvedValueOnce(true);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 42,
+          week: 3,
+          generationName: "똥글똥글 2기",
+          startDate: "2026-05-20T00:00:00.000Z",
+          endDate: "2026-05-27T12:00:00.000Z",
+          githubIssueUrl: "https://github.com/org/repo/issues/42",
+          daysLeft: 1,
+          hoursLeft: 4,
+          organizationSlug: "donguel-donguel",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const scheduledTasks: Promise<unknown>[] = [];
+    const executionContext = {
+      waitUntil: (promise: Promise<unknown>) => scheduledTasks.push(promise),
+      passThroughOnException: vi.fn(),
+    } as unknown as ExecutionContext;
+
+    const response = await worker.fetch(
+      new Request("https://worker.example.test/discord/interactions", {
+        method: "POST",
+        headers: {
+          "x-signature-ed25519": "00".repeat(64),
+          "x-signature-timestamp": "1710000000",
+        },
+        body: JSON.stringify({
+          type: 2,
+          application_id: env.DISCORD_APPLICATION_ID,
+          token: "interaction-token",
+          data: {
+            name: "cycle",
+            options: [{ name: "current", type: 1 }],
+          },
+        }),
+      }),
+      env,
+      executionContext,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ type: 5 });
+    expect(scheduledTasks).toHaveLength(1);
+
+    await Promise.all(scheduledTasks);
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      "https://api.example.test/api/status/current?organizationSlug=donguel-donguel",
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "https://discord.com/api/v10/webhooks/1457578741097042114/interaction-token/messages/@original",
+      expect.objectContaining({
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const updateRequest = fetchSpy.mock.calls[1]?.[1] as RequestInit;
+    expect(JSON.parse(updateRequest.body as string)).toMatchObject({
+      content: expect.stringContaining(
+        "📅 **똥글똥글 2기 3주차가 진행 중이에요**",
+      ),
+      components: [
+        {
+          type: 1,
+          components: [
+            {
+              type: 2,
+              style: 5,
+              label: "이번 주차 이슈 열기",
+              url: "https://github.com/org/repo/issues/42",
+            },
+          ],
+        },
+      ],
     });
   });
 

--- a/docs/cloudflare-workers-migration.md
+++ b/docs/cloudflare-workers-migration.md
@@ -38,14 +38,15 @@ https://<worker-subdomain>.workers.dev/discord/interactions
 - `POST /discord/interactions`
   - Discord `x-signature-ed25519`, `x-signature-timestamp` 검증
   - Discord PING 요청에 `{ "type": 1 }` 응답
-  - application command에 임시 ephemeral scaffold 응답
+  - `/cycle current`는 즉시 deferred response `{ "type": 5 }`를 반환하고, Worker `waitUntil`에서 기존 Render API의 `/api/status/current?organizationSlug=donguel-donguel`를 조회한 뒤 Discord original interaction response를 `PATCH`한다.
+  - 아직 이식되지 않은 application command에는 임시 ephemeral scaffold 응답
 - `POST /webhook/github`
   - 단계적 이전을 위한 기존 Render API 프록시
 
 아직 하지 않은 것:
 
-- `/cycle current` 실제 비즈니스 로직 이식
 - DB 직접 연결 전략 확정
+- `/cycle status`, `/cycle list`, `/me`, `/generation`, `/review` 등 나머지 slash command 이식
 - Discord Developer Portal Interactions Endpoint 등록
 - Render Gateway bot 비활성화
 
@@ -92,12 +93,15 @@ SKIP_ENV_VALIDATION=true pnpm exec vitest run
 2. Worker 배포
 3. Discord Developer Portal에서 Interactions Endpoint URL을 Worker `/discord/interactions`로 등록
 4. Discord PING 검증 통과 확인
-5. `/cycle current`부터 Worker HTTP interaction 방식으로 이식
+5. `/cycle current` smoke test
+   - Discord는 3초 안에 deferred response를 받아야 한다.
+   - Worker가 background task에서 Render API를 깨운 뒤 original interaction response를 수정해야 한다.
 6. DB 접근 전략 결정
    - 단기: Worker가 기존 Render API 호출
    - 중기: Worker-compatible Postgres 접근
    - 장기: 필요하면 D1 등 Cloudflare-native 저장소 검토
-7. Worker command handler가 안정화된 뒤 Render의 Gateway bot 시작을 끄거나 제거
+7. `/cycle status`, `/cycle list` 등 나머지 slash command를 같은 방식으로 단계적 이식
+8. Worker command handler가 안정화된 뒤 Render의 Gateway bot 시작을 끄거나 제거
 
 ## 주의점
 


### PR DESCRIPTION
## Summary
- Handle Discord `/cycle current` in the Cloudflare Worker HTTP interaction path.
- Return an immediate deferred interaction response (`type: 5`) so Discord receives an ACK within the interaction timeout.
- Use Worker `waitUntil` to call the existing Render API `/api/status/current?organizationSlug=donguel-donguel` and PATCH the original Discord interaction response.
- Render the current-cycle message with the same next-action guidance and issue link button shape used by the Gateway command.
- Update the Cloudflare migration document to reflect this phase.

## Test Plan
- [x] `pnpm --filter @hanghae-study/worker format`
- [x] `pnpm --filter @hanghae-study/worker type-check`
- [x] `pnpm --filter @hanghae-study/worker test`
- [x] `pnpm --filter @hanghae-study/worker exec wrangler deploy --dry-run`
- [x] `pnpm --filter @hanghae-study/worker format:check`
- [x] `git diff --check -- apps/worker docs/cloudflare-workers-migration.md`

## Notes
This is still a phased migration: `/cycle current` is now routed through the Worker interaction endpoint, but it still reads current-cycle data from the existing Render API. That means Discord will avoid the initial 3-second interaction timeout via deferred response, while Render cold-start latency can still affect how quickly the final edited message appears.