### PR TITLE
feat: add TanStack-powered study portal prefetching

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -18,7 +18,9 @@
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tailwind-merge": "^2.6.0"
+    "tailwind-merge": "^2.6.0",
+    "@tanstack/react-query": "^5.90.10",
+    "@tanstack/react-router": "^1.139.3"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,5 +1,7 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
-import { ArrowRight, ArrowUpRight, BookOpenText, CheckCircle2, Clock3, Compass, LogIn, Search, Sparkles } from 'lucide-react';
+import { useEffect, useMemo } from 'react';
+import { QueryClient, queryOptions, useQuery, useQueryClient } from '@tanstack/react-query';
+import { createRootRoute, createRoute, createRouter, useNavigate, useSearch } from '@tanstack/react-router';
+import { ArrowRight, ArrowUpRight, BookOpenText, Clock3, Compass, LogIn, Search, Sparkles } from 'lucide-react';
 import { Badge } from './components/ui/badge';
 import { Button } from './components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './components/ui/card';
@@ -7,6 +9,8 @@ import { Input } from './components/ui/input';
 import { Separator } from './components/ui/separator';
 
 const API_BASE_URL = '';
+const ONE_MINUTE = 1000 * 60;
+const FIVE_MINUTES = ONE_MINUTE * 5;
 
 type Study = {
   id: number;
@@ -72,7 +76,10 @@ type CycleStatus = {
   }>;
 };
 
-type ApiState = 'idle' | 'loading' | 'ready' | 'error';
+type PortalSearch = {
+  studySlug?: string;
+  searchQuery?: string;
+};
 
 async function fetchJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
@@ -85,6 +92,51 @@ async function fetchJson<T>(path: string): Promise<T> {
   }
 
   return payload as T;
+}
+
+function portalQueryOptions() {
+  return queryOptions({
+    queryKey: ['study-portal'],
+    queryFn: async () => {
+      const [auth, publicStudies, myStudies] = await Promise.all([
+        fetchJson<AuthSession>('/api/auth/me'),
+        fetchJson<{ studies: Study[] }>('/api/studies'),
+        fetchJson<MyStudiesResponse>('/api/studies/me'),
+      ]);
+
+      return {
+        auth,
+        publicStudies: publicStudies.studies,
+        myStudies: myStudies.studies ?? [],
+        mySubmissionStatus: myStudies.mySubmissionStatus ?? [],
+        message: myStudies.message ?? '스터디를 불러왔습니다.',
+      };
+    },
+    staleTime: FIVE_MINUTES,
+  });
+}
+
+function cycleStatusQueryOptions(study: Study | null) {
+  return queryOptions({
+    queryKey: ['cycle-status', study?.slug, study?.currentCycle?.id],
+    queryFn: async () => {
+      if (!study?.currentCycle) return null;
+      const cycleId = study.currentCycle.id;
+      const status = await fetchJson<CycleStatus>(
+        `/api/status/${cycleId}?organizationSlug=${encodeURIComponent(study.slug)}`,
+      );
+
+      return {
+        ...status,
+        submitted: status.submitted.map((submission) => ({
+          ...submission,
+          title: submission.title ?? submission.url,
+        })),
+      };
+    },
+    enabled: Boolean(study?.currentCycle),
+    staleTime: 1000 * 60,
+  });
 }
 
 function formatDate(value?: string) {
@@ -115,88 +167,111 @@ function getStatusLabel(status?: MySubmissionStatus) {
   return '아직 제출 전';
 }
 
+function normalizeSearchValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+const rootRoute = createRootRoute({
+  component: PortalPage,
+});
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  validateSearch: (search: Record<string, unknown>): PortalSearch => ({
+    studySlug: normalizeSearchValue(search.studySlug),
+    searchQuery: normalizeSearchValue(search.searchQuery),
+  }),
+});
+
+const routeTree = rootRoute.addChildren([indexRoute]);
+
+export const router = createRouter({
+  routeTree,
+  context: { queryClient },
+});
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}
+
 export function App() {
-  const [query, setQuery] = useState('');
-  const [selectedStudy, setSelectedStudy] = useState<Study | null>(null);
-  const [publicStudies, setPublicStudies] = useState<Study[]>([]);
-  const [myStudies, setMyStudies] = useState<Study[]>([]);
-  const [mySubmissionStatus, setMySubmissionStatus] = useState<MySubmissionStatus[]>([]);
-  const [auth, setAuth] = useState<AuthSession>({ authenticated: false, user: null });
-  const [cycleStatus, setCycleStatus] = useState<CycleStatus | null>(null);
-  const [apiState, setApiState] = useState<ApiState>('idle');
-  const [message, setMessage] = useState('스터디를 불러오는 중입니다.');
+  return <PortalPage />;
+}
+
+function PortalPage() {
+  const navigate = useNavigate({ from: '/' });
+  const { studySlug, searchQuery = '' } = useSearch({ from: '/' });
+  const queryClient = useQueryClient();
+  const portalQuery = useQuery(portalQueryOptions());
+
+  const auth = portalQuery.data?.auth ?? { authenticated: false, user: null };
+  const publicStudies = portalQuery.data?.publicStudies ?? [];
+  const myStudies = portalQuery.data?.myStudies ?? [];
+  const mySubmissionStatus = portalQuery.data?.mySubmissionStatus ?? [];
+  const normalizedQuery = searchQuery.trim().toLowerCase();
 
   const visibleStudies = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized) return publicStudies;
