### PR TITLE
feat: add study submission command MVP

### DIFF
--- a/apps/server/src/application/commands/index.ts
+++ b/apps/server/src/application/commands/index.ts
@@ -1,6 +1,7 @@
 // Application Commands exports
 
 export * from './record-submission.command';
+export * from './record-discord-submission.command';
 export * from './create-cycle.command';
 export * from './create-generation.command';
 export * from './create-member.command';

--- a/apps/server/src/application/commands/record-discord-submission.command.test.ts
+++ b/apps/server/src/application/commands/record-discord-submission.command.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RecordDiscordSubmissionCommand } from './record-discord-submission.command';
+import { Member } from '@/domain/member/member.domain';
+import { Organization } from '@/domain/organization/organization.domain';
+import { Cycle } from '@/domain/cycle/cycle.domain';
+import { Generation } from '@/domain/generation/generation.domain';
+import { ForbiddenError, NotFoundError } from '@/domain/common/errors';
+
+function createMember() {
+  return Member.reconstitute({
+    id: 7,
+    discordId: 'discord-user-1',
+    discordUsername: 'bbakjun',
+    githubUsername: 'bbakjun',
+    name: '박준형',
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+  });
+}
+
+function createOrganization() {
+  return Organization.reconstitute({
+    id: 3,
+    name: '똥글똥글',
+    slug: 'donguel-donguel',
+    discordWebhookUrl: null,
+    isActive: true,
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+  });
+}
+
+function createCycle() {
+  return Cycle.reconstitute({
+    id: 11,
+    generationId: 5,
+    week: 8,
+    startDate: new Date('2026-05-11T00:00:00.000Z'),
+    endDate: new Date('2026-05-24T23:59:59.000Z'),
+    githubIssueUrl: 'https://github.com/hanghae-story-forge/archive/issues/17',
+    createdAt: new Date('2026-05-11T00:00:00.000Z'),
+  });
+}
+
+function createGeneration() {
+  return Generation.reconstitute({
+    id: 5,
+    organizationId: 3,
+    name: '똥글똥글 2기',
+    startedAt: new Date('2026-02-01T00:00:00.000Z'),
+    isActive: true,
+    createdAt: new Date('2026-02-01T00:00:00.000Z'),
+  });
+}
+
+function createCommand(
+  overrides: Partial<{
+    organizationRepo: unknown;
+    memberRepo: unknown;
+    cycleRepo: unknown;
+    generationRepo: unknown;
+    organizationMemberRepo: unknown;
+    submissionRepo: unknown;
+    submissionService: unknown;
+  }> = {}
+) {
+  const organization = createOrganization();
+  const member = createMember();
+  const cycle = createCycle();
+  const generation = createGeneration();
+  const submissionRepo = {
+    save: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    command: new RecordDiscordSubmissionCommand(
+      (overrides.organizationRepo ?? {
+        findBySlug: vi.fn().mockResolvedValue(organization),
+      }) as never,
+      (overrides.memberRepo ?? {
+        findByDiscordId: vi.fn().mockResolvedValue(member),
+      }) as never,
+      (overrides.cycleRepo ?? {
+        findActiveCyclesByOrganization: vi.fn().mockResolvedValue([cycle]),
+      }) as never,
+      (overrides.generationRepo ?? {
+        findById: vi.fn().mockResolvedValue(generation),
+      }) as never,
+      (overrides.organizationMemberRepo ?? {
+        isActiveMember: vi.fn().mockResolvedValue(true),
+      }) as never,
+      (overrides.submissionRepo ?? submissionRepo) as never,
+      (overrides.submissionService ?? {
+        validateSubmission: vi.fn().mockResolvedValue(undefined),
+      }) as never
+    ),
+    submissionRepo,
+  };
+}
+
+describe('RecordDiscordSubmissionCommand', () => {
+  it('records a submission for the current cycle from a Discord user', async () => {
+    const { command, submissionRepo } = createCommand();
+
+    const result = await command.execute({
+      discordUserId: 'discord-user-1',
+      organizationSlug: 'donguel-donguel',
+      blogUrl: 'https://bbak.dev/post/study-8',
+    });
+
+    expect(submissionRepo.save).toHaveBeenCalledTimes(1);
+    const savedSubmission = submissionRepo.save.mock.calls[0][0];
+    expect(savedSubmission.toDTO()).toMatchObject({
+      cycleId: 11,
+      memberId: 7,
+      url: 'https://bbak.dev/post/study-8',
+      githubCommentId: 'discord:11:7:https://bbak.dev/post/study-8',
+    });
+    expect(result).toMatchObject({
+      memberName: '박준형',
+      generationName: '똥글똥글 2기',
+      cycleWeek: 8,
+      cycleId: 11,
+      organizationSlug: 'donguel-donguel',
+      statusPath: '/api/status/11?organizationSlug=donguel-donguel',
+    });
+  });
+
+  it('rejects an unknown organization', async () => {
+    const { command } = createCommand({
+      organizationRepo: { findBySlug: vi.fn().mockResolvedValue(null) },
+    });
+
+    await expect(
+      command.execute({
+        discordUserId: 'discord-user-1',
+        organizationSlug: 'missing-org',
+        blogUrl: 'https://bbak.dev/post/study-8',
+      })
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('rejects a Discord user who is not registered as a member', async () => {
+    const { command } = createCommand({
+      memberRepo: { findByDiscordId: vi.fn().mockResolvedValue(null) },
+    });
+
+    await expect(
+      command.execute({
+        discordUserId: 'unknown',
+        organizationSlug: 'donguel-donguel',
+        blogUrl: 'https://bbak.dev/post/study-8',
+      })
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('rejects a registered Discord user who is not approved in the organization', async () => {
+    const { command } = createCommand({
+      organizationMemberRepo: {
+        isActiveMember: vi.fn().mockResolvedValue(false),
+      },
+    });
+
+    await expect(
+      command.execute({
+        discordUserId: 'discord-user-1',
+        organizationSlug: 'donguel-donguel',
+        blogUrl: 'https://bbak.dev/post/study-8',
+      })
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('rejects submission when there is no active cycle', async () => {
+    const { command } = createCommand({
+      cycleRepo: {
+        findActiveCyclesByOrganization: vi.fn().mockResolvedValue([]),
+      },
+    });
+
+    await expect(
+      command.execute({
+        discordUserId: 'discord-user-1',
+        organizationSlug: 'donguel-donguel',
+        blogUrl: 'https://bbak.dev/post/study-8',
+      })
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('rejects submission when the active cycle generation is missing', async () => {
+    const { command } = createCommand({
+      generationRepo: { findById: vi.fn().mockResolvedValue(null) },
+    });
+
+    await expect(
+      command.execute({
+        discordUserId: 'discord-user-1',
+        organizationSlug: 'donguel-donguel',
+        blogUrl: 'https://bbak.dev/post/study-8',
+      })
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/apps/server/src/application/commands/record-discord-submission.command.ts
+++ b/apps/server/src/application/commands/record-discord-submission.command.ts
@@ -1,0 +1,123 @@
+import { CycleRepository } from '@/domain/cycle/cycle.repository';
+import { GenerationId } from '@/domain/generation/generation.domain';
+import { GenerationRepository } from '@/domain/generation/generation.repository';
+import { ForbiddenError, NotFoundError } from '@/domain/common/errors';
+import { MemberRepository } from '@/domain/member/member.repository';
+import { OrganizationRepository } from '@/domain/organization/organization.repository';
+import { OrganizationMemberRepository } from '@/domain/organization-member/organization-member.repository';
+import {
+  CycleId as SubmissionCycleId,
+  MemberId as SubmissionMemberId,
+  Submission,
+} from '@/domain/submission/submission.domain';
+import { SubmissionRepository } from '@/domain/submission/submission.repository';
+import { SubmissionService } from '@/domain/submission/submission.service';
+
+export interface RecordDiscordSubmissionRequest {
+  discordUserId: string;
+  organizationSlug: string;
+  blogUrl: string;
+}
+
+export interface RecordDiscordSubmissionResult {
+  memberName: string;
+  generationName: string;
+  cycleWeek: number;
+  cycleId: number;
+  organizationSlug: string;
+  submittedUrl: string;
+  statusPath: string;
+}
+
+export class RecordDiscordSubmissionCommand {
+  constructor(
+    private readonly organizationRepo: OrganizationRepository,
+    private readonly memberRepo: MemberRepository,
+    private readonly cycleRepo: CycleRepository,
+    private readonly generationRepo: GenerationRepository,
+    private readonly organizationMemberRepo: OrganizationMemberRepository,
+    private readonly submissionRepo: SubmissionRepository,
+    private readonly submissionService: SubmissionService
+  ) {}
+
+  async execute(
+    request: RecordDiscordSubmissionRequest
+  ): Promise<RecordDiscordSubmissionResult> {
+    const organization = await this.organizationRepo.findBySlug(
+      request.organizationSlug
+    );
+    if (!organization) {
+      throw new NotFoundError('Organization', request.organizationSlug);
+    }
+
+    const member = await this.memberRepo.findByDiscordId(request.discordUserId);
+    if (!member) {
+      throw new NotFoundError('Member', `discord=${request.discordUserId}`);
+    }
+
+    const isActiveMember = await this.organizationMemberRepo.isActiveMember(
+      organization.id,
+      member.id
+    );
+    if (!isActiveMember) {
+      throw new ForbiddenError(
+        'Member is not an approved member of the organization'
+      );
+    }
+
+    const activeCycles = await this.cycleRepo.findActiveCyclesByOrganization(
+      organization.id.value
+    );
+    const cycle = activeCycles[0];
+    if (!cycle) {
+      throw new NotFoundError('Active cycle', request.organizationSlug);
+    }
+
+    const generation = await this.generationRepo.findById(
+      GenerationId.create(cycle.generationId)
+    );
+    if (!generation) {
+      throw new NotFoundError('Generation', `id=${cycle.generationId}`);
+    }
+
+    const syntheticCommentId = this.createDiscordSubmissionSourceId(
+      cycle.id.value,
+      member.id.value,
+      request.blogUrl
+    );
+
+    await this.submissionService.validateSubmission(
+      SubmissionCycleId.create(cycle.id.value),
+      SubmissionMemberId.create(member.id.value),
+      syntheticCommentId
+    );
+
+    const submission = Submission.create({
+      cycleId: cycle.id.value,
+      memberId: member.id.value,
+      url: request.blogUrl,
+      githubCommentId: syntheticCommentId,
+      submittedAt: new Date(),
+    });
+
+    await this.submissionRepo.save(submission);
+
+    return {
+      memberName: member.name.value,
+      generationName: generation.name,
+      cycleWeek: cycle.week.toNumber(),
+      cycleId: cycle.id.value,
+      organizationSlug: organization.slug.value,
+      submittedUrl: request.blogUrl,
+      statusPath: `/api/status/${cycle.id.value}?organizationSlug=${organization.slug.value}`,
+    };
+  }
+
+  private createDiscordSubmissionSourceId(
+    cycleId: number,
+    memberId: number,
+    blogUrl: string
+  ): string {
+    return `discord:${cycleId}:${memberId}:${blogUrl}`;
+  }
+}

--- a/apps/server/src/presentation/discord/commands/SubmitCommand.test.ts
+++ b/apps/server/src/presentation/discord/commands/SubmitCommand.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SubmitCommand } from './SubmitCommand';
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from '@/domain/common/errors';
+
+function createInteraction(url = 'https://bbak.dev/post/study-8') {
+  return {
+    user: { id: 'discord-user-1' },
+    options: {
+      getString: vi.fn().mockReturnValue(url),
+    },
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('SubmitCommand', () => {
+  it('defines /submit with a required url option', () => {
+    const command = new SubmitCommand({ execute: vi.fn() } as never);
+
+    const json = command.definition.toJSON();
+
+    expect(json.name).toBe('submit');
+    expect(json.options?.map((option) => option.name)).toEqual(['url']);
+    expect(json.options?.[0]?.required).toBe(true);
+  });
+
+  it('records a Discord submission and replies with the web status path', async () => {
+    const recordSubmission = {
+      execute: vi.fn().mockResolvedValue({
+        memberName: '박준형',
+        generationName: '똥글똥글 2기',
+        cycleWeek: 8,
+        cycleId: 11,
+        organizationSlug: 'donguel-donguel',
+        submittedUrl: 'https://bbak.dev/post/study-8',
+        statusPath: '/api/status/11?organizationSlug=donguel-donguel',
+      }),
+    };
+    const command = new SubmitCommand(recordSubmission as never);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    expect(recordSubmission.execute).toHaveBeenCalledWith({
+      discordUserId: 'discord-user-1',
+      organizationSlug: 'donguel-donguel',
+      blogUrl: 'https://bbak.dev/post/study-8',
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('제출 완료'),
+      })
+    );
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
+    expect(reply.content).toContain('똥글똥글 2기 8주차');
+    expect(reply.content).toContain(
+      '/api/status/11?organizationSlug=donguel-donguel'
+    );
+    expect(reply.content).toContain('/cycle status');
+  });
+
+  it('guides unregistered users to create a member profile first', async () => {
+    const command = new SubmitCommand({
+      execute: vi
+        .fn()
+        .mockRejectedValue(new NotFoundError('Member', 'discord=1')),
+    } as never);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('/member create'),
+      })
+    );
+  });
+
+  it('explains that operators should check the cycle when there is no current cycle', async () => {
+    const command = new SubmitCommand({
+      execute: vi
+        .fn()
+        .mockRejectedValue(
+          new NotFoundError('Active cycle', 'donguel-donguel')
+        ),
+    } as never);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('/cycle current'),
+      })
+    );
+  });
+
+  it('guides unapproved users to join the organization before submitting', async () => {
+    const command = new SubmitCommand({
+      execute: vi.fn().mockRejectedValue(new ForbiddenError('not approved')),
+    } as never);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('/organization join'),
+      })
+    );
+  });
+
+  it('explains duplicate submissions can be checked with cycle status', async () => {
+    const command = new SubmitCommand({
+      execute: vi
+        .fn()
+        .mockRejectedValue(new ConflictError('Already submitted')),
+    } as never);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    const reply = interaction.editReply.mock.calls.at(-1)?.[0] as {
+      content: string;
+    };
+    expect(reply.content).toContain('/cycle status');
+    expect(reply.content).toContain('URL 수정이 필요하면');
+  });
+
+  it('returns a safe fallback message for unexpected errors', async () => {
+    const command = new SubmitCommand({
+      execute: vi.fn().mockRejectedValue(new Error('database is sleepy')),
+    } as never);
+    const interaction = createInteraction();
+
+    await command.execute(interaction as never);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('제출 처리 중 오류'),
+      })
+    );
+  });
+});

--- a/apps/server/src/presentation/discord/commands/SubmitCommand.ts
+++ b/apps/server/src/presentation/discord/commands/SubmitCommand.ts
@@ -1,0 +1,89 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from '@/domain/common/errors';
+import { RecordDiscordSubmissionCommand } from '@/application/commands/record-discord-submission.command';
+import { DiscordCommand } from './types';
+
+const DEFAULT_ORGANIZATION_SLUG = 'donguel-donguel';
+
+export class SubmitCommand implements DiscordCommand {
+  readonly definition = new SlashCommandBuilder()
+    .setName('submit')
+    .setDescription('현재 회차에 글 URL을 제출합니다')
+    .addStringOption((option) =>
+      option.setName('url').setDescription('제출할 글 URL').setRequired(true)
+    );
+
+  constructor(
+    private readonly recordSubmissionCommand: RecordDiscordSubmissionCommand
+  ) {}
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    await interaction.deferReply();
+
+    const blogUrl = interaction.options.getString('url', true);
+
+    try {
+      const result = await this.recordSubmissionCommand.execute({
+        discordUserId: interaction.user.id,
+        organizationSlug: DEFAULT_ORGANIZATION_SLUG,
+        blogUrl,
+      });
+
+      await interaction.editReply({
+        content:
+          `✅ **제출 완료!**\n\n` +
+          `스터디: ${result.generationName} ${result.cycleWeek}주차\n` +
+          `제출자: ${result.memberName}\n` +
+          `제출한 글: ${result.submittedUrl}\n\n` +
+          `전체 현황 보기: ${result.statusPath}\n` +
+          `다음 행동: \`/cycle status\`로 같은 스터디원들의 참여 현황을 확인해 주세요.`,
+      });
+    } catch (error) {
+      await interaction.editReply({ content: this.formatErrorMessage(error) });
+    }
+  }
+
+  private formatErrorMessage(error: unknown): string {
+    if (error instanceof NotFoundError) {
+      if (error.message.includes('Member')) {
+        return (
+          '👤 **아직 멤버 등록이 필요해요.**\n\n' +
+          '1. `/member create`로 스터디봇에 먼저 등록해 주세요.\n' +
+          '2. GitHub 계정을 연결한 뒤 다시 `/submit url:<글 URL>`을 실행해 주세요.'
+        );
+      }
+
+      return (
+        '🗓️ **현재 제출 가능한 회차를 찾지 못했어요.**\n\n' +
+        '운영자에게 현재 회차가 열려 있는지 확인해 달라고 요청해 주세요.\n' +
+        '운영자는 `/cycle current`와 `/cycle list`로 회차 상태를 확인할 수 있어요.'
+      );
+    }
+
+    if (error instanceof ForbiddenError) {
+      return (
+        '🚪 **조직 가입 또는 승인이 필요해요.**\n\n' +
+        '1. `/organization join`으로 조직 가입을 신청해 주세요.\n' +
+        '2. 운영진 승인 후 `/generation join` 또는 `/generation apply`를 진행해 주세요.\n' +
+        '3. 승인 상태는 `/me info`에서 확인할 수 있어요.'
+      );
+    }
+
+    if (error instanceof ConflictError) {
+      return (
+        '✅ **이미 이번 회차에 제출한 기록이 있어요.**\n\n' +
+        '`/cycle status`로 제출 현황을 확인해 주세요.\n' +
+        'URL 수정이 필요하면 운영진에게 요청해 주세요.'
+      );
+    }
+
+    return (
+      '❌ 제출 처리 중 오류가 발생했습니다.\n' +
+      '잠시 후 다시 시도하거나 운영진에게 알려 주세요.'
+    );
+  }
+}

--- a/apps/server/src/presentation/discord/commands/index.ts
+++ b/apps/server/src/presentation/discord/commands/index.ts
@@ -8,6 +8,7 @@ import { OrganizationCommand } from './OrganizationCommand';
 import { GenerationCommand } from './GenerationCommand';
 import { MeCommand } from './MeCommand';
 import { ReviewCommand } from './ReviewCommand';
+import { SubmitCommand } from './SubmitCommand';
 import { GetCycleStatusQuery } from '@/application/queries';
 import {
   CreateMemberCommand as AppCreateMemberCommand,
@@ -15,6 +16,7 @@ import {
   JoinOrganizationCommand as AppJoinOrganizationCommand,
   UpdateMemberStatusCommand,
   JoinGenerationCommand as AppJoinGenerationCommand,
+  RecordDiscordSubmissionCommand,
 } from '@/application/commands';
 import { DrizzleCycleRepository } from '@/infrastructure/persistence/drizzle/cycle.repository.impl';
 import { DrizzleGenerationRepository } from '@/infrastructure/persistence/drizzle/generation.repository.impl';
@@ -44,6 +46,7 @@ import {
   DrizzlePeerReviewAssignmentRepository,
   DrizzlePeerReviewSubmissionLookup,
 } from '@/infrastructure/persistence/drizzle/peer-review.repository.impl';
+import { SubmissionService } from '@/domain/submission/submission.service';
 
 // Repository instances
 const cycleRepo = new DrizzleCycleRepository();
@@ -105,6 +108,16 @@ const getCycleStatusQuery = new GetCycleStatusQuery(
   submissionRepo,
   organizationMemberRepo,
   memberRepo
+);
+const submissionService = new SubmissionService(submissionRepo);
+const recordDiscordSubmissionCommand = new RecordDiscordSubmissionCommand(
+  organizationRepo,
+  memberRepo,
+  cycleRepo,
+  generationRepo,
+  organizationMemberRepo,
+  submissionRepo,
+  submissionService
 );
 const createPeerReviewAssignmentsCommand =
   new CreatePeerReviewAssignmentsCommand(
@@ -175,6 +188,7 @@ export const createCommands = (): DiscordCommand[] => {
       cycleRepo
     ),
     new CycleCommand(getCycleStatusQuery),
+    new SubmitCommand(recordDiscordSubmissionCommand),
     new ReviewCommand({
       memberRepository: memberRepo,
       cycleQuery: currentPeerReviewCycleQuery,

--- a/docs/cloudflare-workers-migration.md
+++ b/docs/cloudflare-workers-migration.md
@@ -61,10 +61,16 @@ pnpm wrangler secret put DISCORD_BOT_TOKEN
 pnpm wrangler secret put GITHUB_WEBHOOK_SECRET
 ```
 
-일반 변수:
+일반 변수는 `apps/worker/wrangler.jsonc`에 들어 있다.
 
 ```txt
 API_BASE_URL=https://donguel-donguel-notification.onrender.com
+```
+
+로컬 개발용 예시는 `apps/worker/.dev.vars.example`을 복사해서 사용한다.
+
+```bash
+cp apps/worker/.dev.vars.example apps/worker/.dev.vars
 ```
 
 ## 로컬/CI 검증
@@ -76,7 +82,7 @@ export PATH="$HOME/.hermes/node/bin:$PATH"
 pnpm install
 pnpm --filter @hanghae-study/worker type-check
 pnpm --filter @hanghae-study/worker test
-pnpm --filter @hanghae-study/worker exec wrangler deploy --dry-run
+pnpm worker:deploy:dry-run
 ```
 
 기존 서버 회귀 검증:
@@ -86,18 +92,48 @@ cd apps/server
 SKIP_ENV_VALIDATION=true pnpm exec vitest run
 ```
 
+## 배포 절차
+
+Cloudflare 계정 인증은 로컬/CI 환경에서 한 번 필요하다.
+
+```bash
+cd apps/worker
+pnpm wrangler login
+pnpm wrangler whoami
+```
+
+secret 설정 후 repo root에서 dry-run과 실제 배포를 실행한다.
+
+```bash
+pnpm worker:deploy:dry-run
+pnpm worker:deploy
+```
+
+배포 후 Worker URL은 보통 다음 형태다.
+
+```txt
+https://donguel-donguel-notification-worker.<account-subdomain>.workers.dev
+```
+
+Discord Developer Portal에는 아래 URL을 Interactions Endpoint URL로 등록한다.
+
+```txt
+https://donguel-donguel-notification-worker.<account-subdomain>.workers.dev/discord/interactions
+```
+
 ## Cutover 순서
 
 1. Cloudflare Worker secrets 설정
-2. Worker 배포
-3. Discord Developer Portal에서 Interactions Endpoint URL을 Worker `/discord/interactions`로 등록
-4. Discord PING 검증 통과 확인
-5. `/cycle current`부터 Worker HTTP interaction 방식으로 이식
-6. DB 접근 전략 결정
+2. `pnpm worker:deploy:dry-run`으로 배포 번들 검증
+3. `pnpm worker:deploy`로 Worker 배포
+4. Discord Developer Portal에서 Interactions Endpoint URL을 Worker `/discord/interactions`로 등록
+5. Discord PING 검증 통과 확인
+6. `/cycle current`부터 Worker HTTP interaction 방식으로 이식
+7. DB 접근 전략 결정
    - 단기: Worker가 기존 Render API 호출
    - 중기: Worker-compatible Postgres 접근
    - 장기: 필요하면 D1 등 Cloudflare-native 저장소 검토
-7. Worker command handler가 안정화된 뒤 Render의 Gateway bot 시작을 끄거나 제거
+8. Worker command handler가 안정화된 뒤 Render의 Gateway bot 시작을 끄거나 제거
 
 ## 주의점
 

--- a/docs/study-dashboard-web-and-commands.md
+++ b/docs/study-dashboard-web-and-commands.md
@@ -1,0 +1,210 @@
+# 스터디봇 웹 대시보드 + 커맨드 제출/현황 초안
+
+## 목표
+
+스터디봇 slash command와 웹 대시보드를 연결해서 운영 중인 스터디 기수/회차 글 제출 현황을 누구나 확인할 수 있게 한다.
+
+- Discord에서는 최소 입력으로 제출/조회한다.
+- 웹에서는 운영 중인 기수와 회차, 제출 글, 참여 현황을 보기 좋게 확인한다.
+- DB를 SSOT로 두고 Discord/GitHub/Web은 projection/input surface로 둔다.
+
+## 핵심 사용자 흐름
+
+### 1. 글 제출
+
+Discord:
+
+```txt
+/submit url:https://blog.example.com/my-post
+```
+
+봇 응답:
+
+- 제출 성공 여부
+- 현재 회차 정보
+- 웹 현황 링크
+- `/cycle status` 다음 액션
+
+기존 GitHub Issue 댓글 제출도 당분간 유지할 수 있다.
+
+### 2. 현재 회차 확인
+
+Discord:
+
+```txt
+/cycle current
+/cycle status
+```
+
+봇 응답:
+
+- 현재 스터디/기수/회차
+- 기간과 마감일
+- 제출률
+- 내 제출 상태
+- 전체 현황 웹 링크
+
+### 3. 웹 현황 확인
+
+URL 예시:
+
+```txt
+/studies/donguel-donguel/generations/2
+/studies/donguel-donguel/generations/2/cycles/8
+```
+
+웹에서 보여줄 것:
+
+- 운영 중인 기수 목록
+- 기수별 회차 목록
+- 회차별 제출 현황
+- 제출한 글 카드 목록
+- 미제출자 목록
+- 마감까지 남은 시간
+
+## 권장 웹 정보 구조
+
+### 홈 / 스터디 목록
+
+- 현재 운영 중인 스터디
+- 활성 기수
+- 현재 회차
+- 제출률 요약
+
+### 기수 상세
+
+- 기수명: 예: `똥글똥글 3기`
+- 상태: planned/active/completed
+- 참가자 수
+- 회차 리스트
+- 전체 제출률
+
+### 회차 상세
+
+- 회차명: 예: `8회차`
+- 기간
+- 마감 상태
+- 제출률: `12 / 15명`
+- 제출자 목록
+- 미제출자 목록
+- 제출 글 목록
+
+### 개인 상세 또는 필터
+
+- 특정 멤버의 회차별 제출 이력
+- GitHub/Discord 연결 상태
+- 누락 회차
+
+## API 초안
+
+### Public read API
+
+```http
+GET /api/public/studies
+GET /api/public/studies/:studySlug/generations
+GET /api/public/studies/:studySlug/generations/active
+GET /api/public/generations/:generationId/cycles
+GET /api/public/cycles/:cycleId/status
+GET /api/public/cycles/:cycleId/submissions
+```
+
+### Command/write API
+
+```http
+POST /api/submissions
+```
+
+Body:
+
+```json
+{
+  "cycleId": 123,
+  "discordUserId": "...",
+  "url": "https://..."
+}
+```
+
+서버는 Discord identity → Member → GenerationParticipant 승인 상태 → Current Cycle을 검증한 뒤 Submission을 만든다.
+
+## Discord command 초안
+
+### 참가자용
+
+```txt
+/submit url:<글 URL>
+/me info
+/cycle current
+/cycle status
+/generation list
+/generation current
+```
+
+### 운영진용
+
+```txt
+/generation create 또는 별도 운영 스크립트
+/cycle open
+/cycle close
+/cycle status
+/missing-submissions
+```
+
+현재 프로덕션에는 generation/cycle 생성 slash command가 없으므로, 먼저 웹/스크립트/운영자 API 중 하나로 생성 경로를 마련해야 한다.
+
+## 데이터 모델 원칙
+
+- `Study` / `Generation` / `Cycle` / `Member` / `GenerationParticipant` / `Submission`을 중심으로 둔다.
+- `GenerationParticipant`는 기수별 참여 상태를 가진다.
+- 제출은 `one public URL = one Submission`으로 모델링한다.
+- Discord ID는 제출 명령의 canonical identity로 사용한다.
+- GitHub username은 GitHub Issue 댓글 ingestion과 기존 archive 연동용 identity로 유지한다.
+- 회차 오픈 시점에 제출 의무자 snapshot을 남기면 이후 참가자 변경에도 과거 통계가 흔들리지 않는다.
+
+## MVP 범위
+
+1. 읽기 전용 웹 대시보드
+   - active generation
+   - cycles list
+   - cycle status
+   - submissions list
+2. Discord 제출 명령 `/submit url:`
+   - 현재 active cycle 자동 선택
+   - 승인된 참가자만 제출 가능
+   - 중복 URL/동일 회차 정책 정의
+3. 웹 링크를 Discord 응답에 포함
+4. 기존 GitHub Issue 댓글 제출은 병행 유지
+
+## 구현 순서 제안
+
+1. 현재 DB/API 스키마와 production 데이터 상태 확인
+2. read model/API 설계와 테스트 작성
+3. cycle status public API 구현
+4. 웹 앱 추가 또는 기존 서버 static/frontend 구성 결정
+5. Discord `/submit` 명령 RED test 작성
+6. 제출 command/application handler 구현
+7. 제출 성공/실패 UX 메시지 100% coverage
+8. production command sync와 Render 배포 검증
+
+## 공개 범위와 개인정보
+
+웹이 누구나 보는 페이지라면 다음을 먼저 결정해야 한다.
+
+- 미제출자 실명 공개 여부
+- Discord display name 공개 여부
+- GitHub username 공개 여부
+- 제출 글 URL 공개 여부
+- 검색엔진 index 허용 여부
+
+권장 기본값:
+
+- 스터디 내부 공유 링크면 이름/URL 공개 가능
+- 완전 public이면 미제출자는 익명화하거나 로그인/토큰 보호 고려
+
+## 남은 의사결정
+
+- 웹은 완전 공개인가, 링크를 아는 사람만 보는가, Discord 로그인 필요한가?
+- 기존 GitHub Issue 댓글 제출을 계속 1급 제출 경로로 둘 것인가?
+- 한 회차에 여러 글 제출 허용 여부
+- 제출 URL 수정/철회 정책
+- 지각 제출 허용 여부
+- 운영 중인 기수만 노출할지, 종료 기수 archive도 노출할지

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "github:assign": "turbo run github:assign",
     "github:fetch-comments": "turbo run github:fetch-comments",
     "github:poll-projects": "turbo run github:poll-projects",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "worker:dev": "pnpm --filter @hanghae-study/worker dev",
+    "worker:deploy": "pnpm --filter @hanghae-study/worker deploy",
+    "worker:deploy:dry-run": "pnpm --filter @hanghae-study/worker deploy:dry-run"
   },
   "devDependencies": {
     "turbo": "^2.5.0",


### PR DESCRIPTION
## Summary
- Add Discord `/submit url:` command for recording the current active study cycle submission from a Discord user
- Add `RecordDiscordSubmissionCommand` with organization/member/active-cycle/approval validation
- Document the study dashboard + command MVP direction
- Add root Worker deploy helper scripts and Cloudflare deploy runbook updates so the existing Worker scaffold can be dry-run deployed and deployed via `pnpm worker:deploy:*`

## Test Plan
- [x] `pnpm --filter @hanghae-study/worker type-check`
- [x] `pnpm --filter @hanghae-study/worker test`
- [x] `pnpm worker:deploy:dry-run`
- [x] `pnpm --filter @hanghae-study/worker format:check`
- [x] `SKIP_ENV_VALIDATION=true pnpm --filter @hanghae-study/server test`
- [x] `pnpm --filter @hanghae-study/server type-check`
- [x] `git diff --check`

## Notes
- This PR is based on `feat/peer-review-persistence` to avoid mixing unrelated base-branch changes into the diff.
- Actual Cloudflare deploy still requires `wrangler login` and Cloudflare secrets to be set outside the repo.
- Worker mode avoids Render Gateway sleep only after Discord is switched to the HTTP Interactions Endpoint flow; current Worker scaffold is deployable and PING-ready, while command business logic migration remains phased work.