### PR TITLE
docs: plan full Cloudflare migration

### DIFF
--- a/apps/worker/.dev.vars.example
+++ b/apps/worker/.dev.vars.example
@@ -2,4 +2,3 @@ DISCORD_PUBLIC_KEY=replace-with-discord-application-public-key
 DISCORD_APPLICATION_ID=replace-with-discord-application-id
 DISCORD_BOT_TOKEN=replace-with-discord-bot-token
 GITHUB_WEBHOOK_SECRET=replace-with-github-webhook-secret
-API_BASE_URL=https://donguel-donguel-notification.onrender.com

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -45,12 +45,15 @@ app.post("/discord/interactions", async (context) => {
   return context.json(response);
 });
 
-app.post("/webhook/github", async (context) => {
-  const apiBaseUrl = context.env.API_BASE_URL.replace(/\/$/, "");
-  const targetUrl = `${apiBaseUrl}/webhook/github`;
-  const request = new Request(targetUrl, context.req.raw);
-
-  return fetch(request);
+app.post("/webhook/github", (context) => {
+  return context.json(
+    {
+      error: "github_webhook_native_handler_not_implemented",
+      message:
+        "GitHub webhook must be handled natively in Cloudflare Worker; Render proxy is disabled.",
+    },
+    501,
+  );
 });
 
 export default app;

--- a/apps/worker/test/discord.test.ts
+++ b/apps/worker/test/discord.test.ts
@@ -11,7 +11,6 @@ const env: Env = {
   DISCORD_APPLICATION_ID: "1457578741097042114",
   DISCORD_BOT_TOKEN: "test-token",
   GITHUB_WEBHOOK_SECRET: "test-secret",
-  API_BASE_URL: "https://api.example.test",
 };
 
 describe("notification Cloudflare Worker", () => {
@@ -79,6 +78,25 @@ describe("notification Cloudflare Worker", () => {
         flags: 64,
       },
     });
+  });
+
+  it("does not proxy GitHub webhooks to Render", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const response = await worker.fetch(
+      new Request("https://worker.example.test/webhook/github", {
+        method: "POST",
+        body: JSON.stringify({ action: "created" }),
+      }),
+      env,
+      {} as ExecutionContext,
+    );
+
+    expect(response.status).toBe(501);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "github_webhook_native_handler_not_implemented",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("verifies Discord signatures using timestamp plus raw body", async () => {

--- a/apps/worker/worker-configuration.d.ts
+++ b/apps/worker/worker-configuration.d.ts
@@ -5,7 +5,6 @@ declare namespace Cloudflare {
     DISCORD_APPLICATION_ID: string;
     DISCORD_BOT_TOKEN: string;
     GITHUB_WEBHOOK_SECRET: string;
-    API_BASE_URL: string;
   }
 }
 

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -6,8 +6,5 @@
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true
-  },
-  "vars": {
-    "API_BASE_URL": "https://donguel-donguel-notification.onrender.com"
   }
 }

--- a/docs/cloudflare-full-migration-plan.md
+++ b/docs/cloudflare-full-migration-plan.md
@@ -1,0 +1,395 @@
+# Notification Full Cloudflare Migration Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Render Web Service 의존성을 제거하고 스터디봇/HTTP API/GitHub webhook/reminder 실행 경로를 Cloudflare Workers + Cloudflare-native storage/scheduling으로 이전한다.
+
+**Architecture:** Discord Gateway bot(`client.login`)과 Render API를 중단하고, Discord Developer Portal Interactions Endpoint가 Cloudflare Worker의 `/discord/interactions`를 직접 호출하게 한다. Worker는 D1을 primary relational store로 사용하고, GitHub webhook과 scheduled reminder도 Worker entrypoint에서 직접 처리한다. 외부 호출은 Discord API/GitHub API처럼 실제 integration 대상에만 허용하고, `*.onrender.com` 또는 `API_BASE_URL` proxy는 금지한다.
+
+**Tech Stack:** Cloudflare Workers, Hono, Discord HTTP Interactions, Cloudflare D1, Drizzle SQLite/D1 schema, Workers Cron Triggers, Vitest, Wrangler.
+
+---
+
+## Non-goals / Guardrails
+
+- Render API proxy 금지: `API_BASE_URL`, `*.onrender.com`, `/webhook/github` forwarding을 새 코드에 추가하지 않는다.
+- Cloudflare Workers에서 `discord.js` Gateway bot을 실행하지 않는다.
+- 실제 Discord/GitHub/Cloudflare secret 값을 커밋하지 않는다.
+- 기존 `apps/server` 파일은 read-only reference로 먼저 다룬다. 재사용이 필요하면 Worker-compatible package로 분리하는 PR을 별도로 만든다.
+- 기존 main worktree가 dirty하면 `/tmp/notification-full-cf-*` 같은 별도 worktree에서 작업한다.
+
+## Current Render-dependent inventory
+
+| Area | Current file(s) | Render dependency | Cloudflare target |
+| --- | --- | --- | --- |
+| Discord slash commands | `apps/server/src/index.ts`, `apps/server/src/presentation/discord/**` | Render process keeps Discord Gateway connection alive | Worker `/discord/interactions` HTTP endpoint |
+| Status/current cycle API | `apps/server/src/presentation/http/status/status.handlers.ts`, `apps/server/src/application/queries/get-cycle-status.query.ts` | Discord command calls server-side query via Render-hosted app | Worker handler queries D1 directly |
+| GitHub webhook | `apps/server/src/presentation/http/github/github.handlers.ts` | GitHub posts to Render `/webhook/github` | GitHub posts to Worker `/webhook/github`, Worker verifies signature and writes D1 |
+| Reminder API/jobs | `apps/server/src/presentation/http/reminder/reminder.handlers.ts` | External scheduler/HTTP path depends on Render being reachable | Worker `scheduled()` Cron Trigger queries D1 and sends Discord webhook/API messages |
+| DB access | `apps/server/src/infrastructure/lib/db.ts`, `apps/server/src/infrastructure/persistence/drizzle-db/schema.ts` | Node postgres driver from Render runtime | D1 binding + Drizzle SQLite/D1 schema |
+| GraphQL/admin API | `apps/server/src/presentation/graphql/**` | Render HTTP service | Later Worker route or separate Cloudflare app; not required for first Discord command cutover |
+
+## Target Worker bindings
+
+Initial binding shape:
+
+```ts
+interface Env {
+  DISCORD_PUBLIC_KEY: string;
+  DISCORD_APPLICATION_ID: string;
+  DISCORD_BOT_TOKEN: string;
+  GITHUB_WEBHOOK_SECRET: string;
+  DB: D1Database;
+}
+```
+
+Wrangler target shape:
+
+```jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "donguel-donguel-notification",
+      "database_id": "<set-after-cloudflare-d1-create>",
+      "migrations_dir": "drizzle/d1"
+    }
+  ],
+  "triggers": {
+    "crons": ["0 9 * * *", "0 21 * * *"]
+  }
+}
+```
+
+`database_id`는 Cloudflare에서 D1 생성 후 별도 PR/환경 설정으로 채운다. placeholder만 커밋한다.
+
+---
+
+## Phase 0: Remove proxy defaults from the Worker scaffold
+
+### Task 0.1: Remove `API_BASE_URL` binding
+
+**Objective:** Worker scaffold가 Render URL을 기본 설정으로 들고 있지 않게 한다.
+
+**Files:**
+- Modify: `apps/worker/wrangler.jsonc`
+- Modify: `apps/worker/worker-configuration.d.ts`
+- Modify: `apps/worker/.dev.vars.example`
+- Test: `apps/worker/test/discord.test.ts`
+
+**Steps:**
+1. Delete `vars.API_BASE_URL` from `wrangler.jsonc`.
+2. Delete `API_BASE_URL` from `Env` type.
+3. Delete `API_BASE_URL=...onrender.com` from `.dev.vars.example`.
+4. Update the test env fixture to remove `API_BASE_URL`.
+5. Run:
+
+```bash
+export PATH="$HOME/.hermes/node/bin:$PATH"
+pnpm --filter @hanghae-study/worker type-check
+pnpm --filter @hanghae-study/worker test
+```
+
+Expected: both pass.
+
+### Task 0.2: Replace GitHub webhook proxy with explicit native-placeholder behavior
+
+**Objective:** `/webhook/github` exists, but cannot silently forward to Render.
+
+**Files:**
+- Modify: `apps/worker/src/index.ts`
+- Modify: `apps/worker/test/discord.test.ts`
+
+**Step 1: Write/update test**
+
+Add a test that posts to `/webhook/github` and asserts:
+
+```ts
+expect(response.status).toBe(501);
+await expect(response.json()).resolves.toMatchObject({
+  error: 'github_webhook_native_handler_not_implemented',
+});
+expect(fetchSpy).not.toHaveBeenCalled();
+```
+
+**Step 2: Implement minimal handler**
+
+```ts
+app.post('/webhook/github', (context) => {
+  return context.json(
+    {
+      error: 'github_webhook_native_handler_not_implemented',
+      message:
+        'GitHub webhook must be handled natively in Cloudflare Worker; Render proxy is disabled.',
+    },
+    501,
+  );
+});
+```
+
+**Step 3: Verify**
+
+```bash
+pnpm --filter @hanghae-study/worker test
+```
+
+Expected: webhook test passes and no network fetch is made.
+
+---
+
+## Phase 1: D1 schema foundation
+
+### Task 1.1: Create D1 schema location
+
+**Objective:** Start a D1-specific schema without breaking the existing Postgres server schema.
+
+**Files:**
+- Create: `apps/worker/src/db/schema.ts`
+- Create: `apps/worker/src/db/types.ts`
+- Modify: `apps/worker/package.json`
+
+**Implementation notes:**
+- Add Drizzle D1 dependencies in a dedicated PR:
+
+```bash
+pnpm --filter @hanghae-study/worker add drizzle-orm
+pnpm --filter @hanghae-study/worker add -D drizzle-kit
+```
+
+- Use SQLite/D1 primitives, not `pgTable`/`pgEnum`.
+- Preserve table names from the production schema where possible:
+  - `organizations`
+  - `studies`
+  - `members`
+  - `member_identities`
+  - `generations`
+  - `cycles`
+  - `organization_members`
+  - `generation_participants`
+  - `generation_participant_roles`
+  - `submissions`
+  - peer-review/outbox tables as later tasks
+
+### Task 1.2: Add initial D1 migrations
+
+**Objective:** Make D1 database reproducible from source.
+
+**Files:**
+- Create: `apps/worker/drizzle.config.ts`
+- Create: `apps/worker/drizzle/d1/*.sql`
+- Modify: `apps/worker/package.json`
+
+**Scripts:**
+
+```json
+{
+  "db:generate": "drizzle-kit generate",
+  "db:migrate:local": "wrangler d1 migrations apply donguel-donguel-notification --local",
+  "db:migrate:remote": "wrangler d1 migrations apply donguel-donguel-notification --remote"
+}
+```
+
+**Verification:**
+
+```bash
+pnpm --filter @hanghae-study/worker db:generate
+pnpm --filter @hanghae-study/worker db:migrate:local
+```
+
+Expected: local D1 migration applies without relying on Render/Postgres.
+
+### Task 1.3: Add data export/import runbook
+
+**Objective:** Define how existing production data leaves Postgres and enters D1 without embedding credentials.
+
+**Files:**
+- Create: `docs/cloudflare-d1-data-migration-runbook.md`
+
+**Required sections:**
+- Read-only Postgres export command using local secure env only.
+- CSV/JSON normalization rules for timestamps/enums/jsonb.
+- D1 import command.
+- Validation SQL counts for organizations/generations/cycles/submissions.
+- Rollback plan: keep Render read-only until D1 validation passes.
+
+---
+
+## Phase 2: `/cycle current` Worker-native command
+
+### Task 2.1: Add Worker repository for current cycle query
+
+**Objective:** Worker can answer current-cycle status from D1 directly.
+
+**Files:**
+- Create: `apps/worker/src/features/cycle/current-cycle.repository.ts`
+- Create: `apps/worker/src/features/cycle/current-cycle.repository.test.ts`
+
+**Repository contract:**
+
+```ts
+export interface CurrentCycleStatus {
+  id: number;
+  week: number;
+  generationName: string;
+  startDate: string;
+  endDate: string;
+  githubIssueUrl: string | null;
+  submittedNames: string[];
+  notSubmittedNames: string[];
+}
+
+export interface CurrentCycleRepository {
+  getCurrentCycleStatus(organizationSlug: string): Promise<CurrentCycleStatus | null>;
+}
+```
+
+**Query rule:**
+- Organization matched by `organizations.slug`.
+- Current cycle is `cycles.status IN ('OPEN', 'ACTIVE')` or date range containing now, ordered by `end_date ASC`.
+- Participant set comes from approved `generation_participants`, not legacy global members.
+- Exclude inactive/removed/non-participant roles from required-submission calculations.
+
+### Task 2.2: Add Discord response formatter
+
+**Objective:** Preserve explicit next-action guidance in Discord output.
+
+**Files:**
+- Create: `apps/worker/src/features/cycle/current-cycle.discord.ts`
+- Create: `apps/worker/src/features/cycle/current-cycle.discord.test.ts`
+
+**Formatter behavior:**
+- No current cycle: tell user no active cycle exists and include admin next action.
+- Current cycle with issue URL: include link button to GitHub issue.
+- Submitted/missing lists should be concrete names.
+- Missing prerequisites should tell the user what to do next.
+
+### Task 2.3: Wire `/cycle current` to Worker interactions
+
+**Objective:** Discord slash command returns D1-backed result without Render.
+
+**Files:**
+- Modify: `apps/worker/src/discord.ts`
+- Modify: `apps/worker/src/index.ts`
+- Modify: `apps/worker/test/discord.test.ts`
+
+**Test assertions:**
+- `/cycle current` returns Discord response type `4` with D1-backed content.
+- No request is made to `*.onrender.com`.
+- Missing active cycle returns helpful guidance.
+- Invalid signature still returns `401`.
+
+---
+
+## Phase 3: GitHub webhook Worker-native handling
+
+### Task 3.1: Implement GitHub signature verification
+
+**Files:**
+- Create: `apps/worker/src/github/signature.ts`
+- Create: `apps/worker/src/github/signature.test.ts`
+
+**Rules:**
+- Verify `x-hub-signature-256` using `GITHUB_WEBHOOK_SECRET` and raw body.
+- Reject missing/invalid signatures with `401`.
+- Do not log secret or raw signature.
+
+### Task 3.2: Implement issue_comment submission recording
+
+**Files:**
+- Create: `apps/worker/src/features/submissions/record-submission.ts`
+- Create: `apps/worker/src/features/submissions/record-submission.test.ts`
+- Modify: `apps/worker/src/index.ts`
+
+**Rules:**
+- Accept GitHub `issue_comment.created` only.
+- Extract first `http(s)` URL from comment body.
+- Match cycle by `github_issue_url` or GitHub issue metadata.
+- Map GitHub username through D1 identities/members.
+- Upsert/dedupe by `source_github_comment_id`.
+- Send Discord notification from Worker if configured.
+
+### Task 3.3: Implement issues webhook cycle drift/create handling
+
+**Files:**
+- Create: `apps/worker/src/features/cycle/github-issue-events.ts`
+- Create: `apps/worker/src/features/cycle/github-issue-events.test.ts`
+
+**Rules:**
+- `issues.opened` can create cycle only when organization/generation mapping is explicit.
+- `issues.closed` records close/drift signal in D1 outbox or cycle fields.
+- Unknown/unmapped issues return 200 with ignored reason to avoid GitHub retry storms.
+
+---
+
+## Phase 4: Reminder scheduling on Cloudflare
+
+### Task 4.1: Add scheduled handler
+
+**Files:**
+- Modify: `apps/worker/src/index.ts`
+- Create: `apps/worker/src/scheduled/reminders.ts`
+- Create: `apps/worker/src/scheduled/reminders.test.ts`
+- Modify: `apps/worker/wrangler.jsonc`
+
+**Rules:**
+- Export Worker object with both `fetch` and `scheduled` handlers if Hono default export needs wrapping.
+- Cron queries D1 for cycles nearing deadline.
+- Send Discord messages from Worker.
+- Record notification attempts in D1 outbox/log table to avoid duplicate spam.
+
+---
+
+## Phase 5: Cutover checklist
+
+1. Create Cloudflare D1 database.
+2. Fill `database_id` in `apps/worker/wrangler.jsonc` or environment-specific config.
+3. Apply D1 migrations locally and remotely.
+4. Export current Postgres data using secure local env; import to D1.
+5. Validate row counts and spot-check current cycle/submission status.
+6. Deploy Worker.
+7. Register Discord Interactions Endpoint URL:
+
+```txt
+https://<worker-domain>/discord/interactions
+```
+
+8. Update GitHub webhook URL to Worker `/webhook/github`.
+9. Run Discord smoke tests:
+   - `/cycle current`
+   - submission comment → D1 row + Discord notification
+   - reminder scheduled dry-run/manual endpoint if present
+10. Disable Render Gateway bot start.
+11. Turn Render service read-only/stop after one full cycle passes.
+
+---
+
+## Verification commands before each PR
+
+```bash
+export PATH="$HOME/.hermes/node/bin:$PATH"
+pnpm install
+pnpm --filter @hanghae-study/worker format
+pnpm --filter @hanghae-study/worker type-check
+pnpm --filter @hanghae-study/worker test
+pnpm --filter @hanghae-study/worker exec wrangler deploy --dry-run
+pnpm --filter @hanghae-study/worker format:check
+git diff --check -- apps/worker docs pnpm-lock.yaml
+```
+
+For PRs that touch existing server/shared code:
+
+```bash
+SKIP_ENV_VALIDATION=true pnpm type-check
+SKIP_ENV_VALIDATION=true pnpm test
+pnpm lint
+pnpm build
+```
+
+## PR sequence
+
+1. `docs/chore`: full CF migration plan + remove proxy defaults from scaffold.
+2. `feat(worker-db)`: D1 schema, migrations, D1 binding, data migration runbook.
+3. `feat(worker-cycle-current)`: `/cycle current` D1-backed interaction.
+4. `feat(worker-github-webhook)`: native GitHub webhook verification + submission recording.
+5. `feat(worker-reminders)`: Cron Trigger reminder handling.
+6. `chore(cutover)`: Discord/GitHub endpoint switch docs and Render shutdown checklist.

--- a/docs/cloudflare-workers-migration.md
+++ b/docs/cloudflare-workers-migration.md
@@ -7,6 +7,8 @@ Render Free 인스턴스가 sleep 상태가 되면 Discord Gateway 연결이 끊
 
 Cloudflare Workers로 옮길 때는 기존 `client.login()` Gateway 구조를 그대로 옮기지 않는다. Workers는 상시 프로세스가 아니라 요청 기반 실행 환경이므로, Discord Developer Portal의 **Interactions Endpoint URL** 방식으로 전환한다.
 
+중요한 목표는 **Render API를 깨우는 프록시가 아니라 Render 의존성 제거**다. Worker가 `*.onrender.com` 또는 `API_BASE_URL`을 호출하는 방식은 명시적인 임시 브릿지 요청이 없는 한 사용하지 않는다.
+
 ## 목표 구조
 
 ```txt
@@ -16,9 +18,18 @@ Cloudflare Worker POST /discord/interactions
         ↓
 Ed25519 signature verification
         ↓
-HTTP interaction handler
+Worker-native command handler
+        ↓
+Cloudflare D1 / Cloudflare-native bindings
         ↓
 Discord interaction response
+```
+
+GitHub webhook과 reminder도 같은 원칙을 따른다.
+
+```txt
+GitHub Webhook ───────→ Cloudflare Worker POST /webhook/github ───────→ D1
+Workers Cron Trigger ─→ Cloudflare Worker scheduled() ────────────────→ D1 + Discord API
 ```
 
 초기 Worker URL 예시:
@@ -27,9 +38,9 @@ Discord interaction response
 https://<worker-subdomain>.workers.dev/discord/interactions
 ```
 
-## 이번 준비 범위
+## 현재 준비 범위
 
-이번 스캐폴드는 실제 cutover 전 준비 단계다.
+현재 스캐폴드는 실제 cutover 전 준비 단계다.
 
 추가된 Worker 기능:
 
@@ -40,16 +51,22 @@ https://<worker-subdomain>.workers.dev/discord/interactions
   - Discord PING 요청에 `{ "type": 1 }` 응답
   - application command에 임시 ephemeral scaffold 응답
 - `POST /webhook/github`
-  - 단계적 이전을 위한 기존 Render API 프록시
+  - endpoint는 존재하지만 Render proxy는 비활성화한다
+  - Cloudflare-native handler가 구현되기 전까지 `501`로 명시적으로 실패한다
 
 아직 하지 않은 것:
 
-- `/cycle current` 실제 비즈니스 로직 이식
-- DB 직접 연결 전략 확정
+- D1 schema/migration 확정
+- 기존 PostgreSQL data export/import runbook 작성
+- `/cycle current` 실제 비즈니스 로직을 D1 기반으로 이식
+- GitHub webhook signature 검증 및 submission recording을 Worker-native로 이식
+- reminder job을 Workers Cron Trigger로 이식
 - Discord Developer Portal Interactions Endpoint 등록
 - Render Gateway bot 비활성화
 
-## 필요한 Cloudflare secrets
+상세 구현 계획은 `docs/cloudflare-full-migration-plan.md`를 따른다.
+
+## 필요한 Cloudflare secrets / bindings
 
 실제 값은 커밋하지 않는다. 배포 전 Cloudflare에 secret으로 넣는다.
 
@@ -61,13 +78,24 @@ pnpm wrangler secret put DISCORD_BOT_TOKEN
 pnpm wrangler secret put GITHUB_WEBHOOK_SECRET
 ```
 
-일반 변수는 `apps/worker/wrangler.jsonc`에 들어 있다.
+D1은 Cloudflare에서 database를 만든 뒤 Worker binding으로 연결한다.
 
-```txt
-API_BASE_URL=https://donguel-donguel-notification.onrender.com
+```jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "donguel-donguel-notification",
+      "database_id": "<set-after-cloudflare-d1-create>",
+      "migrations_dir": "drizzle/d1"
+    }
+  ]
+}
 ```
 
-로컬 개발용 예시는 `apps/worker/.dev.vars.example`을 복사해서 사용한다.
+현재 scaffold PR에서는 실제 `database_id`를 커밋하지 않는다.
+
+로컬 개발용 secret 예시는 `apps/worker/.dev.vars.example`을 복사해서 사용한다.
 
 ```bash
 cp apps/worker/.dev.vars.example apps/worker/.dev.vars
