### PR TITLE
feat: add generation and cycle create commands

### DIFF
--- a/apps/server/src/application/commands/create-cycle.command.test.ts
+++ b/apps/server/src/application/commands/create-cycle.command.test.ts
@@ -128,4 +128,43 @@ describe('CreateCycleCommand', () => {
         'https://github.com/hanghae-story-forge/archive/issues/16',
     });
   });
+
+  it('creates a cycle on a planned generation when the generation is explicitly requested', async () => {
+    const requestedGeneration = Generation.reconstitute({
+      id: 3,
+      organizationId: 2,
+      name: '똥글똥글 3기',
+      startedAt: new Date('2026-06-01T00:00:00.000Z'),
+      isActive: false,
+      createdAt: new Date('2026-05-26T00:00:00.000Z'),
+    });
+    const organizationRepo = {
+      findBySlug: vi.fn().mockResolvedValue(makeOrganization()),
+    } as unknown as OrganizationRepository;
+    const generationRepo = {
+      findActiveByOrganization: vi.fn(),
+      findById: vi.fn().mockResolvedValue(requestedGeneration),
+    } as unknown as GenerationRepository;
+    const cycleRepo = {
+      findByGenerationAndWeek: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CycleRepository;
+    const command = new CreateCycleCommand(
+      cycleRepo,
+      generationRepo,
+      organizationRepo
+    );
+
+    await command.execute({
+      organizationSlug: 'donguel-donguel',
+      generationId: 3,
+      week: 1,
+      startDate: new Date('2026-06-01T00:00:00.000Z'),
+      endDate: new Date('2026-06-14T23:59:59.000Z'),
+    });
+
+    expect(cycleRepo.save).toHaveBeenCalledOnce();
+    const savedCycle = vi.mocked(cycleRepo.save).mock.calls[0][0] as Cycle;
+    expect(savedCycle.generationId).toBe(3);
+  });
 });