+    if (!normalizedQuery) return publicStudies;
     return publicStudies.filter((study) =>
-      `${study.name} ${study.slug} ${study.description}`.toLowerCase().includes(normalized),
+      `${study.name} ${study.slug} ${study.description}`.toLowerCase().includes(normalizedQuery),
     );
-  }, [publicStudies, query]);
+  }, [normalizedQuery, publicStudies]);
 
-  async function loadPortal() {
-    setApiState('loading');
-    setMessage('스터디 탐색 정보를 불러오는 중입니다.');
+  const selectedStudy = useMemo(() => {
+    return (
+      publicStudies.find((study) => study.slug === studySlug) ??
+      myStudies[0] ??
+      visibleStudies[0] ??
+      publicStudies[0] ??
+      null
+    );
+  }, [myStudies, publicStudies, studySlug, visibleStudies]);
 
-    try {
-      const [authSession, studiesResponse, myResponse] = await Promise.all([
-        fetchJson<AuthSession>('/api/auth/me'),
-        fetchJson<{ studies: Study[] }>('/api/studies'),
-        fetchJson<MyStudiesResponse>('/api/studies/me'),
-      ]);
-
-      setAuth(authSession);
-      setPublicStudies(studiesResponse.studies);
-      setMyStudies(myResponse.studies ?? []);
-      setMySubmissionStatus(myResponse.mySubmissionStatus ?? []);
-      const initialStudy = myResponse.studies?.[0] ?? studiesResponse.studies[0] ?? null;
-      setSelectedStudy((current) => current ?? initialStudy);
-      setApiState('ready');
-      if (initialStudy?.currentCycle) {
-        void loadSubmissions(initialStudy);
-      } else {
-        setMessage(myResponse.message ?? '스터디를 불러왔습니다.');
-      }
-    } catch (error) {
-      setApiState('error');
-      setMessage(`스터디 정보를 불러오지 못했습니다: ${(error as Error).message}`);
-    }
-  }
-
-  async function loadSubmissions(study: Study) {
-    setSelectedStudy(study);
-    setCycleStatus(null);
-
-    if (!study.currentCycle) {
-      setMessage('이 스터디는 아직 진행 중인 회차가 없습니다.');
-      return;
-    }
-
-    try {
-      const cycleId = study.currentCycle.id;
-      const status = await fetchJson<CycleStatus>(`/api/status/${cycleId}?organizationSlug=${encodeURIComponent(study.slug)}`);
-      setCycleStatus({
-        ...status,
-        submitted: status.submitted.map((submission) => ({
-          ...submission,
-          title: submission.title ?? submission.url,
-        })),
-      });
-      setMessage('제출글 모아보기를 업데이트했습니다.');
-    } catch (error) {
-      setMessage(`제출글을 불러오지 못했습니다: ${(error as Error).message}`);
-    }
-  }
-
-  function handleSearch(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-  }
+  const cycleStatusQuery = useQuery(cycleStatusQueryOptions(selectedStudy));
+  const isInvalidStudySlug = Boolean(studySlug && selectedStudy && studySlug !== selectedStudy.slug);
 
   useEffect(() => {
-    void loadPortal();
-  }, []);
+    if (isInvalidStudySlug && selectedStudy) {
+      navigateToSearch({ studySlug: selectedStudy.slug });
+    }
+  }, [isInvalidStudySlug, selectedStudy?.slug, studySlug]);
 