@@ -85,7 +113,7 @@ pnpm --filter @hanghae-study/worker test
 pnpm worker:deploy:dry-run
 ```
 
-기존 서버 회귀 검증:
+기존 서버 회귀 검증이 필요한 PR에서는:
 
 ```bash
 cd apps/server
@@ -123,20 +151,23 @@ https://donguel-donguel-notification-worker.<account-subdomain>.workers.dev/disc
 
 ## Cutover 순서
 
-1. Cloudflare Worker secrets 설정
-2. `pnpm worker:deploy:dry-run`으로 배포 번들 검증
-3. `pnpm worker:deploy`로 Worker 배포
-4. Discord Developer Portal에서 Interactions Endpoint URL을 Worker `/discord/interactions`로 등록
-5. Discord PING 검증 통과 확인
-6. `/cycle current`부터 Worker HTTP interaction 방식으로 이식
-7. DB 접근 전략 결정
-   - 단기: Worker가 기존 Render API 호출
-   - 중기: Worker-compatible Postgres 접근
-   - 장기: 필요하면 D1 등 Cloudflare-native 저장소 검토
-8. Worker command handler가 안정화된 뒤 Render의 Gateway bot 시작을 끄거나 제거
+1. Cloudflare D1 database 생성
+2. D1 schema/migrations 작성 및 remote apply
+3. 기존 Postgres data export → D1 import
+4. D1 row count/current-cycle/submission 검증
+5. Cloudflare Worker secrets 설정
+6. `pnpm worker:deploy:dry-run`으로 배포 번들 검증
+7. `pnpm worker:deploy`로 Worker 배포
+8. Discord Developer Portal에서 Interactions Endpoint URL을 Worker `/discord/interactions`로 등록
+9. Discord PING 검증 통과 확인
+10. `/cycle current`를 D1 기반 Worker HTTP interaction으로 smoke test
+11. GitHub webhook URL을 Worker `/webhook/github`로 교체
+12. Workers Cron Trigger reminder smoke test
+13. 한 사이클 이상 안정화 확인 후 Render Gateway bot/service 중단
 
 ## 주의점
 