--- a/apps/server/src/application/commands/create-cycle.command.ts
+++ b/apps/server/src/application/commands/create-cycle.command.ts
@@ -16,7 +16,7 @@ export interface CreateCycleRequest {
   week: number;
   startDate?: Date;
   endDate?: Date;
-  githubIssueUrl: string;
+  githubIssueUrl?: string;
 }
 
 /**
@@ -35,7 +35,7 @@ export interface GithubProjectCycleSyncPort {
     week: number;
     startDate: Date;
     endDate: Date;
-    githubIssueUrl: string;
+    githubIssueUrl?: string;
   }): Promise<void>;
 }
 
@@ -90,7 +90,7 @@ export class CreateCycleCommand {
       );
     }
 
-    if (!generation.isActive) {
+    if (!request.generationId && !generation.isActive) {
       throw new ConflictError(`Generation ${generation.name} is not active`);
     }
 
@@ -123,7 +123,7 @@ export class CreateCycleCommand {
     // 6. 저장
     await this.cycleRepo.save(cycle);
 
-    if (this.githubProjectSync) {
+    if (this.githubProjectSync && request.githubIssueUrl) {
       try {
         await this.githubProjectSync.syncCycle({
           organizationSlug: request.organizationSlug,

--- a/apps/server/src/infrastructure/external/github/github-projects-cycle-sync.ts
+++ b/apps/server/src/infrastructure/external/github/github-projects-cycle-sync.ts
@@ -149,6 +149,11 @@ export class GitHubProjectsCycleSync implements GithubProjectCycleSyncPort {
   async syncCycle(
     request: Parameters<GithubProjectCycleSyncPort['syncCycle']>[0]
   ) {
+    if (!request.githubIssueUrl) {
+      console.warn('Skipping GitHub Project sync: issue URL is not set');
+      return;
+    }
+
     const issueRef = parseGitHubIssueUrl(request.githubIssueUrl);
     if (!issueRef) {
       console.warn(

--- a/apps/server/src/presentation/discord/commands/CycleCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/CycleCommand.test.ts
@@ -4,15 +4,21 @@ import { CycleCommand } from './CycleCommand';
 type MockInteraction = {
   options: {
     getSubcommand: ReturnType<typeof vi.fn>;
+    getString: ReturnType<typeof vi.fn>;
+    getInteger: ReturnType<typeof vi.fn>;
   };
   deferReply: ReturnType<typeof vi.fn>;
   editReply: ReturnType<typeof vi.fn>;
 };
 
-function createInteraction(subcommand: 'current' | 'status'): MockInteraction {
+function createInteraction(
+  subcommand: 'current' | 'status' | 'create'
+): MockInteraction {
   return {
     options: {
       getSubcommand: vi.fn().mockReturnValue(subcommand),
+      getString: vi.fn(),
+      getInteger: vi.fn(),
     },
     deferReply: vi.fn().mockResolvedValue(undefined),
     editReply: vi.fn().mockResolvedValue(undefined),
@@ -116,5 +122,112 @@ describe('CycleCommand', () => {
 
     expect(getCurrentCycle).toHaveBeenCalledWith('donguel-donguel');
     expect(getCycleParticipantNames).toHaveBeenCalledWith(1, 'donguel-donguel');
+  });
+
+  it('defines /cycle create with generation, week, dates, and optional issue URL', () => {
+    const command = new CycleCommand({} as never, {} as never);
+    const json = command.definition.toJSON();
+
+    const create = json.options?.find((option) => option.name === 'create') as
+      | { options?: Array<{ name: string }> }
+      | undefined;
+
+    expect(create).toBeDefined();
+    expect(create?.options?.map((option) => option.name)).toEqual([
+      'organization',
+      'generation',
+      'week',
+      'start_date',
+      'end_date',
+      'github_issue_url',
+    ]);
+  });
+
+  it('creates a cycle for the requested generation name and tells the operator how to verify it', async () => {
+    const createCycleCommand = {
+      execute: vi.fn().mockResolvedValue({
+        generationName: '똥글똥글 3기',
+        cycle: {
+          week: { toNumber: () => 1 },
+          startDate: new Date('2026-06-01T00:00:00.000Z'),
+          endDate: new Date('2026-06-14T23:59:59.000Z'),
+          githubIssueUrl: null,
+        },
+      }),
+    };
+    const generationLookup = {
+      findGenerationByOrganizationAndName: vi.fn().mockResolvedValue({ id: 3 }),
+    };
+    const command = new CycleCommand(
+      {} as never,
+      createCycleCommand as never,
+      generationLookup
+    );
+    const interaction = createInteraction('create');
+    interaction.options.getString = vi.fn((name: string) => {
+      const values: Record<string, string> = {
+        organization: 'donguel-donguel',
+        generation: '똥글똥글 3기',
+        start_date: '2026-06-01',
+        end_date: '2026-06-14',
+      };
+      return values[name] ?? null;
+    });
+    interaction.options.getInteger = vi.fn((name: string) =>
+      name === 'week' ? 1 : null
+    );
+
+    await command.execute(interaction as never);
+
+    expect(
+      generationLookup.findGenerationByOrganizationAndName
+    ).toHaveBeenCalledWith('donguel-donguel', '똥글똥글 3기');
+    expect(createCycleCommand.execute).toHaveBeenCalledWith({
+      organizationSlug: 'donguel-donguel',
+      generationId: 3,
+      week: 1,
+      startDate: new Date('2026-06-01T00:00:00.000Z'),
+      endDate: new Date('2026-06-14T23:59:59.000Z'),
+      githubIssueUrl: undefined,
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('/cycle list'),
+      })
+    );
+  });
+
+  it('rejects an invalid cycle date before calling the application command', async () => {
+    const createCycleCommand = { execute: vi.fn() };
+    const generationLookup = {
+      findGenerationByOrganizationAndName: vi.fn().mockResolvedValue({ id: 3 }),
+    };
+    const command = new CycleCommand(
+      {} as never,
+      createCycleCommand as never,
+      generationLookup
+    );
+    const interaction = createInteraction('create');
+    interaction.options.getString = vi.fn((name: string) => {
+      const values: Record<string, string> = {
+        organization: 'donguel-donguel',
+        generation: '똥글똥글 3기',
+        start_date: '2026-06-99',
+        end_date: '2026-06-14',
+      };
+      return values[name] ?? null;
+    });
+    interaction.options.getInteger = vi.fn((name: string) =>
+      name === 'week' ? 1 : null
+    );
+
+    await command.execute(interaction as never);
+
+    expect(createCycleCommand.execute).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('YYYY-MM-DD'),
+      })
+    );
   });
 });

--- a/apps/server/src/presentation/discord/commands/CycleCommand.ts
+++ b/apps/server/src/presentation/discord/commands/CycleCommand.ts
@@ -6,6 +6,7 @@ import {
   ButtonBuilder,
   ButtonStyle,
 } from 'discord.js';
+import { CreateCycleCommand as AppCreateCycleCommand } from '@/application/commands';
 import { GetCycleStatusQuery } from '@/application/queries';
 import { createStatusMessage } from '@/infrastructure/external/discord';
 import { DiscordCommand } from './types';
@@ -24,6 +25,13 @@ function isIgnorableDiscordError(error: unknown): boolean {
 }
 
 const DEFAULT_ORGANIZATION_SLUG = 'donguel-donguel';
+
+interface CycleGenerationLookup {
+  findGenerationByOrganizationAndName(
+    organizationSlug: string,
+    generationName: string
+  ): Promise<{ id: number } | null>;
+}
 
 function formatRemainingTime(daysLeft: number, hoursLeft?: number): string {
   if (daysLeft <= 0 && (!hoursLeft || hoursLeft <= 0)) {
@@ -66,6 +74,50 @@ export class CycleCommand implements DiscordCommand {
     )
     .addSubcommand((subcommand) =>
       subcommand
+        .setName('create')
+        .setDescription('운영자가 특정 기수의 주차를 생성합니다')
+        .addStringOption((option) =>
+          option
+            .setName('organization')
+            .setDescription('조직 slug (예: donguel-donguel)')
+            .setRequired(true)
+            .setAutocomplete(true)
+        )
+        .addStringOption((option) =>
+          option
+            .setName('generation')
+            .setDescription('기수 이름 (예: 똥글똥글 3기)')
+            .setRequired(true)
+            .setAutocomplete(true)
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('week')
+            .setDescription('주차 번호')
+            .setRequired(true)
+            .setMinValue(1)
+        )
+        .addStringOption((option) =>
+          option
+            .setName('start_date')
+            .setDescription('시작일 (YYYY-MM-DD)')
+            .setRequired(true)
+        )
+        .addStringOption((option) =>
+          option
+            .setName('end_date')
+            .setDescription('마감일 (YYYY-MM-DD)')
+            .setRequired(true)
+        )
+        .addStringOption((option) =>
+          option
+            .setName('github_issue_url')
+            .setDescription('연결할 GitHub Issue URL (선택)')
+            .setRequired(false)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
         .setName('list')
         .setDescription('특정 기수의 주차 목록을 확인합니다')
         .addStringOption((option) =>
@@ -84,7 +136,11 @@ export class CycleCommand implements DiscordCommand {
         )
     );
 
-  constructor(private readonly getCycleStatusQuery: GetCycleStatusQuery) {}
+  constructor(
+    private readonly getCycleStatusQuery: GetCycleStatusQuery,
+    private readonly createCycleCommand?: AppCreateCycleCommand,
+    private readonly generationLookup?: CycleGenerationLookup
+  ) {}
 
   async execute(interaction: ChatInputCommandInteraction): Promise<void> {
     const subcommand = interaction.options.getSubcommand(true);
@@ -93,8 +149,95 @@ export class CycleCommand implements DiscordCommand {
       await this.handleCurrent(interaction);
     } else if (subcommand === 'status') {
       await this.handleStatus(interaction);
+    } else if (subcommand === 'create') {
+      await this.handleCreate(interaction);
     } else if (subcommand === 'list') {
       await this.handleList(interaction);
+    }
+  }
+
+  private parseDateOption(value: string, endOfDay = false): Date | null {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+    const suffix = endOfDay ? 'T23:59:59.000Z' : 'T00:00:00.000Z';
+    const date = new Date(`${value}${suffix}`);
+    return Number.isNaN(date.getTime()) ||
+      date.toISOString().slice(0, 10) !== value
+      ? null
+      : date;
+  }
+
+  private async handleCreate(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    try {
+      await interaction.deferReply({ ephemeral: true });
+    } catch {
+      return;
+    }
+
+    if (!this.createCycleCommand || !this.generationLookup) {
+      await interaction.editReply({
+        content: '❌ 주차 생성 기능이 아직 연결되지 않았습니다.',
+      });
+      return;
+    }
+
+    const organizationSlug = interaction.options.getString(
+      'organization',
+      true
+    );
+    const generationName = interaction.options.getString('generation', true);
+    const week = interaction.options.getInteger('week', true);
+    const startDateValue = interaction.options.getString('start_date', true);
+    const endDateValue = interaction.options.getString('end_date', true);
+    const githubIssueUrl =
+      interaction.options.getString('github_issue_url', false) ?? undefined;
+    const startDate = this.parseDateOption(startDateValue);
+    const endDate = this.parseDateOption(endDateValue, true);
+
+    if (!startDate || !endDate) {
+      await interaction.editReply({
+        content:
+          '❌ 시작일/마감일은 `YYYY-MM-DD` 형식으로 입력해 주세요. 예: `2026-06-01`',
+      });
+      return;
+    }
+
+    try {
+      const generation =
+        await this.generationLookup.findGenerationByOrganizationAndName(
+          organizationSlug,
+          generationName
+        );
+      if (!generation) {
+        await interaction.editReply({
+          content: `❌ "${organizationSlug}" 조직에서 "${generationName}" 기수를 찾을 수 없습니다.`,
+        });
+        return;
+      }
+
+      const result = await this.createCycleCommand.execute({
+        organizationSlug,
+        generationId: generation.id,
+        week,
+        startDate,
+        endDate,
+        githubIssueUrl,
+      });
+
+      await interaction.editReply({
+        content:
+          `✅ **${result.generationName} ${result.cycle.week.toNumber()}주차**를 생성했습니다.\n\n` +
+          `**기간**: ${startDate.toISOString().slice(0, 10)} ~ ${endDate.toISOString().slice(0, 10)}\n` +
+          `**GitHub Issue**: ${githubIssueUrl ?? '나중에 연결'}\n\n` +
+          `확인: \`/cycle list organization:${organizationSlug} generation:${generationName}\``,
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : '알 수 없는 오류';
+      await interaction.editReply({
+        content: `❌ 주차 생성 중 오류가 발생했습니다: ${errorMessage}`,
+      });
     }
   }
 

--- a/apps/server/src/presentation/discord/commands/GenerationCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/GenerationCommand.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GenerationCommand } from './GenerationCommand';
+import { Generation } from '@/domain/generation/generation.domain';
+
+type MockInteraction = {
+  options: {
+    getSubcommand: ReturnType<typeof vi.fn>;
+    getString: ReturnType<typeof vi.fn>;
+    getBoolean: ReturnType<typeof vi.fn>;
+  };
+  deferReply: ReturnType<typeof vi.fn>;
+  editReply: ReturnType<typeof vi.fn>;
+};
+
+function createInteraction(): MockInteraction {
+  return {
+    options: {
+      getSubcommand: vi.fn().mockReturnValue('create'),
+      getString: vi.fn((name: string) => {
+        const values: Record<string, string> = {
+          organization: 'donguel-donguel',
+          name: '똥글똥글 3기',
+          start_date: '2026-06-01',
+        };
+        return values[name] ?? null;
+      }),
+      getBoolean: vi.fn((name: string) => (name === 'active' ? false : null)),
+    },
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createCommand(createGenerationCommand: {
+  execute: ReturnType<typeof vi.fn>;
+}) {
+  return new GenerationCommand(
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    createGenerationCommand as never
+  );
+}
+
+describe('GenerationCommand create', () => {
+  it('defines /generation create with organization, name, start_date, and active options', () => {
+    const command = createCommand({ execute: vi.fn() });
+    const json = command.definition.toJSON();
+
+    const create = json.options?.find((option) => option.name === 'create') as
+      | { options?: Array<{ name: string }> }
+      | undefined;
+
+    expect(create).toBeDefined();
+    expect(create?.options?.map((option) => option.name)).toEqual([
+      'organization',
+      'name',
+      'start_date',
+      'active',
+    ]);
+  });
+
+  it('creates a generation through the application command and tells the operator the next command', async () => {
+    const savedGeneration = Generation.reconstitute({
+      id: 3,
+      organizationId: 2,
+      name: '똥글똥글 3기',
+      startedAt: new Date('2026-06-01T00:00:00.000Z'),
+      isActive: false,
+      createdAt: new Date('2026-05-26T00:00:00.000Z'),
+    });
+    const createGenerationCommand = {
+      execute: vi.fn().mockResolvedValue({ generation: savedGeneration }),
+    };
+    const command = createCommand(createGenerationCommand);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(createGenerationCommand.execute).toHaveBeenCalledWith({
+      organizationSlug: 'donguel-donguel',
+      name: '똥글똥글 3기',
+      startedAt: new Date('2026-06-01T00:00:00.000Z'),
+      isActive: false,
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('/cycle create'),
+      })
+    );
+  });
+
+  it('rejects an invalid start_date before calling the application command', async () => {
+    const createGenerationCommand = { execute: vi.fn() };
+    const command = createCommand(createGenerationCommand);
+    const interaction = createInteraction();
+    interaction.options.getString = vi.fn((name: string) => {
+      const values: Record<string, string> = {
+        organization: 'donguel-donguel',
+        name: '똥글똥글 3기',
+        start_date: 'not-a-date',
+      };
+      return values[name] ?? null;
+    });
+
+    await command.execute(interaction as never);
+
+    expect(createGenerationCommand.execute).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('YYYY-MM-DD'),
+      })
+    );
+  });
+});

--- a/apps/server/src/presentation/discord/commands/GenerationCommand.ts
+++ b/apps/server/src/presentation/discord/commands/GenerationCommand.ts
@@ -1,5 +1,8 @@
 import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
-import { JoinGenerationCommand as AppJoinGenerationCommand } from '@/application/commands';
+import {
+  CreateGenerationCommand as AppCreateGenerationCommand,
+  JoinGenerationCommand as AppJoinGenerationCommand,
+} from '@/application/commands';
 import {
   ApplyToGenerationCommand,
   ApproveGenerationParticipantCommand,
@@ -120,6 +123,36 @@ export class GenerationCommand implements DiscordCommand {
     )
     .addSubcommand((subcommand) =>
       subcommand
+        .setName('create')
+        .setDescription('운영자가 새 기수를 생성합니다')
+        .addStringOption((option) =>
+          option
+            .setName('organization')
+            .setDescription('조직 slug (예: donguel-donguel)')
+            .setRequired(true)
+            .setAutocomplete(true)
+        )
+        .addStringOption((option) =>
+          option
+            .setName('name')
+            .setDescription('기수 이름 (예: 똥글똥글 3기)')
+            .setRequired(true)
+        )
+        .addStringOption((option) =>
+          option
+            .setName('start_date')
+            .setDescription('시작일 (YYYY-MM-DD)')
+            .setRequired(true)
+        )
+        .addBooleanOption((option) =>
+          option
+            .setName('active')
+            .setDescription('생성 즉시 활성 기수로 설정할지 여부')
+            .setRequired(false)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
         .setName('list')
         .setDescription('등록된 모든 기수 목록을 확인합니다')
     );
@@ -133,7 +166,8 @@ export class GenerationCommand implements DiscordCommand {
     private readonly generationRepo: GenerationRepository,
     private readonly organizationRepo: OrganizationRepository,
     private readonly generationMemberRepo: GenerationMemberRepository,
-    private readonly cycleRepo: CycleRepository
+    private readonly cycleRepo: CycleRepository,
+    private readonly createGenerationCommand?: AppCreateGenerationCommand
   ) {}
 
   async execute(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -151,8 +185,77 @@ export class GenerationCommand implements DiscordCommand {
       await this.handleCurrent(interaction);
     } else if (subcommand === 'status') {
       await this.handleStatus(interaction);
+    } else if (subcommand === 'create') {
+      await this.handleCreate(interaction);
     } else if (subcommand === 'list') {
       await this.handleList(interaction);
+    }
+  }
+
+  private parseDateOption(value: string): Date | null {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+    const date = new Date(`${value}T00:00:00.000Z`);
+    return Number.isNaN(date.getTime()) ||
+      date.toISOString().slice(0, 10) !== value
+      ? null
+      : date;
+  }
+
+  private async handleCreate(
+    interaction: ChatInputCommandInteraction
+  ): Promise<void> {
+    try {
+      await interaction.deferReply({ ephemeral: true });
+    } catch {
+      return;
+    }
+
+    if (!this.createGenerationCommand) {
+      await interaction.editReply({
+        content: '❌ 기수 생성 기능이 아직 연결되지 않았습니다.',
+      });
+      return;
+    }
+
+    const organizationSlug = interaction.options.getString(
+      'organization',
+      true
+    );
+    const name = interaction.options.getString('name', true);
+    const startDateValue = interaction.options.getString('start_date', true);
+    const startedAt = this.parseDateOption(startDateValue);
+
+    if (!startedAt) {
+      await interaction.editReply({
+        content:
+          '❌ 시작일은 `YYYY-MM-DD` 형식으로 입력해 주세요. 예: `2026-06-01`',
+      });
+      return;
+    }
+
+    try {
+      const isActive = interaction.options.getBoolean('active') ?? false;
+      const result = await this.createGenerationCommand.execute({
+        organizationSlug,
+        name,
+        startedAt,
+        isActive,
+      });
+
+      await interaction.editReply({
+        content:
+          `✅ **${result.generation.name}** 기수를 생성했습니다.\n\n` +
+          `**조직**: ${organizationSlug}\n` +
+          `**시작일**: ${startedAt.toISOString().slice(0, 10)}\n` +
+          `**상태**: ${isActive ? 'ACTIVE' : 'PLANNED'}\n\n` +
+          '다음 단계: `/cycle create`로 1주차부터 회차를 생성해 주세요.',
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : '알 수 없는 오류';
+      await interaction.editReply({
+        content: `❌ 기수 생성 중 오류가 발생했습니다: ${errorMessage}`,
+      });
     }
   }
 

--- a/apps/server/src/presentation/discord/commands/index.ts
+++ b/apps/server/src/presentation/discord/commands/index.ts
@@ -10,6 +10,8 @@ import { MeCommand } from './MeCommand';
 import { ReviewCommand } from './ReviewCommand';
 import { GetCycleStatusQuery } from '@/application/queries';
 import {
+  CreateGenerationCommand as AppCreateGenerationCommand,
+  CreateCycleCommand as AppCreateCycleCommand,
   CreateMemberCommand as AppCreateMemberCommand,
   CreateOrganizationCommand as AppCreateOrganizationCommand,
   JoinOrganizationCommand as AppJoinOrganizationCommand,
@@ -69,6 +71,15 @@ const createMemberCommand = new AppCreateMemberCommand(
 const createOrganizationCommand = new AppCreateOrganizationCommand(
   organizationRepo
 );
+const createGenerationCommand = new AppCreateGenerationCommand(
+  generationRepo,
+  organizationRepo
+);
+const createCycleCommand = new AppCreateCycleCommand(
+  cycleRepo,
+  generationRepo,
+  organizationRepo
+);
 const joinOrganizationCommand = new AppJoinOrganizationCommand(
   organizationRepo,
   memberRepo,
@@ -119,6 +130,25 @@ const completePeerReviewAssignmentCommand =
 const getPeerReviewStatusQuery = new GetPeerReviewStatusQuery(
   peerReviewAssignmentRepo
 );
+
+const generationLookup = {
+  async findGenerationByOrganizationAndName(
+    organizationSlug: string,
+    generationName: string
+  ) {
+    const organization = await organizationRepo.findBySlug(organizationSlug);
+    if (!organization) return null;
+
+    const generations = await generationRepo.findByOrganization(
+      organization.id.value
+    );
+    const generation =
+      generations.find((item) => item.name === generationName) ?? null;
+    if (!generation) return null;
+
+    return { id: generation.id.value };
+  },
+};
 
 const currentPeerReviewCycleQuery = {
   async getCurrentCycle(organizationSlug: string) {
@@ -172,9 +202,10 @@ export const createCommands = (): DiscordCommand[] => {
       generationRepo,
       organizationRepo,
       generationMemberRepo,
-      cycleRepo
+      cycleRepo,
+      createGenerationCommand
     ),
-    new CycleCommand(getCycleStatusQuery),
+    new CycleCommand(getCycleStatusQuery, createCycleCommand, generationLookup),
     new ReviewCommand({
       memberRepository: memberRepo,
       cycleQuery: currentPeerReviewCycleQuery,


### PR DESCRIPTION
## Summary
- Add `/generation create` Discord subcommand for operators to create new generations without direct DB writes
- Add `/cycle create` Discord subcommand for operators to create cycles for a named generation
- Allow explicitly selected planned generations to receive cycles before activation
- Make GitHub issue URL optional for cycle creation and skip GitHub Project sync when absent

## Test Plan
- `SKIP_ENV_VALIDATION=true pnpm --dir apps/server exec vitest run src/application/commands/create-cycle.command.test.ts src/presentation/discord/commands/GenerationCommand.test.ts src/presentation/discord/commands/CycleCommand.test.ts`
- `SKIP_ENV_VALIDATION=true pnpm --dir apps/server exec vitest run`
- `pnpm --filter @hanghae-study/server type-check`
- `pnpm --filter @hanghae-study/server lint`
- `pnpm --filter @hanghae-study/server format:check`
- `git diff --check`

## Notes
- Work was prepared in a separate worktree at `/tmp/notification-generation-cycle-pr` to avoid touching unrelated files in the main working tree.