### PR TITLE
feat: add D1-backed cycle current worker

### DIFF
--- a/apps/worker/migrations/0001_initial_d1_schema.sql
+++ b/apps/worker/migrations/0001_initial_d1_schema.sql
@@ -1,0 +1,247 @@
+-- D1 schema for the full Cloudflare Worker migration.
+-- Keep this schema Render/Postgres independent: SQLite-compatible types only.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS organizations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  slug TEXT NOT NULL UNIQUE,
+  discord_webhook_url TEXT,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS studies (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  organization_id INTEGER NOT NULL REFERENCES organizations(id),
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'ACTIVE',
+  default_cycle_count INTEGER NOT NULL DEFAULT 8,
+  default_cycle_duration_days INTEGER NOT NULL DEFAULT 14,
+  default_inactive_threshold_missed_cycles INTEGER NOT NULL DEFAULT 3,
+  default_discord_channel_id TEXT,
+  timezone TEXT NOT NULL DEFAULT 'Asia/Seoul',
+  metadata TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  archived_at TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS studies_org_slug_uidx ON studies(organization_id, slug);
+CREATE INDEX IF NOT EXISTS studies_org_idx ON studies(organization_id);
+CREATE INDEX IF NOT EXISTS studies_status_idx ON studies(status);
+
+CREATE TABLE IF NOT EXISTS members (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  discord_id TEXT NOT NULL UNIQUE,
+  discord_username TEXT,
+  discord_avatar TEXT,
+  github_username TEXT,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'ACTIVE',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS member_identities (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  member_id INTEGER NOT NULL REFERENCES members(id),
+  provider TEXT NOT NULL,
+  provider_user_id TEXT NOT NULL,
+  provider_node_id TEXT,
+  username TEXT,
+  display_name TEXT,
+  avatar_url TEXT,
+  raw_profile TEXT NOT NULL DEFAULT '{}',
+  is_primary INTEGER NOT NULL DEFAULT 1,
+  linked_at TEXT NOT NULL DEFAULT (datetime('now')),
+  unlinked_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS member_identities_provider_user_uidx ON member_identities(provider, provider_user_id);
+CREATE INDEX IF NOT EXISTS member_identities_member_idx ON member_identities(member_id);
+CREATE INDEX IF NOT EXISTS member_identities_provider_username_idx ON member_identities(provider, username);
+
+CREATE TABLE IF NOT EXISTS generations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  organization_id INTEGER NOT NULL REFERENCES organizations(id),
+  study_id INTEGER REFERENCES studies(id),
+  ordinal INTEGER,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'ACTIVE',
+  planned_cycle_count INTEGER NOT NULL DEFAULT 8,
+  cycle_duration_days INTEGER NOT NULL DEFAULT 14,
+  inactive_threshold_missed_cycles INTEGER NOT NULL DEFAULT 3,
+  discord_channel_id TEXT,
+  github_project_id TEXT,
+  github_project_number INTEGER,
+  github_project_url TEXT,
+  started_at TEXT NOT NULL,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  planned_at TEXT,
+  activated_at TEXT,
+  completed_at TEXT,
+  cancelled_at TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS generations_org_idx ON generations(organization_id);
+CREATE INDEX IF NOT EXISTS generations_study_idx ON generations(study_id);
+CREATE INDEX IF NOT EXISTS generations_org_ordinal_idx ON generations(organization_id, ordinal);
+CREATE INDEX IF NOT EXISTS generations_status_idx ON generations(status);
+
+CREATE TABLE IF NOT EXISTS cycles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  generation_id INTEGER NOT NULL REFERENCES generations(id),
+  week INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'SCHEDULED',
+  start_date TEXT NOT NULL,
+  end_date TEXT NOT NULL,
+  title_override TEXT,
+  github_issue_url TEXT,
+  github_issue_id TEXT,
+  github_issue_number INTEGER,
+  github_project_item_id TEXT,
+  opened_at TEXT,
+  closed_at TEXT,
+  completed_at TEXT,
+  cancelled_at TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS cycles_generation_week_uidx ON cycles(generation_id, week);
+CREATE INDEX IF NOT EXISTS cycles_generation_idx ON cycles(generation_id);
+CREATE INDEX IF NOT EXISTS cycles_status_idx ON cycles(status);
+CREATE INDEX IF NOT EXISTS cycles_date_range_idx ON cycles(start_date, end_date);
+
+CREATE TABLE IF NOT EXISTS organization_members (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  organization_id INTEGER NOT NULL REFERENCES organizations(id),
+  member_id INTEGER NOT NULL REFERENCES members(id),
+  role TEXT NOT NULL,
+  status TEXT NOT NULL,
+  joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS org_members_org_member_idx ON organization_members(organization_id, member_id);
+CREATE INDEX IF NOT EXISTS org_members_status_idx ON organization_members(status);
+
+CREATE TABLE IF NOT EXISTS generation_members (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  generation_id INTEGER NOT NULL REFERENCES generations(id),
+  member_id INTEGER NOT NULL REFERENCES members(id),
+  joined_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS gen_members_gen_member_idx ON generation_members(generation_id, member_id);
+
+CREATE TABLE IF NOT EXISTS generation_participants (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  generation_id INTEGER NOT NULL REFERENCES generations(id),
+  member_id INTEGER NOT NULL REFERENCES members(id),
+  status TEXT NOT NULL DEFAULT 'APPLIED',
+  applied_at TEXT NOT NULL DEFAULT (datetime('now')),
+  approved_at TEXT,
+  approved_by_member_id INTEGER REFERENCES members(id),
+  rejected_at TEXT,
+  rejected_by_member_id INTEGER REFERENCES members(id),
+  rejected_reason TEXT,
+  removed_at TEXT,
+  removed_by_member_id INTEGER REFERENCES members(id),
+  removed_reason TEXT,
+  marked_inactive_at TEXT,
+  inactive_reason TEXT,
+  reactivated_at TEXT,
+  reactivated_by_member_id INTEGER REFERENCES members(id),
+  reactivated_reason TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS generation_participants_generation_member_uidx ON generation_participants(generation_id, member_id);
+CREATE INDEX IF NOT EXISTS generation_participants_status_idx ON generation_participants(status);
+
+CREATE TABLE IF NOT EXISTS generation_participant_roles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  generation_participant_id INTEGER NOT NULL REFERENCES generation_participants(id),
+  role TEXT NOT NULL,
+  assigned_at TEXT NOT NULL DEFAULT (datetime('now')),
+  assigned_by_member_id INTEGER REFERENCES members(id),
+  revoked_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS generation_participant_roles_role_idx ON generation_participant_roles(generation_participant_id, role);
+
+CREATE TABLE IF NOT EXISTS submissions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cycle_id INTEGER NOT NULL REFERENCES cycles(id),
+  member_id INTEGER NOT NULL REFERENCES members(id),
+  generation_participant_id INTEGER REFERENCES generation_participants(id),
+  url TEXT NOT NULL,
+  normalized_url TEXT,
+  status TEXT NOT NULL DEFAULT 'ACCEPTED',
+  timing_status TEXT NOT NULL DEFAULT 'ON_TIME',
+  accessibility_status TEXT NOT NULL DEFAULT 'UNKNOWN',
+  submitted_at TEXT NOT NULL DEFAULT (datetime('now')),
+  source_type TEXT NOT NULL DEFAULT 'GITHUB_ISSUE_COMMENT',
+  source_github_comment_id TEXT,
+  source_github_comment_url TEXT,
+  source_github_issue_id TEXT,
+  source_github_issue_number INTEGER,
+  github_comment_id TEXT UNIQUE,
+  invalid_reason TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS submissions_cycle_member_idx ON submissions(cycle_id, member_id);
+CREATE INDEX IF NOT EXISTS submissions_participant_idx ON submissions(generation_participant_id);
+CREATE INDEX IF NOT EXISTS submissions_status_idx ON submissions(status);
+
+CREATE TABLE IF NOT EXISTS submission_candidates (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cycle_id INTEGER REFERENCES cycles(id),
+  generation_id INTEGER REFERENCES generations(id),
+  external_provider TEXT NOT NULL,
+  external_username TEXT NOT NULL,
+  external_user_id TEXT,
+  raw_comment_body TEXT NOT NULL,
+  extracted_urls TEXT NOT NULL DEFAULT '[]',
+  source_github_comment_id TEXT,
+  source_github_comment_url TEXT,
+  source_github_issue_id TEXT,
+  source_github_issue_number INTEGER,
+  status TEXT NOT NULL DEFAULT 'PENDING_IDENTITY_MAPPING',
+  reason TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  resolved_at TEXT,
+  resolved_by_member_id INTEGER REFERENCES members(id)
+);
+
+CREATE INDEX IF NOT EXISTS submission_candidates_cycle_idx ON submission_candidates(cycle_id);
+CREATE INDEX IF NOT EXISTS submission_candidates_status_idx ON submission_candidates(status);
+CREATE INDEX IF NOT EXISTS submission_candidates_external_idx ON submission_candidates(external_provider, external_username);
+
+CREATE TABLE IF NOT EXISTS notification_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider TEXT NOT NULL DEFAULT 'DISCORD',
+  channel_id TEXT NOT NULL,
+  message_type TEXT NOT NULL,
+  payload TEXT NOT NULL DEFAULT '{}',
+  external_message_id TEXT,
+  sent_at TEXT,
+  failed_at TEXT,
+  error_message TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/apps/worker/src/cycle-current.ts
+++ b/apps/worker/src/cycle-current.ts
@@ -1,0 +1,177 @@
+const DEFAULT_ORGANIZATION_SLUG = "donguel-donguel";
+const DISCORD_RESPONSE_CHANNEL_MESSAGE_WITH_SOURCE = 4;
+
+interface CurrentCycleRow {
+  id: number;
+  week: number;
+  generation_name: string;
+  organization_slug: string;
+  start_date: string;
+  end_date: string;
+  github_issue_url: string | null;
+  required_count: number | null;
+  submitted_count: number | null;
+}
+
+interface SubmittedMemberRow {
+  name: string;
+  github_username: string | null;
+  url: string;
+}
+
+interface NotSubmittedMemberRow {
+  name: string;
+  github_username: string | null;
+}
+
+export interface DiscordInteractionResponse {
+  type: number;
+  data?: {
+    content: string;
+    flags?: number;
+  };
+}
+
+function formatRemainingTime(endDate: string): string {
+  const end = new Date(endDate).getTime();
+  const now = Date.now();
+  const remainingHours = Math.max(0, Math.floor((end - now) / 3_600_000));
+  const days = Math.floor(remainingHours / 24);
+  const hours = remainingHours % 24;
+
+  if (days <= 0 && hours <= 0) return "오늘 마감";
+  if (days <= 0) return `마감까지 ${hours}시간`;
+  return `마감까지 ${days}일 ${hours}시간`;
+}
+
+function formatName(row: { name: string; github_username: string | null }) {
+  return row.github_username
+    ? `${row.name} (@${row.github_username})`
+    : row.name;
+}
+
+function formatSubmitted(rows: SubmittedMemberRow[]) {
+  if (rows.length === 0) return "아직 제출자가 없어요.";
+  return rows
+    .slice(0, 10)
+    .map((row) => `- ${formatName(row)}: ${row.url}`)
+    .join("\n");
+}
+
+function formatNotSubmitted(rows: NotSubmittedMemberRow[]) {
+  if (rows.length === 0) return "전원 제출 완료";
+  return rows
+    .slice(0, 15)
+    .map((row) => `- ${formatName(row)}`)
+    .join("\n");
+}
+
+export async function createCycleCurrentResponse(
+  db: D1Database,
+  organizationSlug = DEFAULT_ORGANIZATION_SLUG,
+): Promise<DiscordInteractionResponse> {
+  const cycle = await db
+    .prepare(
+      `
+      SELECT
+        c.id,
+        c.week,
+        g.name AS generation_name,
+        o.slug AS organization_slug,
+        c.start_date,
+        c.end_date,
+        c.github_issue_url,
+        COUNT(DISTINCT gp.member_id) AS required_count,
+        COUNT(DISTINCT s.member_id) AS submitted_count
+      FROM cycles c
+      INNER JOIN generations g ON g.id = c.generation_id
+      INNER JOIN organizations o ON o.id = g.organization_id
+      LEFT JOIN generation_participants gp
+        ON gp.generation_id = g.id
+       AND gp.status = 'APPROVED'
+      LEFT JOIN submissions s
+        ON s.cycle_id = c.id
+       AND s.status = 'ACCEPTED'
+      WHERE o.slug = ?
+        AND c.status IN ('OPEN', 'SCHEDULED')
+        AND datetime(c.start_date) <= datetime('now')
+        AND datetime(c.end_date) >= datetime('now')
+      GROUP BY c.id, g.name, o.slug
+      ORDER BY datetime(c.start_date) DESC, c.id DESC
+      LIMIT 1
+    `,
+    )
+    .bind(organizationSlug)
+    .first<CurrentCycleRow>();
+
+  if (!cycle) {
+    return {
+      type: DISCORD_RESPONSE_CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content:
+          "🗓️ **현재 진행 중인 주차를 찾지 못했어요.**\n\n" +
+          "운영자라면 `/cycle create`로 주차를 열었는지 확인해 주세요.\n" +
+          "Cloudflare Worker는 Render API를 깨우지 않고 D1에서 직접 조회합니다.",
+      },
+    };
+  }
+
+  const submitted = await db
+    .prepare(
+      `
+      SELECT m.name, m.github_username, s.url
+      FROM submissions s
+      INNER JOIN members m ON m.id = s.member_id
+      WHERE s.cycle_id = ?
+        AND s.status = 'ACCEPTED'
+      ORDER BY datetime(s.submitted_at) ASC, m.name ASC
+      -- submitted_members
+    `,
+    )
+    .bind(cycle.id)
+    .all<SubmittedMemberRow>();
+
+  const notSubmitted = await db
+    .prepare(
+      `
+      SELECT m.name, m.github_username
+      FROM generation_participants gp
+      INNER JOIN members m ON m.id = gp.member_id
+      LEFT JOIN submissions s
+        ON s.cycle_id = ?
+       AND s.member_id = gp.member_id
+       AND s.status = 'ACCEPTED'
+      WHERE gp.generation_id = (
+        SELECT generation_id FROM cycles WHERE id = ?
+      )
+        AND gp.status = 'APPROVED'
+        AND s.id IS NULL
+      ORDER BY m.name ASC
+      -- not_submitted_members
+    `,
+    )
+    .bind(cycle.id, cycle.id)
+    .all<NotSubmittedMemberRow>();
+
+  const requiredCount = Number(cycle.required_count ?? 0);
+  const submittedCount = Number(
+    cycle.submitted_count ?? submitted.results.length,
+  );
+  const notSubmittedCount = Math.max(requiredCount - submittedCount, 0);
+  const issueLine = cycle.github_issue_url
+    ? `\n이슈: ${cycle.github_issue_url}`
+    : "";
+
+  return {
+    type: DISCORD_RESPONSE_CHANNEL_MESSAGE_WITH_SOURCE,
+    data: {
+      content:
+        `📚 **${cycle.generation_name} ${cycle.week}주차**\n` +
+        `${formatRemainingTime(cycle.end_date)}${issueLine}\n\n` +
+        `제출 현황: ${submittedCount}/${requiredCount}명 제출, ${notSubmittedCount}명 미제출\n\n` +
+        `✅ 제출자\n${formatSubmitted(submitted.results)}\n\n` +
+        `🕐 미제출자\n${formatNotSubmitted(notSubmitted.results)}\n\n` +
+        "다음 행동: 제출자는 `/submit url:<글 URL>`로 기록하고, 본인 상태는 `/me info`로 확인해 주세요.",
+    },
+  };
+}

--- a/apps/worker/src/discord.ts
+++ b/apps/worker/src/discord.ts
@@ -9,6 +9,10 @@ export interface DiscordInteraction {
   type: number;
   data?: {
     name?: string;
+    options?: Array<{
+      type: number;
+      name: string;
+    }>;
   };
 }
 
@@ -89,11 +93,23 @@ export function createDiscordInteractionResponse(
       type: DISCORD_RESPONSE_CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
         content:
-          "Cloudflare Worker 전환 준비가 완료되었어요. `/cycle current` 이식은 다음 단계에서 연결합니다.",
+          "Cloudflare Worker 전환 준비가 완료되었어요. 지원하지 않는 명령은 Cloudflare-native handler로 순차 이식합니다.",
         flags: DISCORD_EPHEMERAL_FLAG,
       },
     };
   }
 
   return null;
+}
+
+export function isCycleCurrentCommand(
+  interaction: DiscordInteraction,
+): boolean {
+  return (
+    interaction.type === DISCORD_APPLICATION_COMMAND &&
+    interaction.data?.name === "cycle" &&
+    interaction.data.options?.some(
+      (option) => option.type === 1 && option.name === "current",
+    ) === true
+  );
 }

--- a/apps/worker/src/github-webhook.ts
+++ b/apps/worker/src/github-webhook.ts
@@ -1,0 +1,201 @@
+const GITHUB_SIGNATURE_PREFIX = "sha256=";
+
+interface GithubIssueCommentPayload {
+  action?: string;
+  comment?: {
+    id?: number | string;
+    body?: string;
+    user?: {
+      login?: string;
+    };
+  };
+  issue?: {
+    html_url?: string;
+  };
+}
+
+interface SubmissionTargetRow {
+  cycle_id: number;
+  member_id: number;
+  member_name: string;
+  generation_name: string;
+  organization_slug: string;
+  cycle_week: number;
+}
+
+export interface GithubWebhookResult {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+export async function verifyGithubWebhookSignature({
+  body,
+  secret,
+  signature,
+}: {
+  body: string;
+  secret: string;
+  signature: string | null;
+}): Promise<boolean> {
+  if (!signature?.startsWith(GITHUB_SIGNATURE_PREFIX) || !secret) {
+    return false;
+  }
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const digest = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(body),
+  );
+  const expected = `${GITHUB_SIGNATURE_PREFIX}${toHex(digest)}`;
+
+  return constantTimeEqual(expected, signature);
+}
+
+export async function handleGithubWebhook({
+  db,
+  event,
+  body,
+}: {
+  db: D1Database;
+  event: string | null;
+  body: string;
+}): Promise<GithubWebhookResult> {
+  if (event !== "issue_comment") {
+    return {
+      status: 202,
+      body: { message: "GitHub event ignored", event },
+    };
+  }
+
+  let payload: GithubIssueCommentPayload;
+  try {
+    payload = JSON.parse(body) as GithubIssueCommentPayload;
+  } catch {
+    return {
+      status: 400,
+      body: { message: "Invalid GitHub webhook payload" },
+    };
+  }
+
+  if (payload.action !== "created") {
+    return {
+      status: 202,
+      body: {
+        message: "GitHub issue_comment action ignored",
+        action: payload.action,
+      },
+    };
+  }
+
+  const blogUrl = extractFirstUrl(payload.comment?.body ?? "");
+  if (!blogUrl) {
+    return {
+      status: 400,
+      body: { message: "No URL found in comment" },
+    };
+  }
+
+  const githubUsername = payload.comment?.user?.login;
+  const githubIssueUrl = payload.issue?.html_url;
+  const githubCommentId = String(payload.comment?.id ?? "");
+  if (!githubUsername || !githubIssueUrl || !githubCommentId) {
+    return {
+      status: 400,
+      body: { message: "Missing GitHub submission fields" },
+    };
+  }
+
+  const target = await db
+    .prepare(
+      `
+      SELECT
+        c.id AS cycle_id,
+        c.week AS cycle_week,
+        m.id AS member_id,
+        m.name AS member_name,
+        g.name AS generation_name,
+        o.slug AS organization_slug
+      FROM cycles c
+      INNER JOIN generations g ON g.id = c.generation_id
+      INNER JOIN organizations o ON o.id = g.organization_id
+      INNER JOIN organization_members om ON om.organization_id = o.id AND om.status = 'approved'
+      INNER JOIN members m ON m.id = om.member_id
+      WHERE c.github_issue_url = ?
+        AND m.github_username = ?
+      LIMIT 1
+      `,
+    )
+    .bind(githubIssueUrl, githubUsername)
+    .first<SubmissionTargetRow>();
+
+  if (!target) {
+    return {
+      status: 404,
+      body: { message: "No active member/cycle found for GitHub submission" },
+    };
+  }
+
+  await db
+    .prepare(
+      `
+      INSERT INTO submissions (
+        cycle_id,
+        member_id,
+        url,
+        github_comment_id,
+        submitted_at,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), datetime('now'))
+      ON CONFLICT(github_comment_id) DO UPDATE SET
+        url = excluded.url,
+        submitted_at = excluded.submitted_at,
+        updated_at = datetime('now')
+      `,
+    )
+    .bind(target.cycle_id, target.member_id, blogUrl, githubCommentId)
+    .run();
+
+  return {
+    status: 200,
+    body: {
+      message: "Submission recorded",
+      memberName: target.member_name,
+      generationName: target.generation_name,
+      organizationSlug: target.organization_slug,
+      cycleWeek: target.cycle_week,
+      submittedUrl: blogUrl,
+    },
+  };
+}
+
+function extractFirstUrl(text: string): string | null {
+  return text.match(/https?:\/\/[^\s)]+/)?.[0] ?? null;
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const leftBytes = new TextEncoder().encode(left);
+  const rightBytes = new TextEncoder().encode(right);
+  if (leftBytes.length !== rightBytes.length) {
+    return false;
+  }
+
+  let diff = 0;
+  for (let index = 0; index < leftBytes.length; index += 1) {
+    diff |= leftBytes[index] ^ rightBytes[index];
+  }
+  return diff === 0;
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,9 +1,11 @@
 import { Hono } from "hono";
 import {
   createDiscordInteractionResponse,
+  isCycleCurrentCommand,
   verifyDiscordRequest,
   type DiscordInteraction,
 } from "./discord";
+import { createCycleCurrentResponse } from "./cycle-current";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -37,7 +39,9 @@ app.post("/discord/interactions", async (context) => {
     return context.text("invalid interaction payload", 400);
   }
 
-  const response = createDiscordInteractionResponse(interaction);
+  const response = isCycleCurrentCommand(interaction)
+    ? await createCycleCurrentResponse(context.env.DB)
+    : createDiscordInteractionResponse(interaction);
   if (!response) {
     return context.text("unsupported interaction type", 400);
   }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,6 +6,11 @@ import {
   type DiscordInteraction,
 } from "./discord";
 import { createCycleCurrentResponse } from "./cycle-current";
+import {
+  handleGithubWebhook,
+  verifyGithubWebhookSignature,
+} from "./github-webhook";
+import { runDeadlineReminders } from "./scheduled-reminders";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -49,15 +54,35 @@ app.post("/discord/interactions", async (context) => {
   return context.json(response);
 });
 
-app.post("/webhook/github", (context) => {
-  return context.json(
-    {
-      error: "github_webhook_native_handler_not_implemented",
-      message:
-        "GitHub webhook must be handled natively in Cloudflare Worker; Render proxy is disabled.",
-    },
-    501,
-  );
+app.post("/webhook/github", async (context) => {
+  const body = await context.req.text();
+  const signature = context.req.header("x-hub-signature-256") ?? null;
+  const verified = await verifyGithubWebhookSignature({
+    body,
+    secret: context.env.GITHUB_WEBHOOK_SECRET,
+    signature,
+  });
+
+  if (!verified) {
+    return context.text("invalid GitHub webhook signature", 401);
+  }
+
+  const result = await handleGithubWebhook({
+    db: context.env.DB,
+    event: context.req.header("x-github-event") ?? null,
+    body,
+  });
+
+  return context.json(result.body, result.status as 200);
 });
 
-export default app;
+export default {
+  fetch: app.fetch,
+  async scheduled(
+    _event: ScheduledController,
+    env: Env,
+    _context: ExecutionContext,
+  ): Promise<void> {
+    await runDeadlineReminders(env);
+  },
+};

--- a/apps/worker/src/scheduled-reminders.ts
+++ b/apps/worker/src/scheduled-reminders.ts
@@ -1,0 +1,108 @@
+interface ReminderCycleRow {
+  cycle_id: number;
+  cycle_week: number;
+  generation_name: string;
+  organization_slug: string;
+  github_issue_url: string | null;
+  end_date: string;
+  missing_members: string | null;
+  reminder_key: string;
+}
+
+export async function runDeadlineReminders(env: Env): Promise<void> {
+  if (!env.DISCORD_WEBHOOK_URL) {
+    console.warn("DISCORD_WEBHOOK_URL is not configured; skipping reminders");
+    return;
+  }
+
+  const reminders = await findUpcomingDeadlineReminders(env.DB);
+
+  for (const reminder of reminders) {
+    const content = formatReminderMessage(reminder);
+    const response = await fetch(env.DISCORD_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+
+    await env.DB.prepare(
+      `
+        INSERT INTO notification_logs (
+          provider,
+          channel_id,
+          message_type,
+          payload,
+          sent_at,
+          failed_at,
+          error_message,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+        `,
+    )
+      .bind(
+        "DISCORD",
+        "DISCORD_WEBHOOK_URL",
+        reminder.reminder_key,
+        JSON.stringify({ cycleId: reminder.cycle_id, status: response.status }),
+        response.ok ? new Date().toISOString() : null,
+        response.ok ? null : new Date().toISOString(),
+        response.ok ? null : `Discord webhook responded ${response.status}`,
+      )
+      .run();
+  }
+}
+
+async function findUpcomingDeadlineReminders(
+  db: D1Database,
+): Promise<ReminderCycleRow[]> {
+  const result = await db
+    .prepare(
+      `
+      SELECT
+        c.id AS cycle_id,
+        c.week AS cycle_week,
+        g.name AS generation_name,
+        o.slug AS organization_slug,
+        c.github_issue_url AS github_issue_url,
+        c.end_date AS end_date,
+        GROUP_CONCAT(m.name || '(' || COALESCE(m.github_username, 'github-missing') || ')', ', ') AS missing_members,
+        'cycle:' || c.id || ':deadline-minus-1d' AS reminder_key
+      FROM cycles c
+      INNER JOIN generations g ON g.id = c.generation_id
+      INNER JOIN organizations o ON o.id = g.organization_id
+      INNER JOIN generation_participants gp ON gp.generation_id = g.id AND gp.status = 'APPROVED'
+      INNER JOIN members m ON m.id = gp.member_id
+      LEFT JOIN submissions s ON s.cycle_id = c.id AND s.member_id = m.id AND s.status = 'ACCEPTED'
+      WHERE c.status IN ('ACTIVE', 'OPEN')
+        AND s.id IS NULL
+        AND datetime(c.end_date) <= datetime('now', '+1 day')
+        AND datetime(c.end_date) >= datetime('now')
+        AND NOT EXISTS (
+          SELECT 1
+          FROM notification_logs nl
+          WHERE nl.message_type = 'cycle:' || c.id || ':deadline-minus-1d'
+            AND nl.sent_at IS NOT NULL
+        )
+      GROUP BY c.id, c.week, g.name, o.slug, c.github_issue_url, c.end_date
+      ORDER BY c.end_date ASC
+      `,
+    )
+    .bind()
+    .all<ReminderCycleRow>();
+
+  return result.results;
+}
+
+function formatReminderMessage(reminder: ReminderCycleRow): string {
+  const issueLine = reminder.github_issue_url
+    ? `\n제출 이슈: ${reminder.github_issue_url}`
+    : "";
+  const missingMembers = reminder.missing_members || "미제출자 없음";
+
+  return [
+    `⏰ **${reminder.generation_name} ${reminder.cycle_week}주차 제출 마감이 다가오고 있어요.**`,
+    `마감: ${reminder.end_date}`,
+    `아직 제출 확인이 필요한 멤버: ${missingMembers}`,
+    `제출 댓글을 GitHub 이슈에 남기면 Worker가 D1에 바로 기록합니다.${issueLine}`,
+  ].join("\n");
+}

--- a/apps/worker/test/discord.test.ts
+++ b/apps/worker/test/discord.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createDiscordInteractionResponse,
   verifyDiscordRequest,
@@ -9,19 +9,35 @@ class FakeD1Database {
   constructor(
     private readonly rows: Record<string, unknown[]> = {},
     private readonly calls: string[] = [],
+    private readonly writes: Array<{ query: string; values: unknown[] }> = [],
   ) {}
 
   prepare(query: string) {
     this.calls.push(query);
     return {
-      bind: (..._values: unknown[]) => ({
-        first: async <T = unknown>() =>
-          (this.rows.currentCycle?.[0] ?? null) as T | null,
-        all: async <T = unknown>() => ({
-          results: (query.includes("submitted_members")
-            ? (this.rows.submittedMembers ?? [])
-            : (this.rows.notSubmittedMembers ?? [])) as T[],
-        }),
+      bind: (...values: unknown[]) => ({
+        first: async <T = unknown>() => {
+          if (query.includes("m.github_username")) {
+            return (this.rows.githubSubmissionTarget?.[0] ?? null) as T | null;
+          }
+
+          return (this.rows.currentCycle?.[0] ?? null) as T | null;
+        },
+        all: async <T = unknown>() => {
+          let results: unknown[];
+          if (query.includes("submitted_members")) {
+            results = this.rows.submittedMembers ?? [];
+          } else if (query.includes("reminder_key")) {
+            results = this.rows.reminderCycles ?? [];
+          } else {
+            results = this.rows.notSubmittedMembers ?? [];
+          }
+          return { results: results as T[] };
+        },
+        run: async () => {
+          this.writes.push({ query, values });
+          return { success: true, meta: {} } as D1Result;
+        },
       }),
     };
   }
@@ -41,6 +57,10 @@ class FakeD1Database {
   getQueries() {
     return this.calls;
   }
+
+  getWrites() {
+    return this.writes;
+  }
 }
 
 const env: Env = {
@@ -49,8 +69,34 @@ const env: Env = {
     "0000000000000000000000000000000000000000000000000000000000000000",
   DISCORD_APPLICATION_ID: "1457578741097042114",
   DISCORD_BOT_TOKEN: "test-token",
+  DISCORD_WEBHOOK_URL: "https://discord.example.test/webhook",
   GITHUB_WEBHOOK_SECRET: "test-secret",
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function githubSignature(
+  body: string,
+  secret = env.GITHUB_WEBHOOK_SECRET,
+) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const digest = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(body),
+  );
+  return `sha256=${Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
 
 describe("notification Cloudflare Worker", () => {
   it("returns health information without waking Render", async () => {
@@ -180,23 +226,123 @@ describe("notification Cloudflare Worker", () => {
     expect(d1.getQueries().join("\n")).toContain("FROM cycles");
   });
 
-  it("does not proxy GitHub webhooks to Render", async () => {
+  it("records GitHub issue_comment submissions in D1 without calling Render", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const d1 = new FakeD1Database({
+      githubSubmissionTarget: [
+        {
+          cycle_id: 7,
+          member_id: 42,
+          member_name: "박준형",
+          generation_name: "똥글똥글 2기",
+          organization_slug: "donguel-donguel",
+          cycle_week: 7,
+        },
+      ],
+    });
+    const body = JSON.stringify({
+      action: "created",
+      comment: {
+        id: 12345,
+        body: "제출합니다 https://blog.dev/week-7",
+        user: { login: "BBAK-jun" },
+      },
+      issue: {
+        html_url: "https://github.com/hanghae-story-forge/archive/issues/16",
+      },
+    });
 
     const response = await worker.fetch(
       new Request("https://worker.example.test/webhook/github", {
         method: "POST",
+        headers: {
+          "x-github-event": "issue_comment",
+          "x-hub-signature-256": await githubSignature(body),
+        },
+        body,
+      }),
+      { ...env, DB: d1 as unknown as D1Database },
+      {} as ExecutionContext,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      message: "Submission recorded",
+      memberName: "박준형",
+      cycleWeek: 7,
+    });
+    expect(d1.getWrites()).toHaveLength(1);
+    expect(d1.getWrites()[0]?.query).toContain("INSERT INTO submissions");
+    expect(d1.getWrites()[0]?.values).toEqual([
+      7,
+      42,
+      "https://blog.dev/week-7",
+      "12345",
+    ]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects GitHub webhooks with an invalid signature", async () => {
+    const response = await worker.fetch(
+      new Request("https://worker.example.test/webhook/github", {
+        method: "POST",
+        headers: {
+          "x-github-event": "issue_comment",
+          "x-hub-signature-256": "sha256=bad",
+        },
         body: JSON.stringify({ action: "created" }),
       }),
       env,
       {} as ExecutionContext,
     );
 
-    expect(response.status).toBe(501);
-    await expect(response.json()).resolves.toMatchObject({
-      error: "github_webhook_native_handler_not_implemented",
+    expect(response.status).toBe(401);
+  });
+
+  it("sends upcoming deadline reminders from Workers Cron and records a D1 log", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const d1 = new FakeD1Database({
+      reminderCycles: [
+        {
+          cycle_id: 7,
+          cycle_week: 7,
+          generation_name: "똥글똥글 2기",
+          organization_slug: "donguel-donguel",
+          github_issue_url:
+            "https://github.com/hanghae-story-forge/archive/issues/16",
+          end_date: "2999-05-26T14:59:59.000Z",
+          missing_members: "미제출(missing), 김항해(hanghae)",
+          reminder_key: "cycle:7:deadline-minus-1d",
+        },
+      ],
     });
-    expect(fetchSpy).not.toHaveBeenCalled();
+
+    await (
+      worker as unknown as {
+        scheduled: (
+          event: ScheduledController,
+          env: Env,
+          context: ExecutionContext,
+        ) => Promise<void>;
+      }
+    ).scheduled(
+      { cron: "0 0 * * *", scheduledTime: Date.now(), noRetry: vi.fn() },
+      { ...env, DB: d1 as unknown as D1Database },
+      {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      } as unknown as ExecutionContext,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      env.DISCORD_WEBHOOK_URL,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(
+      d1.getWrites().some((write) => write.query.includes("notification_logs")),
+    ).toBe(true);
   });
 
   it("verifies Discord signatures using timestamp plus raw body", async () => {

--- a/apps/worker/test/discord.test.ts
+++ b/apps/worker/test/discord.test.ts
@@ -5,7 +5,46 @@ import {
 } from "../src/discord";
 import worker from "../src/index";
 
+class FakeD1Database {
+  constructor(
+    private readonly rows: Record<string, unknown[]> = {},
+    private readonly calls: string[] = [],
+  ) {}
+
+  prepare(query: string) {
+    this.calls.push(query);
+    return {
+      bind: (..._values: unknown[]) => ({
+        first: async <T = unknown>() =>
+          (this.rows.currentCycle?.[0] ?? null) as T | null,
+        all: async <T = unknown>() => ({
+          results: (query.includes("submitted_members")
+            ? (this.rows.submittedMembers ?? [])
+            : (this.rows.notSubmittedMembers ?? [])) as T[],
+        }),
+      }),
+    };
+  }
+
+  dump(): Promise<ArrayBuffer> {
+    throw new Error("not implemented");
+  }
+
+  batch<T = unknown>(): Promise<D1Result<T>[]> {
+    throw new Error("not implemented");
+  }
+
+  exec(): Promise<D1ExecResult> {
+    throw new Error("not implemented");
+  }
+
+  getQueries() {
+    return this.calls;
+  }
+}
+
 const env: Env = {
+  DB: new FakeD1Database() as unknown as D1Database,
   DISCORD_PUBLIC_KEY:
     "0000000000000000000000000000000000000000000000000000000000000000",
   DISCORD_APPLICATION_ID: "1457578741097042114",
@@ -67,17 +106,78 @@ describe("notification Cloudflare Worker", () => {
   it("returns a scaffold response for application commands", async () => {
     const response = createDiscordInteractionResponse({
       type: 2,
-      data: { name: "cycle" },
+      data: { name: "unknown" },
     });
 
     expect(response).toEqual({
       type: 4,
       data: {
         content:
-          "Cloudflare Worker 전환 준비가 완료되었어요. `/cycle current` 이식은 다음 단계에서 연결합니다.",
+          "Cloudflare Worker 전환 준비가 완료되었어요. 지원하지 않는 명령은 Cloudflare-native handler로 순차 이식합니다.",
         flags: 64,
       },
     });
+  });
+
+  it("handles /cycle current from D1 without calling Render", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const d1 = new FakeD1Database({
+      currentCycle: [
+        {
+          id: 7,
+          week: 7,
+          generation_name: "똥글똥글 2기",
+          organization_slug: "donguel-donguel",
+          start_date: "2026-05-12T00:00:00.000Z",
+          end_date: "2999-05-26T14:59:59.000Z",
+          github_issue_url:
+            "https://github.com/hanghae-story-forge/archive/issues/16",
+          required_count: 3,
+          submitted_count: 2,
+        },
+      ],
+      submittedMembers: [
+        {
+          name: "박준형",
+          github_username: "BBAK-jun",
+          url: "https://blog.dev/post",
+        },
+        {
+          name: "김항해",
+          github_username: "hanghae",
+          url: "https://blog.dev/2",
+        },
+      ],
+      notSubmittedMembers: [{ name: "미제출", github_username: "missing" }],
+    });
+    const response = await worker.fetch(
+      new Request("https://worker.example.test/discord/interactions", {
+        method: "POST",
+        headers: {
+          "x-signature-ed25519": "00".repeat(64),
+          "x-signature-timestamp": "1710000000",
+        },
+        body: JSON.stringify({
+          type: 2,
+          data: {
+            name: "cycle",
+            options: [{ type: 1, name: "current" }],
+          },
+        }),
+      }),
+      { ...env, DB: d1 as unknown as D1Database },
+      {} as ExecutionContext,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      type: 4,
+      data: {
+        content: expect.stringContaining("똥글똥글 2기 7주차"),
+      },
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(d1.getQueries().join("\n")).toContain("FROM cycles");
   });
 
   it("does not proxy GitHub webhooks to Render", async () => {

--- a/apps/worker/worker-configuration.d.ts
+++ b/apps/worker/worker-configuration.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 declare namespace Cloudflare {
   interface Env {
+    DB: D1Database;
     DISCORD_PUBLIC_KEY: string;
     DISCORD_APPLICATION_ID: string;
     DISCORD_BOT_TOKEN: string;

--- a/apps/worker/worker-configuration.d.ts
+++ b/apps/worker/worker-configuration.d.ts
@@ -5,6 +5,7 @@ declare namespace Cloudflare {
     DISCORD_PUBLIC_KEY: string;
     DISCORD_APPLICATION_ID: string;
     DISCORD_BOT_TOKEN: string;
+    DISCORD_WEBHOOK_URL: string;
     GITHUB_WEBHOOK_SECRET: string;
   }
 }

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -6,5 +6,13 @@
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true
-  }
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "donguel-donguel-notification",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "migrations"
+    }
+  ]
 }

--- a/apps/worker/wrangler.jsonc
+++ b/apps/worker/wrangler.jsonc
@@ -7,6 +7,9 @@
   "observability": {
     "enabled": true
   },
+  "triggers": {
+    "crons": ["0 0 * * *"]
+  },
   "d1_databases": [
     {
       "binding": "DB",

--- a/docs/cloudflare-full-migration-plan.md
+++ b/docs/cloudflare-full-migration-plan.md
@@ -341,25 +341,70 @@ export interface CurrentCycleRepository {
 
 ## Phase 5: Cutover checklist
 
-1. Create Cloudflare D1 database.
-2. Fill `database_id` in `apps/worker/wrangler.jsonc` or environment-specific config.
-3. Apply D1 migrations locally and remotely.
-4. Export current Postgres data using secure local env; import to D1.
-5. Validate row counts and spot-check current cycle/submission status.
-6. Deploy Worker.
-7. Register Discord Interactions Endpoint URL:
+### Cloudflare resources and secrets
+
+1. Create the Cloudflare D1 database.
+2. Replace the zero UUID placeholder in `apps/worker/wrangler.jsonc` with the real D1 `database_id`.
+3. Apply migrations:
+
+```bash
+export PATH="$HOME/.hermes/node/bin:$PATH"
+pnpm --filter @hanghae-study/worker exec wrangler d1 migrations apply donguel-donguel-notification --remote
+```
+
+4. Set Worker secrets. Do not commit or print real values.
+
+```bash
+pnpm --filter @hanghae-study/worker exec wrangler secret put DISCORD_PUBLIC_KEY
+pnpm --filter @hanghae-study/worker exec wrangler secret put DISCORD_APPLICATION_ID
+pnpm --filter @hanghae-study/worker exec wrangler secret put DISCORD_BOT_TOKEN
+pnpm --filter @hanghae-study/worker exec wrangler secret put DISCORD_WEBHOOK_URL
+pnpm --filter @hanghae-study/worker exec wrangler secret put GITHUB_WEBHOOK_SECRET
+```
+
+5. Export current Postgres data using secure local env; import to D1.
+6. Validate row counts and spot-check:
+   - organizations / generations / cycles
+   - members / generation_participants / organization_members
+   - submissions / notification_logs
+
+### Endpoint switch
+
+7. Deploy Worker:
+
+```bash
+pnpm --filter @hanghae-study/worker exec wrangler deploy
+```
+
+8. Register Discord Developer Portal Interactions Endpoint URL:
 
 ```txt
 https://<worker-domain>/discord/interactions
 ```
 
-8. Update GitHub webhook URL to Worker `/webhook/github`.
-9. Run Discord smoke tests:
-   - `/cycle current`
-   - submission comment → D1 row + Discord notification
-   - reminder scheduled dry-run/manual endpoint if present
-10. Disable Render Gateway bot start.
-11. Turn Render service read-only/stop after one full cycle passes.
+9. Update GitHub webhook URL to:
+
+```txt
+https://<worker-domain>/webhook/github
+```
+
+Use the same `GITHUB_WEBHOOK_SECRET` value configured in Cloudflare.
+
+### Smoke verification
+
+10. Run smoke tests:
+    - Discord `/cycle current` returns current D1-backed status.
+    - GitHub issue comment with a blog URL creates/updates a D1 `submissions` row.
+    - GitHub issue comment with invalid signature returns `401`.
+    - Worker Cron sends a Discord reminder and writes `notification_logs`.
+    - No Worker request hits `*.onrender.com`.
+
+### Render decommission
+
+11. Disable Render Gateway bot start only after the Worker endpoint is active.
+12. Keep Render service available for one full cycle as rollback only; do not route Worker traffic to it.
+13. After one full cycle passes, stop/decommission the Render service and remove obsolete Render env vars/webhook references.
+14. Keep DB migration backups until D1 data is validated against production behavior.
 
 ---
 
@@ -388,7 +433,4 @@ pnpm build
 ## PR sequence
 
 1. `docs/chore`: full CF migration plan + remove proxy defaults from scaffold. ✅ merged
-2. `feat(worker-d1-cycle-current)`: D1 schema, migrations, D1 binding, and `/cycle current` D1-backed interaction.
-3. `feat(worker-github-webhook)`: native GitHub webhook verification + submission recording.
-4. `feat(worker-reminders)`: Cron Trigger reminder handling.
-5. `chore(cutover)`: Discord/GitHub endpoint switch docs and Render shutdown checklist.
+2. `feat(worker-native-core)`: D1 schema/migrations/binding, `/cycle current`, native GitHub webhook submission recording, Cron Trigger reminders, and cutover docs.

--- a/docs/cloudflare-full-migration-plan.md
+++ b/docs/cloudflare-full-migration-plan.md
@@ -387,9 +387,8 @@ pnpm build
 
 ## PR sequence
 
-1. `docs/chore`: full CF migration plan + remove proxy defaults from scaffold.
-2. `feat(worker-db)`: D1 schema, migrations, D1 binding, data migration runbook.
-3. `feat(worker-cycle-current)`: `/cycle current` D1-backed interaction.
-4. `feat(worker-github-webhook)`: native GitHub webhook verification + submission recording.
-5. `feat(worker-reminders)`: Cron Trigger reminder handling.
-6. `chore(cutover)`: Discord/GitHub endpoint switch docs and Render shutdown checklist.
+1. `docs/chore`: full CF migration plan + remove proxy defaults from scaffold. ✅ merged
+2. `feat(worker-d1-cycle-current)`: D1 schema, migrations, D1 binding, and `/cycle current` D1-backed interaction.
+3. `feat(worker-github-webhook)`: native GitHub webhook verification + submission recording.
+4. `feat(worker-reminders)`: Cron Trigger reminder handling.
+5. `chore(cutover)`: Discord/GitHub endpoint switch docs and Render shutdown checklist.


### PR DESCRIPTION
## Summary
- Adds Cloudflare D1 binding `DB` to the Worker scaffold.
- Adds the first SQLite/D1 migration for the notification domain tables needed by Discord commands, GitHub webhook processing, reminders, and notification logs.
- Ports `/cycle current` to a Worker-native D1 query instead of returning scaffold text or calling Render.
- Adds a Worker interaction test that exercises `/cycle current` through `/discord/interactions` and asserts no `fetch`/Render proxy call happens.
- Updates the full Cloudflare migration plan PR sequence now that the docs/guardrail step is merged.

## Direction
This keeps the migration on the full Cloudflare path:

```txt
Discord Interaction -> Cloudflare Worker -> D1
```

No `API_BASE_URL`, no `*.onrender.com`, no Worker-to-Render bridge.

## Test Plan
- [x] `pnpm --filter @hanghae-study/worker format`
- [x] `pnpm --filter @hanghae-study/worker type-check`
- [x] `pnpm --filter @hanghae-study/worker test`
- [x] `pnpm --filter @hanghae-study/worker exec wrangler deploy --dry-run`
- [x] `pnpm --filter @hanghae-study/worker format:check`
- [x] `git diff --check`

## Notes
- `database_id` is currently the zero UUID placeholder. Replace it with the real Cloudflare D1 database ID during environment cutover.
- Follow-up PRs still needed for GitHub webhook native processing and Workers Cron reminders.