-- Worker로 바꿔도 Worker가 매번 Render API를 호출하면 Render sleep 지연이 다시 영향을 줄 수 있다.
-- Discord interaction은 짧은 시간 안에 응답해야 하므로, 오래 걸리는 작업은 deferred response/follow-up 설계가 필요하다.
+- Worker가 매번 Render API를 호출하면 Render sleep 지연이 다시 영향을 준다. 이 migration의 기본값은 no Render dependency다.
+- Discord interaction은 짧은 시간 안에 응답해야 하므로, 오래 걸리는 작업은 deferred response/follow-up 설계가 필요하다. 단, deferred background work도 D1/Queue/Discord API 같은 Cloudflare-native 경로여야 한다.
 - 기존 `discord.js`의 `deferReply()`, `editReply()` 중심 코드는 Worker에서 그대로 사용할 수 없다. Interaction response JSON 중심으로 재구성해야 한다.
+- 기존 Postgres schema는 `pgEnum`, `jsonb`, `timestamp` 등 Postgres 전용 타입을 사용하므로 D1로 옮길 때 SQLite/D1 schema를 별도로 정의해야 한다.


### PR DESCRIPTION
## Summary
- Adds `docs/cloudflare-full-migration-plan.md` for a no-Render, full Cloudflare migration path.
- Updates the existing Workers migration doc to make Render proxy explicitly non-default.
- Removes `API_BASE_URL` / `onrender.com` from the Worker scaffold config, env type, and `.dev.vars.example`.
- Changes `/webhook/github` scaffold from Render forwarding to an explicit `501` native-handler placeholder.
- Adds a Worker test asserting GitHub webhooks are not proxied via `fetch`.

## Direction
This PR intentionally does **not** implement the old bridge pattern:

```txt
Cloudflare Worker -> Render API
```

The target is:

```txt
Discord/GitHub/Cron -> Cloudflare Worker -> Cloudflare-native storage/bindings
```

## Test Plan
- [x] `pnpm --filter @hanghae-study/worker format`
- [x] `pnpm --filter @hanghae-study/worker type-check`
- [x] `pnpm --filter @hanghae-study/worker test`
- [x] `pnpm --filter @hanghae-study/worker exec wrangler deploy --dry-run`
- [x] `pnpm --filter @hanghae-study/worker format:check`
- [x] `git diff --check -- apps/worker docs pnpm-lock.yaml`

## Notes
- Wrangler dry-run reports `No bindings found` in this PR because D1 binding/database ID is deliberately left for the follow-up D1 setup PR.
- No real secrets are included.