+  const cycleStatus = cycleStatusQuery.data;
   const selectedMyStatus = selectedStudy ? getMyStatus(mySubmissionStatus, selectedStudy) : undefined;
+
+  const selectedMessage = getPortalMessage({
+    selectedStudy,
+    portalQueryError: portalQuery.error,
+    portalQueryStatus: portalQuery.status,
+    cycleStatusError: cycleStatusQuery.error,
+    cycleStatusStatus: cycleStatusQuery.status,
+    fallbackMessage: portalQuery.data?.message,
+  });
+
+  function navigateToSearch(nextSearch: PortalSearch) {
+    void navigate({ search: (previous) => ({ ...previous, ...nextSearch }), replace: true });
+  }
+
+  function openStudy(study: Study) {
+    navigateToSearch({ studySlug: study.slug });
+  }
+
+  function prefetchStudy(study: Study) {
+    if (!study.currentCycle) return;
+    void queryClient.prefetchQuery(cycleStatusQueryOptions(study));
+  }
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -212,12 +287,12 @@ export function App() {
             </div>
           </div>
 
-          <form onSubmit={handleSearch} className="hidden flex-1 justify-center md:flex">
+          <form onSubmit={(event) => event.preventDefault()} className="hidden flex-1 justify-center md:flex">
             <div className="flex w-full max-w-xl items-center gap-3 rounded-full border border-border bg-white px-5 py-2 shadow-airbnb">
               <Search className="h-4 w-4 text-muted-foreground" />
               <Input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
+                value={searchQuery}
+                onChange={(event) => navigateToSearch({ searchQuery: event.target.value || undefined })}
                 className="border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
                 placeholder="스터디 이름이나 설명으로 검색"
               />
@@ -250,6 +325,7 @@ export function App() {
             누구나 공개 스터디와 제출글을 볼 수 있고, Discord로 로그인하면 내 스터디와 내 제출 상태가 먼저 보여요.
           </p>
           <div className="mt-6 flex flex-wrap gap-3 text-sm text-muted-foreground">
+            <Badge variant="secondary">TanStack Query 프리페칭</Badge>
             <Badge variant="secondary">Airbnb 참고 화이트 테마</Badge>
             <Badge variant="secondary">제출글 모아보기</Badge>
             <Badge variant="secondary">내 제출 상태</Badge>
@@ -276,7 +352,9 @@ export function App() {
                       key={study.slug}
                       study={study}
                       myStatus={getMyStatus(mySubmissionStatus, study)}
-                      onOpen={() => void loadSubmissions(study)}
+                      selected={selectedStudy?.slug === study.slug}
+                      onOpen={() => openStudy(study)}
+                      onPrefetch={() => prefetchStudy(study)}
                     />
                   ))}
                 </div>
