### PR TITLE
feat: standardize REST API envelopes

### DIFF
--- a/apps/dashboard/functions/_shared.js
+++ b/apps/dashboard/functions/_shared.js
@@ -1,9 +1,23 @@
-export const UPSTREAM_ORIGIN = 'https://donguel-donguel-notification.onrender.com';
+export const UPSTREAM_ORIGIN =
+  'https://donguel-donguel-notification.onrender.com';
 
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
   'Access-Control-Allow-Headers': 'content-type, accept, cookie',
+};
+
+const STATUS_CODES = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  422: 'UNPROCESSABLE_ENTITY',
+  429: 'TOO_MANY_REQUESTS',
+  500: 'INTERNAL_SERVER_ERROR',
+  502: 'BAD_GATEWAY',
+  503: 'SERVICE_UNAVAILABLE',
 };
 
 export function normalizePath(pathParam) {
@@ -34,10 +48,70 @@ export function decodeSession(request) {
   }
 }
 
+function createMeta() {
+  return {
+    requestId: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function errorCodeForStatus(status) {
+  return (
+    STATUS_CODES[status] ??
+    (status >= 500 ? 'INTERNAL_SERVER_ERROR' : 'REQUEST_FAILED')
+  );
+}
+
+export function apiSuccess(data) {
+  return {
+    success: true,
+    data,
+    error: null,
+    meta: createMeta(),
+  };
+}
+
+export function apiFailure(message, status = 500, details) {
+  return {
+    success: false,
+    data: null,
+    error: {
+      code: errorCodeForStatus(status),
+      message,
+      ...(details === undefined ? {} : { details }),
+    },
+    meta: createMeta(),
+  };
+}
+
+export function isApiEnvelope(payload) {
+  return Boolean(
+    payload &&
+    typeof payload === 'object' &&
+    'success' in payload &&
+    'data' in payload &&
+    'error' in payload &&
+    'meta' in payload,
+  );
+}
+
 export function jsonResponse(payload, init = {}) {
+  const status = init.status ?? 200;
   const headers = new Headers(corsHeaders);
   headers.set('content-type', 'application/json; charset=utf-8');
   headers.set('cache-control', 'no-store');
-  for (const [key, value] of Object.entries(init.headers || {})) headers.set(key, value);
-  return new Response(JSON.stringify(payload), { ...init, headers });
+  for (const [key, value] of Object.entries(init.headers || {}))
+    headers.set(key, value);
+
+  const enveloped = isApiEnvelope(payload)
+    ? payload
+    : status >= 400
+      ? apiFailure(
+          payload?.message ?? payload?.error ?? `HTTP ${status}`,
+          status,
+          payload?.details,
+        )
+      : apiSuccess(payload);
+
+  return new Response(JSON.stringify(enveloped), { ...init, headers });
 }

--- a/apps/dashboard/functions/api/auth/discord/callback.js
+++ b/apps/dashboard/functions/api/auth/discord/callback.js
@@ -1,4 +1,4 @@
-import { getCookie } from '../../../_shared.js';
+import { apiFailure, getCookie, jsonResponse } from '../../../_shared.js';
 
 export async function onRequestGet(context) {
   const url = new URL(context.request.url);
@@ -7,15 +7,21 @@ export async function onRequestGet(context) {
   const expectedState = getCookie(context.request, 'discord_oauth_state');
 
   if (!code || !state || state !== expectedState) {
-    return new Response('Invalid Discord OAuth callback', { status: 400 });
+    return jsonResponse(apiFailure('Invalid Discord OAuth callback', 400), {
+      status: 400,
+    });
   }
 
   const clientId = context.env.DISCORD_CLIENT_ID;
   const clientSecret = context.env.DISCORD_CLIENT_SECRET;
-  const redirectUri = context.env.DISCORD_REDIRECT_URI ?? `${url.origin}/api/auth/discord/callback`;
+  const redirectUri =
+    context.env.DISCORD_REDIRECT_URI ??
+    `${url.origin}/api/auth/discord/callback`;
 
   if (!clientId || !clientSecret) {
-    return new Response('Discord OAuth is not configured', { status: 500 });
+    return jsonResponse(apiFailure('Discord OAuth is not configured', 500), {
+      status: 500,
+    });
   }
 
   const tokenResponse = await fetch('https://discord.com/api/oauth2/token', {
@@ -31,7 +37,10 @@ export async function onRequestGet(context) {
   });
 
   if (!tokenResponse.ok) {
-    return new Response('Failed to exchange Discord OAuth code', { status: 502 });
+    return jsonResponse(
+      apiFailure('Failed to exchange Discord OAuth code', 502),
+      { status: 502 },
+    );
   }
 
   const token = await tokenResponse.json();
@@ -40,16 +49,22 @@ export async function onRequestGet(context) {
   });
 
   if (!userResponse.ok) {
-    return new Response('Failed to read Discord user', { status: 502 });
+    return jsonResponse(apiFailure('Failed to read Discord user', 502), {
+      status: 502,
+    });
   }
 
   const user = await userResponse.json();
-  const session = encodeURIComponent(btoa(JSON.stringify({
-    id: user.id,
-    username: user.username,
-    globalName: user.global_name,
-    avatar: user.avatar,
-  })));
+  const session = encodeURIComponent(
+    btoa(
+      JSON.stringify({
+        id: user.id,
+        username: user.username,
+        globalName: user.global_name,
+        avatar: user.avatar,
+      }),
+    ),
+  );
 
   return new Response(null, {
     status: 302,

--- a/apps/dashboard/functions/api/auth/discord/login.js
+++ b/apps/dashboard/functions/api/auth/discord/login.js
@@ -1,10 +1,17 @@
+import { apiFailure, jsonResponse } from '../../../_shared.js';
+
 export function onRequestGet(context) {
   const url = new URL(context.request.url);
   const clientId = context.env.DISCORD_CLIENT_ID;
-  const redirectUri = context.env.DISCORD_REDIRECT_URI ?? `${url.origin}/api/auth/discord/callback`;
+  const redirectUri =
+    context.env.DISCORD_REDIRECT_URI ??
+    `${url.origin}/api/auth/discord/callback`;
 
   if (!clientId) {
-    return new Response('DISCORD_CLIENT_ID is not configured', { status: 500 });
+    return jsonResponse(
+      apiFailure('DISCORD_CLIENT_ID is not configured', 500),
+      { status: 500 },
+    );
   }
 
   const state = crypto.randomUUID();

--- a/apps/dashboard/functions/api/auth/me.js
+++ b/apps/dashboard/functions/api/auth/me.js
@@ -1,8 +1,16 @@
-import { decodeSession, jsonResponse } from '../../_shared.js';
+import { decodeSession, apiSuccess, jsonResponse } from '../../_shared.js';
 
 export function onRequestGet(context) {
   // Reads the discord_session cookie set by the Discord OAuth callback.
   const session = decodeSession(context.request);
-  const oauthConfigured = Boolean(context.env.DISCORD_CLIENT_ID && context.env.DISCORD_CLIENT_SECRET);
-  return jsonResponse({ authenticated: Boolean(session), user: session, oauthConfigured });
+  const oauthConfigured = Boolean(
+    context.env.DISCORD_CLIENT_ID && context.env.DISCORD_CLIENT_SECRET,
+  );
+  return jsonResponse(
+    apiSuccess({
+      authenticated: Boolean(session),
+      user: session,
+      oauthConfigured,
+    }),
+  );
 }

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -81,17 +81,52 @@ type PortalSearch = {
   searchQuery?: string;
 };
 
+type ApiEnvelope<T> =
+  | {
+      success: true;
+      data: T;
+      error: null;
+      meta: { requestId: string; timestamp: string };
+    }
+  | {
+      success: false;
+      data: null;
+      error: { code: string; message: string; details?: unknown };
+      meta: { requestId: string; timestamp: string };
+    };
+
+function isApiEnvelope<T>(payload: unknown): payload is ApiEnvelope<T> {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    'success' in payload &&
+    'data' in payload &&
+    'error' in payload &&
+    'meta' in payload
+  );
+}
+
+function unwrapApiResponse<T>(payload: unknown, response: Response): T {
+  if (isApiEnvelope<T>(payload)) {
+    if (payload.success) return payload.data;
+    throw new Error(payload.error.message || `HTTP ${response.status}`);
+  }
+
+  if (!response.ok) {
+    const legacyError = payload as { error?: string; message?: string };
+    throw new Error(legacyError.error ?? legacyError.message ?? `HTTP ${response.status}`);
+  }
+
+  return payload as T;
+}
+
 async function fetchJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     headers: { accept: 'application/json' },
   });
   const payload = await response.json().catch(() => ({}));
 
-  if (!response.ok) {
-    throw new Error((payload as { error?: string }).error ?? `HTTP ${response.status}`);
-  }
-
-  return payload as T;
+  return unwrapApiResponse<T>(payload, response);
 }
 
 function portalQueryOptions() {

--- a/apps/dashboard/test/study-portal.test.mjs
+++ b/apps/dashboard/test/study-portal.test.mjs
@@ -46,26 +46,54 @@ test('portal document metadata is customer-facing, not admin or implementation c
   assert.doesNotMatch(html, /운영자를 위한/);
 });
 
-test('dashboard client uses public studies API, Discord auth session, and cycle status proxy', async () => {
+test('dashboard client uses public studies API, Discord auth session, cycle status proxy, and API envelopes', async () => {
   const app = await readProjectFile('src/App.tsx');
-  const studiesProxy = await readProjectFile('functions/api/studies/[[path]].js');
-  const authLogin = await readProjectFile('functions/api/auth/discord/login.js');
+  const shared = await readProjectFile('functions/_shared.js');
+  const studiesProxy = await readProjectFile(
+    'functions/api/studies/[[path]].js',
+  );
+  const authLogin = await readProjectFile(
+    'functions/api/auth/discord/login.js',
+  );
   const authMe = await readProjectFile('functions/api/auth/me.js');
 
   assert.match(app, /\/api\/studies/);
   assert.match(app, /\/api\/studies\/me/);
   assert.match(app, /\/api\/auth\/me/);
   assert.match(app, /\/api\/status\/\$\{cycleId\}/);
+  assert.match(app, /unwrapApiResponse/);
+  assert.match(app, /success/);
+  assert.match(app, /data/);
   assert.doesNotMatch(app, /onrender\.com/);
+  assert.match(shared, /apiSuccess/);
+  assert.match(shared, /apiFailure/);
   assert.match(studiesProxy, /\/api\/studies/);
   assert.match(authLogin, /DISCORD_CLIENT_ID/);
   assert.match(authLogin, /discord\.com\/oauth2\/authorize/);
-  assert.match(authMe, /discord_session/);
+  assert.match(authMe, /apiSuccess/);
+});
+
+test('server wraps REST API responses in a standard envelope', async () => {
+  const index = await readRepoFile('apps/server/src/index.ts');
+  const envelope = await readRepoFile(
+    'apps/server/src/presentation/shared/api-envelope.ts',
+  );
+
+  assert.match(index, /apiEnvelopeMiddleware/);
+  assert.match(index, /app\.use\('\/api\/\*'/);
+  assert.match(envelope, /success: true/);
+  assert.match(envelope, /success: false/);
+  assert.match(envelope, /data/);
+  assert.match(envelope, /error/);
+  assert.match(envelope, /requestId/);
+  assert.match(envelope, /timestamp/);
 });
 
 test('server exposes study portal read APIs backed by organization-as-study model', async () => {
   const index = await readRepoFile('apps/server/src/index.ts');
-  const handlers = await readRepoFile('apps/server/src/presentation/http/studies/studies.handlers.ts');
+  const handlers = await readRepoFile(
+    'apps/server/src/presentation/http/studies/studies.handlers.ts',
+  );
 
   assert.match(index, /getPublicStudies/);
   assert.match(index, /\/api\/studies/);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -37,6 +37,7 @@ import {
 
 import { env } from './env';
 import { logger } from './infrastructure/lib/logger';
+import { apiEnvelopeMiddleware } from './presentation/shared/api-envelope';
 
 // Import GraphQL configuration
 import { graphql } from './presentation/graphql/pylon.service';
@@ -98,6 +99,8 @@ app.use('*', async (c, next) => {
     });
   }
 });
+
+app.use('/api/*', apiEnvelopeMiddleware);
 
 // ========================================
 // REST Endpoints

--- a/apps/server/src/presentation/shared/api-envelope.test.ts
+++ b/apps/server/src/presentation/shared/api-envelope.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { createApiEnvelope, normalizeError } from './api-envelope';
+
+describe('API envelope', () => {
+  it('wraps successful REST payloads with success, data, error, and meta', () => {
+    const envelope = createApiEnvelope({ studies: [] }, 200, 'req_test');
+
+    expect(envelope).toEqual({
+      success: true,
+      data: { studies: [] },
+      error: null,
+      meta: {
+        requestId: 'req_test',
+        timestamp: expect.any(String),
+      },
+    });
+  });
+
+  it('wraps error payloads with a structured error and null data', () => {
+    const envelope = createApiEnvelope(
+      { error: 'Study not found' },
+      404,
+      'req_missing'
+    );
+
+    expect(envelope).toEqual({
+      success: false,
+      data: null,
+      error: {
+        code: 'NOT_FOUND',
+        message: 'Study not found',
+      },
+      meta: {
+        requestId: 'req_missing',
+        timestamp: expect.any(String),
+      },
+    });
+  });
+
+  it('keeps already enveloped payloads stable', () => {
+    const existing = createApiEnvelope({ ok: true }, 200, 'req_original');
+
+    expect(createApiEnvelope(existing, 200, 'req_new')).toBe(existing);
+  });
+
+  it('normalizes message-only failures to status-derived error codes', () => {
+    expect(normalizeError({ message: 'Invalid payload' }, 400)).toEqual({
+      code: 'BAD_REQUEST',
+      message: 'Invalid payload',
+    });
+  });
+});

--- a/apps/server/src/presentation/shared/api-envelope.ts
+++ b/apps/server/src/presentation/shared/api-envelope.ts
@@ -1,0 +1,168 @@
+import type { Context, MiddlewareHandler } from 'hono';
+
+export type ApiSuccess<T> = {
+  success: true;
+  data: T;
+  error: null;
+  meta: ApiMeta;
+};
+
+export type ApiFailure = {
+  success: false;
+  data: null;
+  error: ApiError;
+  meta: ApiMeta;
+};
+
+export type ApiResponse<T> = ApiSuccess<T> | ApiFailure;
+
+export type ApiMeta = {
+  requestId: string;
+  timestamp: string;
+};
+
+export type ApiError = {
+  code: string;
+  message: string;
+  details?: unknown;
+};
+
+const STATUS_CODES: Record<number, string> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  422: 'UNPROCESSABLE_ENTITY',
+  429: 'TOO_MANY_REQUESTS',
+  500: 'INTERNAL_SERVER_ERROR',
+  502: 'BAD_GATEWAY',
+  503: 'SERVICE_UNAVAILABLE',
+};
+
+function createMeta(requestId?: string): ApiMeta {
+  return {
+    requestId: requestId ?? crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function getStatusCodeName(status: number) {
+  return (
+    STATUS_CODES[status] ??
+    (status >= 500 ? 'INTERNAL_SERVER_ERROR' : 'REQUEST_FAILED')
+  );
+}
+
+export function isApiEnvelope(value: unknown): value is ApiResponse<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'success' in value &&
+    'data' in value &&
+    'error' in value &&
+    'meta' in value
+  );
+}
+
+export function normalizeError(payload: unknown, status: number): ApiError {
+  if (payload && typeof payload === 'object') {
+    const candidate = payload as {
+      error?: unknown;
+      message?: unknown;
+      details?: unknown;
+      code?: unknown;
+    };
+    const message =
+      typeof candidate.error === 'string'
+        ? candidate.error
+        : typeof candidate.message === 'string'
+          ? candidate.message
+          : `HTTP ${status}`;
+
+    return {
+      code:
+        typeof candidate.code === 'string'
+          ? candidate.code
+          : getStatusCodeName(status),
+      message,
+      ...(candidate.details === undefined
+        ? {}
+        : { details: candidate.details }),
+    };
+  }
+
+  return {
+    code: getStatusCodeName(status),
+    message: typeof payload === 'string' ? payload : `HTTP ${status}`,
+  };
+}
+
+export function createApiEnvelope<T>(
+  payload: T,
+  status: number,
+  requestId?: string
+): ApiResponse<T> {
+  if (isApiEnvelope(payload)) {
+    return payload as ApiResponse<T>;
+  }
+
+  const meta = createMeta(requestId);
+
+  if (status >= 400) {
+    return {
+      success: false,
+      data: null,
+      error: normalizeError(payload, status),
+      meta,
+    };
+  }
+
+  return {
+    success: true,
+    data: payload,
+    error: null,
+    meta,
+  };
+}
+
+function getRequestId(c: Context) {
+  return c.req.header('x-request-id') ?? crypto.randomUUID();
+}
+
+export const apiEnvelopeMiddleware: MiddlewareHandler = async (c, next) => {
+  const requestId = getRequestId(c);
+  c.header('x-request-id', requestId);
+
+  await next();
+
+  const response = c.res;
+  if (!response || response.status === 204 || response.status === 304) {
+    return;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return;
+  }
+
+  const payload = await response
+    .clone()
+    .json()
+    .catch(() => undefined);
+  if (payload === undefined) {
+    return;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set('content-type', 'application/json; charset=utf-8');
+  headers.set('x-request-id', requestId);
+
+  c.res = new Response(
+    JSON.stringify(createApiEnvelope(payload, response.status, requestId)),
+    {
+      status: response.status,
+      headers,
+    }
+  );
+};

--- a/apps/server/src/presentation/shared/index.ts
+++ b/apps/server/src/presentation/shared/index.ts
@@ -1,3 +1,14 @@
 // Presentation Layer - Shared Utilities
 
 export { asyncHandler, type AppContext } from './error.handler';
+export {
+  apiEnvelopeMiddleware,
+  createApiEnvelope,
+  isApiEnvelope,
+  normalizeError,
+  type ApiError,
+  type ApiFailure,
+  type ApiMeta,
+  type ApiResponse,
+  type ApiSuccess,
+} from './api-envelope';


### PR DESCRIPTION
## Summary
- Wrap server REST `/api/*` JSON responses in a consistent `{ success, data, error, meta }` envelope while preserving HTTP status codes and request IDs.
- Add dashboard Pages API envelope helpers and migrate JSON auth responses to the same shape, keeping OAuth redirects as redirects.
- Make the dashboard client envelope-aware with legacy raw JSON fallback during deploy rollout.

## Test Plan
- `pnpm --filter @hanghae-study/dashboard test`
- `pnpm --filter @hanghae-study/server type-check`
- `pnpm --filter @hanghae-study/server test`
- `pnpm --filter @hanghae-study/dashboard build`
- `pnpm --filter @hanghae-study/dashboard exec tsc -p tsconfig.json --noEmit`
- `pnpm format:check`
- `git diff --check`
- Local Pages smoke: `GET /api/auth/me` returns enveloped response