@@ -302,12 +380,28 @@ export function App() {
             </section>
 
             <section>
-              <div className="mb-4 flex items-end justify-between gap-4">
+              <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
                 <div>
                   <h3 className="text-2xl font-black">전체 공개 스터디</h3>
                   <p className="mt-1 text-sm text-muted-foreground">스터디 이름과 설명으로 검색하고 회차별 제출글을 볼 수 있습니다.</p>
                 </div>
-                <Badge variant={apiState === 'error' ? 'destructive' : 'secondary'}>{apiState}</Badge>
+                <div className="flex items-center gap-2">
+                  <Badge variant={portalQuery.isError ? 'destructive' : 'secondary'}>
+                    {portalQuery.isFetching ? 'syncing' : portalQuery.status}
+                  </Badge>
+                  {searchQuery && <Badge variant="outline">검색 {visibleStudies.length}개</Badge>}
+                </div>
+              </div>
+              <div className="mb-4 flex md:hidden">
+                <div className="flex w-full items-center gap-3 rounded-full border border-border bg-white px-5 py-2 shadow-airbnb">
+                  <Search className="h-4 w-4 text-muted-foreground" />
+                  <Input
+                    value={searchQuery}
+                    onChange={(event) => navigateToSearch({ searchQuery: event.target.value || undefined })}
+                    className="border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
+                    placeholder="스터디 검색"
+                  />
+                </div>
               </div>
               <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                 {visibleStudies.map((study) => (
@@ -315,10 +409,19 @@ export function App() {
                     key={study.slug}
                     study={study}
                     myStatus={getMyStatus(mySubmissionStatus, study)}
-                    onOpen={() => void loadSubmissions(study)}
+                    selected={selectedStudy?.slug === study.slug}
+                    onOpen={() => openStudy(study)}
+                    onPrefetch={() => prefetchStudy(study)}
                   />
                 ))}
               </div>
+              {!visibleStudies.length && (
+                <Card className="mt-4 border-dashed bg-secondary/40">
+                  <CardContent className="p-6 text-sm text-muted-foreground">
+                    검색 결과가 없습니다. 스터디 이름이나 설명을 다르게 입력해보세요.
+                  </CardContent>
+                </Card>
+              )}
             </section>
           </div>
 
@@ -354,7 +457,7 @@ export function App() {
                   )}
                 </div>
 
-                <p className="rounded-2xl bg-rose-50 p-4 text-sm leading-6 text-rose-700">{message}</p>
+                <p className="rounded-2xl bg-rose-50 p-4 text-sm leading-6 text-rose-700">{selectedMessage}</p>
               </CardContent>
             </Card>
 
@@ -364,7 +467,11 @@ export function App() {
                 <CardDescription>회차별 제출글을 공개 목록으로 보여줍니다.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
-                {cycleStatus?.submitted.length ? (
+                {cycleStatusQuery.isFetching && selectedStudy?.currentCycle ? (
+                  <div className="rounded-2xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+                    프리페치된 제출글을 확인하는 중입니다.
+                  </div>
+                ) : cycleStatus?.submitted.length ? (
                   cycleStatus.submitted.map((submission) => (
                     <a key={`${submission.name}-${submission.url}`} href={submission.url} target="_blank" rel="noreferrer" className="block rounded-2xl border border-border p-4 transition hover:-translate-y-0.5 hover:shadow-airbnb">
                       <p className="font-bold">{getSubmissionTitle(submission)}</p>
@@ -385,9 +492,55 @@ export function App() {
   );
 }
 
-function StudyCard({ study, myStatus, onOpen }: { study: Study; myStatus?: MySubmissionStatus; onOpen: () => void }) {
+function getPortalMessage({
+  selectedStudy,
+  portalQueryError,
+  portalQueryStatus,
+  cycleStatusError,
+  cycleStatusStatus,
+  fallbackMessage,
+}: {
+  selectedStudy: Study | null;
+  portalQueryError: Error | null;
+  portalQueryStatus: 'error' | 'success' | 'pending';
+  cycleStatusError: Error | null;
+  cycleStatusStatus: 'error' | 'success' | 'pending';
+  fallbackMessage?: string;
+}) {
+  if (portalQueryError) return `스터디 정보를 불러오지 못했습니다: ${portalQueryError.message}`;
+  if (portalQueryStatus === 'pending') return '스터디 탐색 정보를 불러오는 중입니다.';
+  if (!selectedStudy) return fallbackMessage ?? '스터디를 불러왔습니다.';
+  if (!selectedStudy.currentCycle) return '이 스터디는 아직 진행 중인 회차가 없습니다.';
+  if (cycleStatusError) return `제출글을 불러오지 못했습니다: ${cycleStatusError.message}`;
+  if (cycleStatusStatus === 'pending') return '제출글을 미리 불러오는 중입니다.';
+  return '제출글 모아보기를 업데이트했습니다.';
+}
+
+function StudyCard({
+  study,
+  myStatus,
+  selected,
+  onOpen,
+  onPrefetch,
+}: {
+  study: Study;
+  myStatus?: MySubmissionStatus;
+  selected: boolean;
+  onOpen: () => void;
+  onPrefetch: () => void;
+}) {
   return (
-    <Card className="group cursor-pointer rounded-[1.75rem] transition hover:-translate-y-1 hover:shadow-airbnb" onClick={onOpen}>
+    <Card
+      className={`group cursor-pointer rounded-[1.75rem] transition hover:-translate-y-1 hover:shadow-airbnb ${
+        selected ? 'border-primary shadow-airbnb ring-2 ring-primary/10' : ''
+      }`}
+      onClick={onOpen}
+      onMouseEnter={onPrefetch}
+      onFocus={onPrefetch}
+      tabIndex={0}
+      role="button"
+      aria-pressed={selected}
+    >
       <CardHeader>
         <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-rose-50 text-primary">
           <BookOpenText className="h-6 w-6" />

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { App } from './App';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider } from '@tanstack/react-router';
+import { queryClient, router } from './App';
 import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/apps/dashboard/test/tanstack-prefetch.test.mjs
+++ b/apps/dashboard/test/tanstack-prefetch.test.mjs
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises';
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+const appRoot = new URL('../', import.meta.url);
+
+async function readProjectFile(path) {
+  return readFile(new URL(path, appRoot), 'utf8');
+}
+
+test('dashboard uses TanStack Router and Query as the portal shell', async () => {
+  const pkg = JSON.parse(await readProjectFile('package.json'));
+  const main = await readProjectFile('src/main.tsx');
+  const app = await readProjectFile('src/App.tsx');
+
+  assert.ok(pkg.dependencies['@tanstack/react-router'], 'TanStack Router dependency is required');
+  assert.ok(pkg.dependencies['@tanstack/react-query'], 'TanStack Query dependency is required');
+  assert.match(main, /RouterProvider/);
+  assert.match(main, /QueryClientProvider/);
+  assert.match(app, /createRootRoute/);
+  assert.match(app, /createRoute/);
+  assert.match(app, /createRouter/);
+});
+
+test('study cards prefetch cycle status before users click', async () => {
+  const app = await readProjectFile('src/App.tsx');
+
+  assert.match(app, /useQueryClient/);
+  assert.match(app, /prefetchQuery/);
+  assert.match(app, /onMouseEnter=\{onPrefetch\}/);
+  assert.match(app, /onFocus=\{onPrefetch\}/);
+  assert.match(app, /cycleStatusQueryOptions/);
+  assert.match(app, /staleTime:\s*1000 \* 60/);
+});
+
+test('portal route keeps study and search state shareable in the URL', async () => {
+  const app = await readProjectFile('src/App.tsx');
+
+  assert.match(app, /validateSearch/);
+  assert.match(app, /studySlug/);
+  assert.match(app, /searchQuery/);
+  assert.match(app, /navigate\(\{ search:/);
+  assert.match(app, /replace:\s*true/);
+});
+
+test('portal normalizes invalid shared study slugs after data loads', async () => {
+  const app = await readProjectFile('src/App.tsx');
+
+  assert.match(app, /isInvalidStudySlug/);
+  assert.match(app, /selectedStudy\.slug/);
+  assert.match(app, /studySlug !== selectedStudy\.slug/);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,12 @@ importers:
 
   apps/dashboard:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.90.10
+        version: 5.100.14(react@18.3.1)
+      '@tanstack/react-router':
+        specifier: ^1.139.3
+        version: 1.170.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^4.5.0
         version: 4.7.0(vite@5.4.21(@types/node@22.19.3))
@@ -2448,6 +2454,38 @@ packages:
       zod:
         optional: true
 
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.100.14':
+    resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
+
+  '@tanstack/react-query@5.100.14':
+    resolution: {integrity: sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-router@1.170.8':
+    resolution: {integrity: sha512-Qw2ju6jjnIsMpuW+VrnHZWHuugqs592PWsnI56sG28qNhg14CgRLahOcNajfuJR9P4MxKGP94WVzmFKSYUz/ig==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.6':
+    resolution: {integrity: sha512-Ol6DQ+j6rf/rPVELIzo8LHwOQV2KL+zry3b+39kL/GKrt7YId52WJRAFMzuseY4XceSW+PU7sG/Cc1QkwJr0hg==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
   '@types/aws-lambda@8.10.159':
     resolution: {integrity: sha512-SAP22WSGNN12OQ8PlCzGzRCZ7QDCwI85dQZbmpz7+mAk+L7j+wI7qnvmdKh+o7A5LaOp6QnOZ2NJphAZQTTHQg==}
 
@@ -2914,6 +2952,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -3517,6 +3558,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  isbot@5.1.40:
+    resolution: {integrity: sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -4178,6 +4223,16 @@ packages:
   sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
 
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
+
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
@@ -4548,6 +4603,11 @@ packages:
 
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6732,6 +6792,40 @@ snapshots:
       typescript: 5.9.3
       zod: 4.3.5
 
+  '@tanstack/history@1.162.0': {}
+
+  '@tanstack/query-core@5.100.14': {}
+
+  '@tanstack/react-query@5.100.14(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.100.14
+      react: 18.3.1
+
+  '@tanstack/react-router@1.170.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-core': 1.171.6
+      isbot: 5.1.40
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/react-store@0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  '@tanstack/router-core@1.171.6':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.9.3': {}
+
   '@types/aws-lambda@8.10.159': {}
 
   '@types/babel__core@7.20.5':
@@ -7279,6 +7373,8 @@ snapshots:
       upper-case: 2.0.2
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   cookie@1.1.1: {}
 
@@ -7940,6 +8036,8 @@ snapshots:
 
   is-windows@1.0.2: {}
 
+  isbot@5.1.40: {}
+
   isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
@@ -8585,6 +8683,12 @@ snapshots:
       tslib: 2.8.1
       upper-case-first: 2.0.2
 
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
+
   setimmediate@1.0.5: {}
 
   sharp@0.34.5:
@@ -8978,6 +9082,10 @@ snapshots:
       punycode: 2.3.1
 
   urlpattern-polyfill@10.1.0: {}
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary
- Rework the study portal shell onto TanStack Router + TanStack Query.
- Cache the portal bootstrap data and cycle status queries with explicit stale times.
- Prefetch cycle status on study card hover/focus before click.
- Keep selected study and search query in URL search params for shareable links.
- Improve UX with selected-card state, mobile search, empty-search feedback, and invalid shared slug normalization.

## Verification
- `pnpm --filter @hanghae-study/dashboard test`
- `pnpm --filter @hanghae-study/dashboard build`
- `pnpm --filter @hanghae-study/dashboard exec tsc -p tsconfig.json --noEmit`
- `SKIP_ENV_VALIDATION=true pnpm --filter @hanghae-study/server type-check`
- `SKIP_ENV_VALIDATION=true pnpm --filter @hanghae-study/server test`
- `pnpm format:check`
- `git diff --check`
- Local browser e2e via `wrangler pages dev` for search URL state, invalid slug normalization, selected card state, and console errors